### PR TITLE
ci: generate the root README chart index on every pull request

### DIFF
--- a/.github/scripts/chart-index.py
+++ b/.github/scripts/chart-index.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Emit the chart index the root README is rendered from, as one line of JSON on stdout.
+
+Every value comes from a chart's own Chart.yaml, so the table in the README cannot drift from
+what the charts actually declare: adding a chart or bumping a version is enough. Application
+and library charts are reported separately because the README presents them differently —
+library charts are not published to the Helm repository.
+
+Usage: .github/scripts/chart-index.py [charts-dir]
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+# Without these a chart cannot be listed at all, and a silently empty table cell is worse than
+# a failed pipeline.
+REQUIRED_FIELDS = ("name", "description", "version")
+
+
+def fail(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def read_chart(chart_yaml: Path) -> dict[str, str]:
+    with chart_yaml.open(encoding="utf-8") as handle:
+        metadata = yaml.safe_load(handle)
+
+    if not isinstance(metadata, dict):
+        fail(f"{chart_yaml} does not contain a YAML mapping")
+
+    missing = [field for field in REQUIRED_FIELDS if not str(metadata.get(field, "")).strip()]
+    if missing:
+        fail(f"{chart_yaml} is missing required field(s): {', '.join(missing)}")
+
+    return {
+        "name": str(metadata["name"]),
+        # Folded and multi-line descriptions become one line: the README renders them into a
+        # table cell, where a line break would split the row.
+        "description": " ".join(str(metadata["description"]).split()),
+        "version": str(metadata["version"]),
+        "appVersion": str(metadata.get("appVersion", "")),
+        # Helm defaults an absent `type` to `application`.
+        "type": str(metadata.get("type", "application")),
+    }
+
+
+def main(argv: list[str]) -> None:
+    # Descriptions are not ASCII, and the rendered README must not depend on the locale the
+    # script happens to run under.
+    sys.stdout.reconfigure(encoding="utf-8")
+
+    charts_dir = Path(argv[1] if len(argv) > 1 else "charts")
+    if not charts_dir.is_dir():
+        fail(f"{charts_dir} is not a directory")
+
+    charts = [
+        read_chart(entry / "Chart.yaml")
+        for entry in sorted(charts_dir.iterdir())
+        if (entry / "Chart.yaml").is_file()
+    ]
+    if not charts:
+        fail(f"no charts found under {charts_dir}")
+
+    index = {
+        "charts": [chart for chart in charts if chart["type"] != "library"],
+        "libraryCharts": [chart for chart in charts if chart["type"] == "library"],
+    }
+
+    json.dump(index, sys.stdout, ensure_ascii=False, separators=(",", ":"))
+    print()
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/.github/templates/README.md.hbs
+++ b/.github/templates/README.md.hbs
@@ -77,17 +77,15 @@ helm uninstall my-release
 
 | Chart | Description | Chart Version | App Version |
 |-------|-------------|---------------|-------------|
-| [cloudflare-access-webhook-redirect](./charts/cloudflare-access-webhook-redirect) | A Helm chart for deploying the Cloudflare Access Webhook Redirect service. This service acts as an authentication proxy that validates requests using Cloudflare Access Service Auth tokens before forwarding them to target backend services. | `3.0.3` | `v0.3.21` |
-| [mp-stats-legacy-viewer](./charts/mp-stats-legacy-viewer) | MP Stats Legacy Viewer | `1.0.5` | `v0.14.0` |
-| [netcup-offer-bot](./charts/netcup-offer-bot) | This chart deploys the Netcup Offer Bot, which monitors https://www.netcup-sonderangebote.de/ RSS feed and sends notifications to Discord webhooks when new offers are available. | `3.0.4` | `v1.5.22` |
-| [portfolio](./charts/portfolio) | Personal portfolio built with Rust (Yew frontend, Axum server). | `3.0.5` | `v2.2.1` |
-| [s3-bucket-perma-link](./charts/s3-bucket-perma-link) | This chart deploys a simple web server that provides permanent links to specific S3 bucket resources. It allows you to define static URL paths that always point to specific files in your S3 buckets. | `2.0.4` | `v0.3.23` |
-| [tankovault](./charts/tankovault) | This chart deploys the full TankoVault manga aggregator stack — frontend, api, control-plane, worker, notifier, sync, challenge-solver and render — hardened to the restricted Pod Security Standard, with file-backed configuration that reloads in place instead of restarting pods, optional bundled PostgreSQL, Valkey, NATS JetStream and FlareSolverr, and optional Prometheus metrics, alerting rules and Grafana dashboards. | `1.1.0` | `0.4.1` |
-| [teamspeak](./charts/teamspeak) | This chart deploys a TeamSpeak 3 server hardened to the restricted Pod Security Standard, with optional persistence, an optional Prometheus metrics exporter sidecar, Grafana dashboards and Prometheus alerting rules. | `1.0.1` | `3.13.8` |
+{{#each charts}}
+| [{{name}}](./charts/{{name}}) | {{mdCell description}} | `{{version}}` | `{{appVersion}}` |
+{{/each}}
+{{#each libraryCharts}}
 
-The [`common`](./charts/common) library chart (`1.0.3`) is not published. It holds the
+The [`{{name}}`](./charts/{{name}}) library chart (`{{version}}`) is not published. It holds the
 shared template partials every chart above composes, and is consumed locally via
-`file://../common`.
+`file://../{{name}}`.
+{{/each}}
 
 ## Upgrading
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,8 @@ concurrency:
 permissions: {}
 
 jobs:
-  # `values.schema.json` and `README.md` are generated from `values.yaml` and `README.md.gotmpl`.
+  # Every chart's `values.schema.json` and `README.md` are generated from `values.yaml` and
+  # `README.md.gotmpl`, and the root `README.md` from `.github/templates/README.md.hbs`.
   # This job regenerates them and commits the result back to the PR branch, so contributors
   # never have to run the toolchain locally. The other jobs deliberately do not gate on it:
   # the follow-up push re-runs the whole workflow against the corrected tree anyway, and
@@ -68,17 +69,52 @@ jobs:
           commit_message: "docs: update Helm chart documentation and schemas"
           token: ${{ steps.generate_token.outputs.token }}
 
+      # The chart table in the root README is rendered from every chart's Chart.yaml, so a new
+      # chart or a version bump cannot leave the index stale. Deliberately placed after the
+      # commit above, whose `.` file pattern would otherwise sweep the rendered README into the
+      # helm-docs commit; the render commits only its own output path.
+      #
+      # PyYAML ships with the runner image's system `python3`. `actions/setup-python` is not used
+      # here on purpose: the interpreter it installs would not have it.
+      - name: Collect chart metadata
+        id: chart-index
+        run: |
+          set -euo pipefail
+          index="$(python3 ./.github/scripts/chart-index.py)"
+          echo "variables=${index}" >> "$GITHUB_OUTPUT"
+
+      - name: Render and commit the root README
+        id: readme
+        uses: TimSchoenle/actions/actions/common/render-template-and-commit@7036b316c73d401f531468d09f391a76a4ab4b3f # tag=actions-common-render-template-and-commit-v1.1.1
+        with:
+          template: .github/templates/README.md.hbs
+          output: README.md
+          variables: ${{ steps.chart-index.outputs.variables }}
+          token: ${{ steps.generate_token.outputs.token }}
+          commit_message: "docs: update chart index in README"
+
       - name: Comment on PR
-        if: steps.auto-commit.outputs.changes_detected == 'true'
+        if: steps.auto-commit.outputs.changes_detected == 'true' || steps.readme.outputs.changes_detected == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          DOCS_CHANGED: ${{ steps.auto-commit.outputs.changes_detected }}
+          README_CHANGED: ${{ steps.readme.outputs.changes_detected }}
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           script: |
-            github.rest.issues.createComment({
+            const updated = [];
+            if (process.env.DOCS_CHANGED === 'true') {
+              updated.push('chart documentation and schemas');
+            }
+            if (process.env.README_CHANGED === 'true') {
+              updated.push('the README chart index');
+            }
+
+            await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '📚 Helm chart documentation and schema have been automatically updated.'
+              body: `📚 Automatically updated ${updated.join(' and ')}.`
             })
 
   unit-test:


### PR DESCRIPTION
## What

The *Available Charts* table in the root `README.md` is now generated on CI from every `charts/*/Chart.yaml`, using [`render-template-and-commit`](https://github.com/TimSchoenle/actions/tree/main/actions/common/render-template-and-commit).

- **`.github/scripts/chart-index.py`** (new) — reads every `charts/*/Chart.yaml` and emits one line of JSON: `charts` (applications) and `libraryCharts`, each with `name`, `description`, `version`, `appVersion`, `type`. Multi-line descriptions are collapsed to a single line so they cannot split a table row; a chart missing `name`, `description` or `version` fails the step rather than rendering an empty cell.
- **`.github/templates/README.md.hbs`** (new) — the root README as a Handlebars template. Only the chart table and the library-chart paragraph are generated; the rest is the existing prose, unchanged. Descriptions pass through the action's `mdCell` helper so a pipe or backslash cannot break the table.
- **`.github/workflows/ci.yaml`** — two steps in the existing `docs` job, which already has the app token, a `head_ref` checkout and `contents: write`.
- **`README.md`** — replaced with the rendered output.

## Why

The table was hand-maintained and had already drifted. `tankovault` and `teamspeak` were missing entirely, and the version column read "Check [Chart.yaml](...)" instead of a version. Both are now derived from the charts, so a new chart or a version bump keeps the index correct with no manual step — including on Renovate and release PRs.

## Notes for review

- **Step ordering is deliberate.** The render runs *after* the helm-docs commit: that step's default `file_pattern` of `.` would otherwise sweep the rendered README into the schema commit. The render action defaults its pattern to its own output path, so it commits `README.md` alone, as a verified bot commit, and skips committing when nothing changed.
- **Descriptions are now the full `Chart.yaml` text**, not the shorter hand-written summaries. That is what makes them self-maintaining; to shorten one, edit `Chart.yaml` (which also feeds `helm search`), not the README.
- **`python3` + PyYAML** comes from the runner image's system interpreter. `actions/setup-python` is intentionally not used for this step, since the interpreter it installs would not have PyYAML. A regression there surfaces as a plain `ImportError`.
- **The PR comment** now names precisely what was regenerated (docs/schemas, README index, or both) instead of always claiming both.
- The action is SHA-pinned with a `# tag=` comment, matching the repo's existing pins, so Renovate tracks it like the others.

## Verification

The template was rendered locally against Handlebars 4.7 with the same `mdCell` implementation as the pinned action, and the committed `README.md` matches that output byte for byte — so the first CI run should report no change rather than immediately committing over it. The script's failure paths (missing field, missing directory, no charts) were each exercised and exit non-zero with a clear message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
