### PR TITLE
fix(tankovault): keep version labels off immutable StatefulSet fields

### DIFF
--- a/.github/scripts/check-immutable-fields.py
+++ b/.github/scripts/check-immutable-fields.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Guard the fields Kubernetes refuses to update in place.
+
+Two failure modes are checked, both of which render and lint cleanly and only surface on a
+real cluster — one of them not until an upgrade of an already-running release, which is the
+worst possible time to find out.
+
+1. Version invariance of the immutable StatefulSet spec.
+
+   The API server accepts updates to `replicas`, `ordinals`, `template`, `updateStrategy`,
+   `revisionHistoryLimit`, `persistentVolumeClaimRetentionPolicy` and `minReadySeconds`, and
+   rejects the entire patch if anything else moved. `volumeClaimTemplates` is the trap: it
+   sits in the spec, so its *labels* are immutable too, and stamping `common.labels` onto it
+   folds in `helm.sh/chart` and `app.kubernetes.io/version`. Both move on every release, so a
+   chart bump that changes nothing else still produces a diff the API server refuses:
+
+     StatefulSet.apps "..." is invalid: spec: Forbidden: updates to statefulset spec for
+     fields other than ... are forbidden
+
+   Rendering each chart at its own version and at a synthetic bumped version and diffing the
+   immutable half of every StatefulSet spec catches this at PR time. Use
+   `common.immutableLabels` for anything that lands in such a field.
+
+2. Selector/template agreement.
+
+   `spec.selector.matchLabels` must be a subset of `spec.template.metadata.labels` or the
+   workload is rejected at admission with "`selector` does not match template `labels`". A
+   scoped render context that resolves `common.name` differently from the root context breaks
+   this, and only under `nameOverride` — which no ci/ fixture sets, so the default render
+   looks perfectly healthy. Every chart is therefore rendered a second time with an explicit
+   `nameOverride` purely to exercise that path.
+
+Which StatefulSet fields are mutable is not something the Kubernetes schema records, so the
+set is a constant here. `verify_against_schema` cross-checks it against the same schema
+catalog kubeconform validates the rendered manifests with, which is authoritative on the
+fields that exist and so catches the list drifting from the API.
+
+Usage: .github/scripts/check-immutable-fields.py
+       KUBE_VERSION=1.31.0 .github/scripts/check-immutable-fields.py
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+CHARTS_DIR = Path("charts")
+
+# A library chart renders nothing on its own.
+EXCLUDED_CHARTS = {"common"}
+
+# `helm template` reports the built-in API surface but no CRDs, and charts that ship custom
+# resources refuse to render rather than dropping them silently. Kept in step with
+# render-charts.sh.
+API_VERSIONS = [
+    "--api-versions", "monitoring.coreos.com/v1",
+    "--api-versions", "grafana.integreatly.org/v1beta1",
+]
+
+# Everything the API server allows to change on an existing StatefulSet. Anything else in the
+# spec is immutable and must therefore be invariant under a version bump.
+#
+# This list cannot be derived from the schemas the manifests are validated against, and it is
+# worth being precise about why. Mutability is not part of the Kubernetes OpenAPI surface: it
+# is enforced imperatively in `ValidateStatefulSetUpdate`, which copies the permitted fields
+# onto the old object and rejects the request if anything else differs. The published JSON
+# schema carries no `x-kubernetes-validations`, no immutability marker and no wording to parse
+# — it describes shape and type only. So the set is transcribed from the API server's error
+# message, which enumerates it in full, and `verify_against_schema` below pins it to the real
+# schema in the one way the schema can support.
+MUTABLE_STATEFULSET_SPEC_FIELDS = {
+    "replicas",
+    "ordinals",
+    "template",
+    "updateStrategy",
+    "revisionHistoryLimit",
+    "persistentVolumeClaimRetentionPolicy",
+    "minReadySeconds",
+}
+
+# The catalog kubeconform resolves `-schema-location default` against, so the cross-check below
+# reads the same schema data the manifests are already validated with in validate-manifests.sh.
+SCHEMA_URL = (
+    "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/"
+    "v{version}-standalone-strict/statefulset-apps-v1.json"
+)
+
+# Kept in step with the highest version in the validate-manifests matrix. Overridable so a
+# toolchain bump can be tried without editing the script.
+SCHEMA_KUBERNETES_VERSION = os.environ.get("KUBE_VERSION", "1.34.0")
+
+# Workloads whose selector is immutable and must match their own pod template.
+SELECTOR_KINDS = {"Deployment", "StatefulSet", "DaemonSet"}
+
+# Deliberately implausible as a real value, so a chart that leaks it into an unexpected place
+# is easy to spot in the failure output.
+PROBE_NAME_OVERRIDE = "immutability-probe"
+
+# Bumped far beyond any real version so the synthetic render can never collide with the
+# chart's own. Both fields move: `version` feeds `helm.sh/chart`, `appVersion` feeds
+# `app.kubernetes.io/version`, and either one reaching an immutable field is a defect.
+PROBE_VERSION = "99.99.99"
+
+
+def statefulset_spec_properties() -> set[str] | None:
+    """Every field a StatefulSet spec is allowed to contain, per the published schema."""
+    url = SCHEMA_URL.format(version=SCHEMA_KUBERNETES_VERSION)
+    try:
+        with urllib.request.urlopen(url, timeout=30) as response:
+            schema = json.load(response)
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as error:
+        print(f"WARNING: could not read {url} ({error}).")
+        print("WARNING: the mutable-field list was not cross-checked against the schema.")
+        return None
+    return set(schema["properties"]["spec"]["properties"])
+
+
+def verify_against_schema(failures: list[str]) -> None:
+    """Pin `MUTABLE_STATEFULSET_SPEC_FIELDS` to the schema as far as the schema allows.
+
+    The schema cannot say which fields are mutable, but it is authoritative on which fields
+    *exist*. That is enough to catch the failure mode that matters: a name in the list which is
+    not a real spec field is silently inert, and the actual field it was meant to name is then
+    treated as immutable — or, worse after a rename, a genuinely mutable field is diffed and
+    every chart fails for the wrong reason. Either way the list has drifted from the API and
+    the diff output stops meaning what it says.
+
+    Deliberately not fatal when the schema is unreachable: this is an assertion about a
+    constant, not one of the two checks the job exists to run, and a network blip should not
+    fail a PR that has nothing wrong with it.
+    """
+    properties = statefulset_spec_properties()
+    if properties is None:
+        return
+
+    unknown = MUTABLE_STATEFULSET_SPEC_FIELDS - properties
+    if unknown:
+        failures.append(
+            f"MUTABLE_STATEFULSET_SPEC_FIELDS names {sorted(unknown)}, which the "
+            f"StatefulSet schema for Kubernetes {SCHEMA_KUBERNETES_VERSION} does not define. "
+            f"The list has drifted from the API. Reconcile it against "
+            f"`ValidateStatefulSetUpdate` before trusting any result from this job."
+        )
+        return
+
+    immutable = sorted(properties - MUTABLE_STATEFULSET_SPEC_FIELDS)
+    print(
+        f"Schema for Kubernetes {SCHEMA_KUBERNETES_VERSION}: treating {immutable} as "
+        f"immutable.\n"
+    )
+
+
+def render(chart: Path, values: Path, extra: list[str] | None = None) -> list[dict]:
+    """Render a chart and return its non-empty documents."""
+    cmd = [
+        "helm", "template", chart.name, str(chart),
+        "--namespace", "default",
+        *API_VERSIONS,
+        "--values", str(values),
+        *(extra or []),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"helm template failed for {chart.name} / {values.name}:\n{result.stderr}")
+    return [doc for doc in yaml.safe_load_all(result.stdout) if doc]
+
+
+def bumped_copy(chart: Path, destination: Path) -> Path:
+    """Copy a chart, vendored dependencies and all, with only its versions changed."""
+    target = destination / chart.name
+    shutil.copytree(chart, target)
+
+    chart_yaml = target / "Chart.yaml"
+    text = chart_yaml.read_text(encoding="utf-8")
+    text = re.sub(r"^version: .*$", f"version: {PROBE_VERSION}", text, count=1, flags=re.MULTILINE)
+    text = re.sub(r"^appVersion: .*$", f"appVersion: {PROBE_VERSION}", text, count=1, flags=re.MULTILINE)
+    chart_yaml.write_text(text, encoding="utf-8")
+    return target
+
+
+def immutable_spec(statefulset: dict) -> dict:
+    """The half of a StatefulSet spec the API server refuses to update."""
+    spec = statefulset.get("spec") or {}
+    return {k: v for k, v in spec.items() if k not in MUTABLE_STATEFULSET_SPEC_FIELDS}
+
+
+def identify(doc: dict) -> str:
+    metadata = doc.get("metadata") or {}
+    return f"{doc.get('kind')}/{metadata.get('name')}"
+
+
+def dump(value: object) -> list[str]:
+    return yaml.safe_dump(value, default_flow_style=False, sort_keys=True).splitlines()
+
+
+def check_version_invariance(chart: Path, values: Path, failures: list[str]) -> None:
+    """Every immutable StatefulSet field must survive a version-only bump untouched."""
+    with tempfile.TemporaryDirectory() as tmp:
+        bumped = bumped_copy(chart, Path(tmp))
+        before = render(chart, values)
+        after = render(bumped, values)
+
+    indexed = {
+        identify(doc): doc
+        for doc in after
+        if doc.get("kind") == "StatefulSet"
+    }
+
+    for doc in before:
+        if doc.get("kind") != "StatefulSet":
+            continue
+        name = identify(doc)
+        counterpart = indexed.get(name)
+        if counterpart is None:
+            failures.append(
+                f"{chart.name} [{values.name}] {name}: the StatefulSet is renamed by a version "
+                f"bump, so an upgrade would orphan the running one rather than update it"
+            )
+            continue
+
+        diff = list(difflib.unified_diff(
+            dump(immutable_spec(doc)),
+            dump(immutable_spec(counterpart)),
+            fromfile=f"{name} @ chart version as committed",
+            tofile=f"{name} @ chart version {PROBE_VERSION}",
+            lineterm="",
+        ))
+        if diff:
+            failures.append(
+                f"{chart.name} [{values.name}] {name}: immutable spec fields change under a "
+                f"version-only bump, so upgrading a live release is rejected by the API "
+                f"server. Render these through `common.immutableLabels`.\n"
+                + "\n".join(f"    {line}" for line in diff)
+            )
+
+
+def check_selector_matches_template(chart: Path, values: Path, failures: list[str]) -> None:
+    """A workload's immutable selector must match the pod template it ships."""
+    for extra, label in (
+        ([], "as configured"),
+        (["--set", f"nameOverride={PROBE_NAME_OVERRIDE}"], f"nameOverride={PROBE_NAME_OVERRIDE}"),
+    ):
+        for doc in render(chart, values, extra):
+            if doc.get("kind") not in SELECTOR_KINDS:
+                continue
+            spec = doc.get("spec") or {}
+            selector = ((spec.get("selector") or {}).get("matchLabels")) or {}
+            template_labels = (
+                ((spec.get("template") or {}).get("metadata") or {}).get("labels")
+            ) or {}
+
+            mismatched = {
+                key: (value, template_labels.get(key))
+                for key, value in selector.items()
+                if template_labels.get(key) != value
+            }
+            if mismatched:
+                detail = "\n".join(
+                    f"    {key}: selector={selector_value!r} template={template_value!r}"
+                    for key, (selector_value, template_value) in sorted(mismatched.items())
+                )
+                failures.append(
+                    f"{chart.name} [{values.name}, {label}] {identify(doc)}: "
+                    f"`selector` does not match template `labels`; the API server rejects this "
+                    f"workload outright. The selector and the pod template must be rendered "
+                    f"against the same context.\n{detail}"
+                )
+
+
+def main() -> int:
+    failures: list[str] = []
+    checked = 0
+
+    verify_against_schema(failures)
+
+    for chart in sorted(CHARTS_DIR.iterdir()):
+        if not chart.is_dir() or chart.name in EXCLUDED_CHARTS:
+            continue
+
+        values_files = sorted((chart / "ci").glob("*.yaml"))
+        if not values_files:
+            print(f"No ci/ values files for {chart.name}, skipping...")
+            continue
+
+        for values in values_files:
+            print(f"Checking {chart.name} with {values.name}")
+            check_version_invariance(chart, values, failures)
+            check_selector_matches_template(chart, values, failures)
+            checked += 1
+
+    print()
+    if failures:
+        print(f"{len(failures)} immutable-field violation(s) found:\n")
+        for failure in failures:
+            print(f"  - {failure}\n")
+        return 1
+
+    print(f"OK: {checked} (chart, values) pair(s) carry no immutable-field violations.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/testdata/common-fixture/Chart.yaml
+++ b/.github/testdata/common-fixture/Chart.yaml
@@ -12,5 +12,5 @@ version: 0.0.0
 appVersion: "1.2.3"
 dependencies:
   - name: common
-    version: 1.2.1
+    version: 1.3.0
     repository: "file://../../../charts/common"

--- a/.github/testdata/common-fixture/templates/statefulset.yaml
+++ b/.github/testdata/common-fixture/templates/statefulset.yaml
@@ -1,0 +1,44 @@
+{{- /*
+Exercises `common.immutableLabels` in the field it exists for.
+
+A `volumeClaimTemplate` is part of the StatefulSet *spec*, so its labels are immutable once
+the object is created. Rendering them through `common.labels` folds in `helm.sh/chart` and
+`app.kubernetes.io/version`, both of which move on every release, and the next upgrade is
+rejected outright. The suite asserts the emitted set carries neither.
+*/ -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "common.fullname" . }}
+  namespace: {{ include "common.namespace" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  serviceName: {{ include "common.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "common.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "common.podLabels" . | nindent 8 }}
+    spec:
+      {{- include "common.podSpec.common" . | nindent 6 }}
+      containers:
+        {{- include "common.container" (dict
+              "ctx" $
+              "ports" (list (dict "name" "http" "containerPort" .Values.containerPort "protocol" "TCP"))
+              "volumeMounts" (list (dict "name" "data" "mountPath" "/data"))
+            ) | nindent 8 }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          {{- include "common.immutableLabels" . | nindent 10 }}
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi

--- a/.github/testdata/common-fixture/tests/immutable_labels_test.yaml
+++ b/.github/testdata/common-fixture/tests/immutable_labels_test.yaml
@@ -1,0 +1,67 @@
+suite: common.immutableLabels
+templates:
+  - statefulset.yaml
+tests:
+  # The whole point of the helper. `helm.sh/chart` carries the chart version and
+  # `app.kubernetes.io/version` the app version; both move on every release, and both land in
+  # a field the API server refuses to update. A release that ships either one here cannot be
+  # upgraded in place again — the failure appears on a cluster, at sync time, never in review.
+  - it: emits exactly the labels that are stable for the life of a release
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.labels
+          value:
+            app.kubernetes.io/name: common-fixture
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+
+  - it: never carries the chart or version labels
+    asserts:
+      - notExists:
+          path: spec.volumeClaimTemplates[0].metadata.labels["helm.sh/chart"]
+      - notExists:
+          path: spec.volumeClaimTemplates[0].metadata.labels["app.kubernetes.io/version"]
+
+  # `component` and `partOf` reach object metadata and pod labels through
+  # `common.versionLabels`, which the helper deliberately does not include — not because they
+  # carry a version, but because they share a helper with the labels that do. Pinning the
+  # behaviour so a later edit to `common.versionLabels` cannot leak a version label in here.
+  - it: ignores the version-label block even when its inputs are set
+    set:
+      component: api
+      partOf: platform
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.labels
+          value:
+            app.kubernetes.io/name: common-fixture
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+
+  # Operator-settable, therefore excluded on purpose: folding `commonLabels` in would re-open
+  # the trap the first time someone adds a label to a running release.
+  - it: excludes operator-settable commonLabels
+    set:
+      commonLabels:
+        team: platform
+    asserts:
+      - notExists:
+          path: spec.volumeClaimTemplates[0].metadata.labels.team
+      # Proof the value really was plumbed through — otherwise the assertion above passes for
+      # the wrong reason and would keep passing if the helper were deleted entirely.
+      - equal:
+          path: metadata.labels.team
+          value: platform
+
+  # The immutable labels must be a superset of the selector, or the PVCs a StatefulSet creates
+  # stop being attributable to the release that owns them.
+  - it: keeps the selector labels intact under nameOverride
+    set:
+      nameOverride: renamed
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.labels["app.kubernetes.io/name"]
+          value: renamed
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: renamed

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -289,6 +289,44 @@ jobs:
           KUBE_VERSION: ${{ matrix.kubernetes }}
         run: bash ./.github/scripts/validate-manifests.sh
 
+  # Immutable fields are the one class of defect that renders, lints and installs cleanly and
+  # only fails on an upgrade of an already-running release — on a cluster, during a sync, long
+  # after review. `ct install` cannot see it either: it installs fresh, and a fresh install of
+  # a broken chart succeeds. This job is the only thing standing between a version bump and a
+  # release that cannot be upgraded in place.
+  immutable-fields:
+    name: Immutable Fields
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # to checkout code
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Helm Environment
+        uses: ./.github/actions/setup-helm
+
+      - name: Build Helm dependencies
+        uses: ./.github/actions/build-deps
+
+      # PyYAML ships with the runner image's system `python3`, matching the `chart-index.py`
+      # step above. `actions/setup-python` is deliberately not used: the interpreter it
+      # installs would not have it.
+      #
+      # KUBE_VERSION pins which StatefulSet schema the mutable-field list is cross-checked
+      # against; kept in step with the highest version in the validate-manifests matrix.
+      - name: Check immutable fields
+        env:
+          KUBE_VERSION: 1.34.0
+        run: python3 ./.github/scripts/check-immutable-fields.py
+
   policy-scan:
     name: Policy Scan
     runs-on: ubuntu-latest

--- a/charts/cloudflare-access-webhook-redirect/Chart.yaml
+++ b/charts/cloudflare-access-webhook-redirect/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudflare-access-webhook-redirect
 description: A Helm chart for deploying the Cloudflare Access Webhook Redirect service. This service acts as an authentication proxy that validates requests using Cloudflare Access Service Auth tokens before forwarding them to target backend services.
 type: application
-version: 3.0.7
+version: 3.0.8
 appVersion: v0.3.22
 keywords:
   - cloudflare
@@ -18,5 +18,5 @@ maintainers:
     url: https://github.com/TimSchoenle
 dependencies:
   - name: common
-    version: 1.2.1
+    version: 1.3.0
     repository: "file://../common"

--- a/charts/cloudflare-access-webhook-redirect/README.md
+++ b/charts/cloudflare-access-webhook-redirect/README.md
@@ -1,6 +1,6 @@
 # cloudflare-access-webhook-redirect
 
-![Version: 3.0.7](https://img.shields.io/badge/Version-3.0.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.22](https://img.shields.io/badge/AppVersion-v0.3.22-informational?style=flat-square)
+![Version: 3.0.8](https://img.shields.io/badge/Version-3.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.22](https://img.shields.io/badge/AppVersion-v0.3.22-informational?style=flat-square)
 
 A Helm chart for deploying the Cloudflare Access Webhook Redirect service. This service acts as an authentication proxy that validates requests using Cloudflare Access Service Auth tokens before forwarding them to target backend services.
 

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Shared template partials for the TimSchoenle Helm charts
 type: library
-version: 1.2.1
+version: 1.3.0
 home: https://github.com/TimSchoenle/helm-charts
 sources:
   - https://github.com/TimSchoenle/helm-charts

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Shared template partials for the TimSchoenle Helm charts
 

--- a/charts/common/templates/_labels.tpl
+++ b/charts/common/templates/_labels.tpl
@@ -57,6 +57,28 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
+Labels for metadata that cannot be updated after creation — currently
+`volumeClaimTemplates`, whose entries are part of the StatefulSet *spec* and are therefore
+immutable down to their labels.
+
+Excludes `helm.sh/chart` and every version label: an otherwise no-op chart bump would
+render a diff the API server rejects outright with "updates to statefulset spec for fields
+other than ... are forbidden", breaking in-place upgrades of every persistent datastore the
+chart ships. Same reasoning as `common.podLabels`, one step further — there a version label
+costs a rollout, here it costs the upgrade.
+
+`.Values.commonLabels` is deliberately excluded as well. It is operator-settable, so folding
+it in would re-open this trap the first time someone adds a label to a running release.
+
+Anything added here must be stable for the entire lifetime of a release. If it can change,
+it does not belong in an immutable field.
+*/}}
+{{- define "common.immutableLabels" -}}
+{{ include "common.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
 Annotations applied to every object this chart creates.
 */}}
 {{- define "common.annotations" -}}

--- a/charts/mp-stats-legacy-viewer/Chart.yaml
+++ b/charts/mp-stats-legacy-viewer/Chart.yaml
@@ -1,6 +1,6 @@
 name: mp-stats-legacy-viewer
 description: MP Stats Legacy Viewer
-version: 1.0.8
+version: 1.0.9
 appVersion: v0.14.0
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts
@@ -11,5 +11,5 @@ maintainers:
     email: contact@tim-schoenle.de
 dependencies:
   - name: common
-    version: 1.2.1
+    version: 1.3.0
     repository: "file://../common"

--- a/charts/mp-stats-legacy-viewer/README.md
+++ b/charts/mp-stats-legacy-viewer/README.md
@@ -1,6 +1,6 @@
 # mp-stats-legacy-viewer
 
-![Version: 1.0.8](https://img.shields.io/badge/Version-1.0.8-informational?style=flat-square) ![AppVersion: v0.14.0](https://img.shields.io/badge/AppVersion-v0.14.0-informational?style=flat-square)
+![Version: 1.0.9](https://img.shields.io/badge/Version-1.0.9-informational?style=flat-square) ![AppVersion: v0.14.0](https://img.shields.io/badge/AppVersion-v0.14.0-informational?style=flat-square)
 
 MP Stats Legacy Viewer
 

--- a/charts/netcup-offer-bot/Chart.yaml
+++ b/charts/netcup-offer-bot/Chart.yaml
@@ -1,6 +1,6 @@
 name: netcup-offer-bot
 description: This chart deploys the Netcup Offer Bot, which monitors https://www.netcup-sonderangebote.de/ RSS feed and sends notifications to Discord webhooks when new offers are available.
-version: 3.0.8
+version: 3.0.9
 appVersion: v1.5.24
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts
@@ -11,5 +11,5 @@ maintainers:
     email: contact@tim-schoenle.de
 dependencies:
   - name: common
-    version: 1.2.1
+    version: 1.3.0
     repository: "file://../common"

--- a/charts/netcup-offer-bot/README.md
+++ b/charts/netcup-offer-bot/README.md
@@ -1,6 +1,6 @@
 # netcup-offer-bot
 
-![Version: 3.0.8](https://img.shields.io/badge/Version-3.0.8-informational?style=flat-square) ![AppVersion: v1.5.24](https://img.shields.io/badge/AppVersion-v1.5.24-informational?style=flat-square)
+![Version: 3.0.9](https://img.shields.io/badge/Version-3.0.9-informational?style=flat-square) ![AppVersion: v1.5.24](https://img.shields.io/badge/AppVersion-v1.5.24-informational?style=flat-square)
 
 This chart deploys the Netcup Offer Bot, which monitors https://www.netcup-sonderangebote.de/ RSS feed and sends notifications to Discord webhooks when new offers are available.
 

--- a/charts/portfolio/Chart.yaml
+++ b/charts/portfolio/Chart.yaml
@@ -1,6 +1,6 @@
 name: portfolio
 description: Personal portfolio built with Rust (Yew frontend, Axum server).
-version: 3.0.8
+version: 3.0.9
 appVersion: v2.2.1
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts
@@ -11,5 +11,5 @@ maintainers:
     email: contact@tim-schoenle.de
 dependencies:
   - name: common
-    version: 1.2.1
+    version: 1.3.0
     repository: "file://../common"

--- a/charts/portfolio/README.md
+++ b/charts/portfolio/README.md
@@ -1,6 +1,6 @@
 # portfolio
 
-![Version: 3.0.8](https://img.shields.io/badge/Version-3.0.8-informational?style=flat-square) ![AppVersion: v2.2.1](https://img.shields.io/badge/AppVersion-v2.2.1-informational?style=flat-square)
+![Version: 3.0.9](https://img.shields.io/badge/Version-3.0.9-informational?style=flat-square) ![AppVersion: v2.2.1](https://img.shields.io/badge/AppVersion-v2.2.1-informational?style=flat-square)
 
 Personal portfolio built with Rust (Yew frontend, Axum server).
 

--- a/charts/s3-bucket-perma-link/Chart.yaml
+++ b/charts/s3-bucket-perma-link/Chart.yaml
@@ -1,6 +1,6 @@
 name: s3-bucket-perma-link
 description: This chart deploys a simple web server that provides permanent links to specific S3 bucket resources. It allows you to define static URL paths that always point to specific files in your S3 buckets.
-version: 2.0.8
+version: 2.0.9
 appVersion: v0.3.24
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts
@@ -11,5 +11,5 @@ maintainers:
     email: contact@tim-schoenle.de
 dependencies:
   - name: common
-    version: 1.2.1
+    version: 1.3.0
     repository: "file://../common"

--- a/charts/s3-bucket-perma-link/README.md
+++ b/charts/s3-bucket-perma-link/README.md
@@ -1,6 +1,6 @@
 # s3-bucket-perma-link
 
-![Version: 2.0.8](https://img.shields.io/badge/Version-2.0.8-informational?style=flat-square) ![AppVersion: v0.3.24](https://img.shields.io/badge/AppVersion-v0.3.24-informational?style=flat-square)
+![Version: 2.0.9](https://img.shields.io/badge/Version-2.0.9-informational?style=flat-square) ![AppVersion: v0.3.24](https://img.shields.io/badge/AppVersion-v0.3.24-informational?style=flat-square)
 
 This chart deploys a simple web server that provides permanent links to specific S3 bucket resources. It allows you to define static URL paths that always point to specific files in your S3 buckets.
 

--- a/charts/tankovault/Chart.yaml
+++ b/charts/tankovault/Chart.yaml
@@ -1,6 +1,6 @@
 name: tankovault
 description: This chart deploys the full TankoVault manga aggregator stack — frontend, api, control-plane, worker, notifier, sync, challenge-solver and render — hardened to the restricted Pod Security Standard, with file-backed configuration that reloads in place instead of restarting pods, optional bundled PostgreSQL, Valkey, NATS JetStream and TRAWL, and optional Prometheus metrics, alerting rules and Grafana dashboards.
-version: 3.0.2
+version: 3.0.3
 appVersion: 1.2.0
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts
@@ -11,5 +11,5 @@ maintainers:
     email: contact@tim-schoenle.de
 dependencies:
   - name: common
-    version: 1.2.1
+    version: 1.3.0
     repository: "file://../common"

--- a/charts/tankovault/README.md
+++ b/charts/tankovault/README.md
@@ -1,6 +1,6 @@
 # tankovault
 
-![Version: 3.0.2](https://img.shields.io/badge/Version-3.0.2-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 3.0.3](https://img.shields.io/badge/Version-3.0.3-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 This chart deploys the full TankoVault manga aggregator stack — frontend, api, control-plane, worker, notifier, sync, challenge-solver and render — hardened to the restricted Pod Security Standard, with file-backed configuration that reloads in place instead of restarting pods, optional bundled PostgreSQL, Valkey, NATS JetStream and TRAWL, and optional Prometheus metrics, alerting rules and Grafana dashboards.
 

--- a/charts/tankovault/README.md
+++ b/charts/tankovault/README.md
@@ -354,6 +354,69 @@ Documents supplied through `content` are read on demand behind an mtime check, s
 policy is a values change and the kubelet's ConfigMap refresh, never a restart. That ConfigMap is
 deliberately excluded from the pod's `checksum/config` annotation for exactly that reason.
 
+## Upgrading to 3.0.3
+
+**Read this before upgrading any release that runs a bundled datastore with persistence.** The
+fix in this version is complete for new installs and requires one manual step for existing ones.
+
+Until 3.0.3 the chart stamped the full label set — including `helm.sh/chart` and
+`app.kubernetes.io/version` — onto the `volumeClaimTemplates` of the bundled NATS and
+PostgreSQL StatefulSets. That block is part of the StatefulSet **spec**, which Kubernetes
+refuses to update for any field other than `replicas`, `ordinals`, `template`,
+`updateStrategy`, `revisionHistoryLimit`, `persistentVolumeClaimRetentionPolicy` and
+`minReadySeconds`. Both of those labels move on every release, so any version bump of this
+chart made the next in-place upgrade fail:
+
+```
+StatefulSet.apps "tankovault-nats" is invalid: spec: Forbidden: updates to statefulset spec
+for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy',
+'revisionHistoryLimit', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are
+forbidden
+```
+
+The claim templates now carry only labels that are stable for the lifetime of a release
+(`name`, `instance`, `managed-by`, `component`), so this cannot recur.
+
+**It does not repair an existing install.** The StatefulSet already running still carries the
+old labels, and the corrected render still differs from them — so the upgrade is rejected on
+exactly the same field until the object is recreated once:
+
+```shell
+kubectl delete statefulset <release>-nats -n <namespace> --cascade=orphan
+```
+
+Repeat for `<release>-postgresql` if the bundled database is in use. If you are unsure of the
+names:
+
+```shell
+kubectl get statefulset -n <namespace> -l app.kubernetes.io/instance=<release>
+```
+
+Then upgrade as usual. This is safe, and it is worth knowing exactly why rather than having to
+reason it out under a failing sync:
+
+- **The data survives.** The chart sets no `persistentVolumeClaimRetentionPolicy`, so it
+  defaults to `Retain`/`Retain` and the PVCs carry no owner reference to the StatefulSet. The
+  JetStream and PostgreSQL volumes are untouched however the StatefulSet is deleted.
+- **The service stays up.** `--cascade=orphan` deletes only the StatefulSet object; the pod
+  keeps running throughout.
+- **No second pod appears.** The recreated StatefulSet's selector is `name`/`instance`/
+  `component` only and is unchanged between versions, so it adopts the orphaned pod rather
+  than starting a rival. It then rolls it once to pick up the new image — which the upgrade
+  was going to do anyway.
+
+Argo CD users: perform the delete manually, then sync. Do not add the StatefulSet to a
+`Replace=true` sync policy — that would delete the pod along with it.
+
+### `nameOverride` on the bundled datastores
+
+Also fixed here, and unrelated to the above. The bundled datastores rendered their selector and
+their pod template against two different contexts, so under `nameOverride` the two disagreed on
+`app.kubernetes.io/name` and the API server rejected the workload outright with "`selector` does
+not match template `labels`". `nameOverride` broke the bundled NATS, PostgreSQL, Valkey, TRAWL
+and NATS exporter rather than renaming them. If you were affected you will not have a running
+release to upgrade — install normally.
+
 ## Upgrading to 3.0.2
 
 Three corrections to the rules 3.0.0 introduced, all found by evaluating them against synthetic

--- a/charts/tankovault/README.md.gotmpl
+++ b/charts/tankovault/README.md.gotmpl
@@ -356,6 +356,69 @@ Documents supplied through `content` are read on demand behind an mtime check, s
 policy is a values change and the kubelet's ConfigMap refresh, never a restart. That ConfigMap is
 deliberately excluded from the pod's `checksum/config` annotation for exactly that reason.
 
+## Upgrading to 3.0.3
+
+**Read this before upgrading any release that runs a bundled datastore with persistence.** The
+fix in this version is complete for new installs and requires one manual step for existing ones.
+
+Until 3.0.3 the chart stamped the full label set — including `helm.sh/chart` and
+`app.kubernetes.io/version` — onto the `volumeClaimTemplates` of the bundled NATS and
+PostgreSQL StatefulSets. That block is part of the StatefulSet **spec**, which Kubernetes
+refuses to update for any field other than `replicas`, `ordinals`, `template`,
+`updateStrategy`, `revisionHistoryLimit`, `persistentVolumeClaimRetentionPolicy` and
+`minReadySeconds`. Both of those labels move on every release, so any version bump of this
+chart made the next in-place upgrade fail:
+
+```
+StatefulSet.apps "tankovault-nats" is invalid: spec: Forbidden: updates to statefulset spec
+for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy',
+'revisionHistoryLimit', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are
+forbidden
+```
+
+The claim templates now carry only labels that are stable for the lifetime of a release
+(`name`, `instance`, `managed-by`, `component`), so this cannot recur.
+
+**It does not repair an existing install.** The StatefulSet already running still carries the
+old labels, and the corrected render still differs from them — so the upgrade is rejected on
+exactly the same field until the object is recreated once:
+
+```shell
+kubectl delete statefulset <release>-nats -n <namespace> --cascade=orphan
+```
+
+Repeat for `<release>-postgresql` if the bundled database is in use. If you are unsure of the
+names:
+
+```shell
+kubectl get statefulset -n <namespace> -l app.kubernetes.io/instance=<release>
+```
+
+Then upgrade as usual. This is safe, and it is worth knowing exactly why rather than having to
+reason it out under a failing sync:
+
+- **The data survives.** The chart sets no `persistentVolumeClaimRetentionPolicy`, so it
+  defaults to `Retain`/`Retain` and the PVCs carry no owner reference to the StatefulSet. The
+  JetStream and PostgreSQL volumes are untouched however the StatefulSet is deleted.
+- **The service stays up.** `--cascade=orphan` deletes only the StatefulSet object; the pod
+  keeps running throughout.
+- **No second pod appears.** The recreated StatefulSet's selector is `name`/`instance`/
+  `component` only and is unchanged between versions, so it adopts the orphaned pod rather
+  than starting a rival. It then rolls it once to pick up the new image — which the upgrade
+  was going to do anyway.
+
+Argo CD users: perform the delete manually, then sync. Do not add the StatefulSet to a
+`Replace=true` sync policy — that would delete the pod along with it.
+
+### `nameOverride` on the bundled datastores
+
+Also fixed here, and unrelated to the above. The bundled datastores rendered their selector and
+their pod template against two different contexts, so under `nameOverride` the two disagreed on
+`app.kubernetes.io/name` and the API server rejected the workload outright with "`selector` does
+not match template `labels`". `nameOverride` broke the bundled NATS, PostgreSQL, Valkey, TRAWL
+and NATS exporter rather than renaming them. If you were affected you will not have a running
+release to upgrade — install normally.
+
 ## Upgrading to 3.0.2
 
 Three corrections to the rules 3.0.0 introduced, all found by evaluating them against synthetic

--- a/charts/tankovault/templates/_datastores.tpl
+++ b/charts/tankovault/templates/_datastores.tpl
@@ -41,7 +41,16 @@ Args: ctx (root), component, runAsUser, readOnlyRootFilesystem.
 */}}
 {{- define "tankovault.datastore.values" -}}
 {{- $ctx := .ctx -}}
+{{- /*
+  `nameOverride` is pinned to the root context's resolved name, exactly as
+  `tankovault.serviceValues` pins it for the services. Without it the scoped context has no
+  `nameOverride` at all and `common.name` falls back to the chart name, while the selector
+  and the object metadata are rendered against the root. Under `nameOverride` the two
+  disagree and the API server rejects the workload outright — `selector` does not match
+  template `labels` — so the setting breaks every bundled datastore rather than renaming it.
+*/ -}}
 {{- $values := dict
+      "nameOverride" (include "common.name" $ctx)
       "image" (merge (deepCopy .image) (deepCopy ($ctx.Values.image | default dict)))
       "imagePullSecrets" ($ctx.Values.imagePullSecrets | default list)
       "resourcesPreset" (.resourcesPreset | default "medium")

--- a/charts/tankovault/templates/nats.yaml
+++ b/charts/tankovault/templates/nats.yaml
@@ -79,7 +79,7 @@ spec:
     - metadata:
         name: data
         labels:
-          {{- include "common.labels" $ctx | nindent 10 }}
+          {{- include "common.immutableLabels" $ctx | nindent 10 }}
           app.kubernetes.io/component: nats
       spec:
         accessModes:

--- a/charts/tankovault/templates/postgresql.yaml
+++ b/charts/tankovault/templates/postgresql.yaml
@@ -79,7 +79,7 @@ spec:
     - metadata:
         name: data
         labels:
-          {{- include "common.labels" $ctx | nindent 10 }}
+          {{- include "common.immutableLabels" $ctx | nindent 10 }}
           app.kubernetes.io/component: postgresql
       spec:
         accessModes:

--- a/charts/tankovault/tests/datastore_immutability_test.yaml
+++ b/charts/tankovault/tests/datastore_immutability_test.yaml
@@ -1,0 +1,134 @@
+suite: immutable fields of the bundled datastores
+templates:
+  - nats.yaml
+  - postgresql.yaml
+values:
+  - ../ci/bundled-datastores-values.yaml
+tests:
+  # `volumeClaimTemplates` is part of the StatefulSet spec, which the API server refuses to
+  # update for any field outside `replicas`, `ordinals`, `template`, `updateStrategy`,
+  # `revisionHistoryLimit`, `persistentVolumeClaimRetentionPolicy` and `minReadySeconds`. Its
+  # labels are therefore immutable too. `common.labels` would stamp `helm.sh/chart` and
+  # `app.kubernetes.io/version` onto them, both of which move on every release — so a chart
+  # bump that changes nothing else still renders a diff the API server rejects, and the
+  # release can never be upgraded in place again. This must stay `common.immutableLabels`.
+  - it: gives the NATS claim template only labels that are stable across releases
+    documentSelector:
+      path: kind
+      value: StatefulSet
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.labels
+          value:
+            app.kubernetes.io/name: tankovault
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/component: nats
+    template: nats.yaml
+
+  - it: gives the PostgreSQL claim template only labels that are stable across releases
+    documentSelector:
+      path: kind
+      value: StatefulSet
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.labels
+          value:
+            app.kubernetes.io/name: tankovault
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/component: postgresql
+    template: postgresql.yaml
+
+  # Asserted separately from the exact-set checks above: those would also fail on an unrelated
+  # label being added, which is a legitimate change. These two never are.
+  - it: keeps the chart and version labels off the NATS claim template
+    documentSelector:
+      path: kind
+      value: StatefulSet
+    asserts:
+      - notExists:
+          path: spec.volumeClaimTemplates[0].metadata.labels["helm.sh/chart"]
+      - notExists:
+          path: spec.volumeClaimTemplates[0].metadata.labels["app.kubernetes.io/version"]
+    template: nats.yaml
+
+  - it: keeps the chart and version labels off the PostgreSQL claim template
+    documentSelector:
+      path: kind
+      value: StatefulSet
+    asserts:
+      - notExists:
+          path: spec.volumeClaimTemplates[0].metadata.labels["helm.sh/chart"]
+      - notExists:
+          path: spec.volumeClaimTemplates[0].metadata.labels["app.kubernetes.io/version"]
+    template: postgresql.yaml
+
+  # The object metadata is a different matter entirely: labels there are mutable, so the
+  # version labels belong on it and must not be stripped by an over-eager fix to the above.
+  - it: still carries the version labels on the mutable object metadata
+    documentSelector:
+      path: kind
+      value: StatefulSet
+    asserts:
+      - exists:
+          path: metadata.labels["helm.sh/chart"]
+      - exists:
+          path: metadata.labels["app.kubernetes.io/version"]
+    template: nats.yaml
+
+  # `nameOverride` reaches the selector and the object metadata through the root context, but
+  # the pod template and the claim template through the datastore's scoped context. Unless
+  # that scope pins `nameOverride`, `common.name` falls back to the chart name, the selector
+  # stops matching the pod template it ships, and the API server rejects the StatefulSet with
+  # "`selector` does not match template `labels`" — so the setting breaks the datastore rather
+  # than renaming it. Only reachable under an override, which no ci/ fixture sets.
+  - it: resolves one name across selector, pod template and claim template under nameOverride
+    set:
+      nameOverride: renamed
+    documentSelector:
+      path: kind
+      value: StatefulSet
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: renamed
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: renamed
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.labels["app.kubernetes.io/name"]
+          value: renamed
+    template: nats.yaml
+
+  - it: resolves one name for the PostgreSQL StatefulSet under nameOverride
+    set:
+      nameOverride: renamed
+    documentSelector:
+      path: kind
+      value: StatefulSet
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: renamed
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: renamed
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.labels["app.kubernetes.io/name"]
+          value: renamed
+    template: postgresql.yaml
+
+  # `existingClaim` takes the volumeClaimTemplates branch away entirely. Guards against a
+  # future refactor that emits an empty or partial claim template on that path — which would
+  # be just as immutable, and just as fatal, as a wrong label.
+  - it: emits no claim template when an existing claim is supplied
+    set:
+      nats.persistence.existingClaim: my-claim
+    documentSelector:
+      path: kind
+      value: StatefulSet
+    asserts:
+      - notExists:
+          path: spec.volumeClaimTemplates
+    template: nats.yaml

--- a/charts/teamspeak/Chart.yaml
+++ b/charts/teamspeak/Chart.yaml
@@ -1,6 +1,6 @@
 name: teamspeak
 description: This chart deploys a TeamSpeak 3 server hardened to the restricted Pod Security Standard, with optional persistence, an optional Prometheus metrics exporter sidecar, Grafana dashboards and Prometheus alerting rules.
-version: 1.0.4
+version: 1.0.5
 appVersion: 3.13.8
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts
@@ -12,5 +12,5 @@ maintainers:
     email: contact@tim-schoenle.de
 dependencies:
   - name: common
-    version: 1.2.1
+    version: 1.3.0
     repository: "file://../common"

--- a/charts/teamspeak/README.md
+++ b/charts/teamspeak/README.md
@@ -1,6 +1,6 @@
 # teamspeak
 
-![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![AppVersion: 3.13.8](https://img.shields.io/badge/AppVersion-3.13.8-informational?style=flat-square)
+![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![AppVersion: 3.13.8](https://img.shields.io/badge/AppVersion-3.13.8-informational?style=flat-square)
 
 This chart deploys a TeamSpeak 3 server hardened to the restricted Pod Security Standard, with optional persistence, an optional Prometheus metrics exporter sidecar, Grafana dashboards and Prometheus alerting rules.
 


### PR DESCRIPTION
## The bug

Upgrading a live `tankovault` release fails at apply time:

```
StatefulSet.apps "tankovault-nats" is invalid: spec: Forbidden: updates to statefulset spec
for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy',
'revisionHistoryLimit', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are
forbidden
```

`volumeClaimTemplates` is part of the StatefulSet **spec**, so its labels are immutable once the object exists. Both bundled datastores stamped `common.labels` onto it, which folds in `helm.sh/chart` and `app.kubernetes.io/version` — both of which move on every release. Rendering the NATS StatefulSet at two versions with identical values produced exactly one difference, and it was in the immutable block:

```diff
       labels:
-          helm.sh/chart: tankovault-3.0.2
+          helm.sh/chart: tankovault-9.9.9
-          app.kubernetes.io/version: "1.2.0"
+          app.kubernetes.io/version: "9.9.9"
```

This was never specific to one release. **Any** version bump of this chart broke in-place upgrades of every StatefulSet it ships with persistence enabled.

## The fix

New `common.immutableLabels` helper, used for both claim templates. The resulting set — `name`, `instance`, `managed-by`, `component` — is stable for the lifetime of a release. `.Values.commonLabels` is deliberately excluded too: it is operator-settable, so folding it in would re-open the trap the first time someone adds a label to a running release.

The chart already encoded this rule one level too shallow. `common.podLabels` exists precisely to keep `helm.sh/chart` off pod labels. On a pod template that costs a needless rollout; on a claim template it costs the whole upgrade.

## Repository audit

Only the two call sites were affected. Everything else is safe for concrete reasons:

- **Standalone PVCs** (`netcup-offer-bot`, `teamspeak`) put `common.labels` in object *metadata*, which is mutable; their specs carry nothing version-derived.
- **Jobs** are either Helm hooks with `before-hook-creation`, or content-addressed via `common.fullname.hashed` — and `common.podLabels` already excludes `helm.sh/chart`, so a chart-only bump does not re-run them.
- **`_workload.tpl`** emits Deployment/Service/HPA/PDB, no StatefulSets. No `clusterIP` is set anywhere, and every selector uses a version-free helper.

## A second defect the audit turned up

Unrelated to the above, and also fixed here. `tankovault.datastore.values` never pinned `nameOverride`, so the datastores rendered their **selector** against the root context and their **pod template** against the scoped one. Under `nameOverride` the two disagreed on `app.kubernetes.io/name`:

```
app.kubernetes.io/name: selector='custom' template='tankovault'
```

The API server rejects that outright — `selector` does not match template `labels`. So `nameOverride` *broke* the bundled NATS, PostgreSQL, Valkey, TRAWL and NATS exporter rather than renaming them. Now pinned the way `tankovault.serviceValues` already does for the services.

## CI guard

Both defects render, lint and install cleanly. `ct install` cannot catch either: it installs fresh, and a fresh install of a broken chart succeeds. The version-invariance failure only appears on an upgrade of an already-running release.

`.github/scripts/check-immutable-fields.py` renders every chart against every `ci/` values file at its own version and at a synthetic bumped one, diffs the immutable half of each StatefulSet spec, and separately checks selector/template agreement — including a render with `nameOverride` forced, since no fixture sets it.

Verified by reintroducing both bugs: precise, actionable diffs, and no false positives across all 28 (chart, values) pairs.

### On the hardcoded field list

Mutability is **not** expressed in the Kubernetes schema. It is enforced imperatively in `ValidateStatefulSetUpdate`; the published schema carries no `x-kubernetes-validations`, no immutability marker and no wording to parse — I checked the actual schema rather than assuming.

What the schema *is* authoritative on is which fields exist. So the list is cross-checked against the same catalog kubeconform already validates the manifests with, which catches drift from a typo or a rename — otherwise a bad name is silently inert and the field it meant to cover goes unchecked. It prints the derived immutable set (`podManagementPolicy`, `selector`, `serviceName`, `volumeClaimTemplates`) and degrades to a warning if the network is unavailable, since it is an assertion about a constant rather than one of the two checks the job exists to run.

## Versions

`common` gains a helper, so it goes to **1.3.0**. A bare version in `dependencies` is an exact constraint — `helm dependency build` fails for any chart left pinned to the old one — so every dependent updates its pin and takes a patch bump. This matches the repo's own convention for a `common` bump (see c8f088e).

`tankovault` is **3.0.3**.

## ⚠️ Existing installs need one manual step

**The fix does not repair an already-deployed release.** The running StatefulSet still carries the old labels, and the corrected render still differs from them, so the upgrade is rejected on the same field until the object is recreated once:

```shell
kubectl delete statefulset <release>-nats -n <namespace> --cascade=orphan
```

Documented in the README along with why it is safe:

- The chart sets no `persistentVolumeClaimRetentionPolicy`, so it defaults to `Retain`/`Retain` and the PVCs hold no owner reference to the StatefulSet — the data survives regardless of how it is deleted. (Verified against the rendered output, not assumed.)
- `--cascade=orphan` deletes only the StatefulSet object; the pod keeps running.
- The recreated selector is `name`/`instance`/`component` only and is unchanged between versions, so it adopts the orphaned pod rather than starting a rival, then rolls it once for the new image — which the upgrade was going to do anyway.

## Testing

- `charts/tankovault/tests/datastore_immutability_test.yaml` — 8 tests covering both claim templates and the `nameOverride` path. Verified non-vacuous: 6 of 8 fail when the bugs are reintroduced, and the 2 that pass are correctly insensitive to them.
- `.github/testdata/common-fixture/` — a StatefulSet instantiating `common.immutableLabels`, plus 5 tests. Verified non-vacuous by mutating the helper to re-add `helm.sh/chart`: 3 of 5 fail.
- Full suite green: `helm lint` on all 8 charts, 592 chart tests + 50 fixture tests, and the new guard at 0 violations.

## Note for the reviewer

`helm-docs` was not available locally, so `README.md.gotmpl` (the source of truth) and the prose in `README.md` are updated, but version badges and values tables are left for CI's docs job to regenerate — as it does on every PR.
