### PR TITLE
fix(tankovault): give TRAWL a writable camoufox addons directory

### DIFF
--- a/charts/tankovault/Chart.yaml
+++ b/charts/tankovault/Chart.yaml
@@ -1,6 +1,6 @@
 name: tankovault
 description: This chart deploys the full TankoVault manga aggregator stack — frontend, api, control-plane, worker, notifier, sync, challenge-solver and render — hardened to the restricted Pod Security Standard, with file-backed configuration that reloads in place instead of restarting pods, optional bundled PostgreSQL, Valkey, NATS JetStream and TRAWL, and optional Prometheus metrics, alerting rules and Grafana dashboards.
-version: 3.0.3
+version: 3.0.4
 appVersion: 1.2.0
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts

--- a/charts/tankovault/README.md
+++ b/charts/tankovault/README.md
@@ -1,6 +1,6 @@
 # tankovault
 
-![Version: 3.0.3](https://img.shields.io/badge/Version-3.0.3-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 3.0.4](https://img.shields.io/badge/Version-3.0.4-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 This chart deploys the full TankoVault manga aggregator stack — frontend, api, control-plane, worker, notifier, sync, challenge-solver and render — hardened to the restricted Pod Security Standard, with file-backed configuration that reloads in place instead of restarting pods, optional bundled PostgreSQL, Valkey, NATS JetStream and TRAWL, and optional Prometheus metrics, alerting rules and Grafana dashboards.
 

--- a/charts/tankovault/templates/trawl.yaml
+++ b/charts/tankovault/templates/trawl.yaml
@@ -11,9 +11,17 @@
   database, and far more shared memory than the 64Mi Kubernetes gives `/dev/shm` by default.
   Both are emptyDirs so the root filesystem can stay read-only; `/tmp`, where Playwright
   stages each launch's throwaway profile, is already provisioned by `common.volumes` for
-  exactly that reason. Nothing under `/app` or `/opt/camoufox` is written at runtime — the
-  image bakes the GeoLite2 database that `camoufox-js` would otherwise download into
-  `CAMOUFOX_INSTALL_DIR` on first launch — so no other path needs to be writable.
+  exactly that reason.
+
+  `/opt/camoufox/addons` is writable for a third reason. `camoufox-js` resolves its addons
+  under `CAMOUFOX_INSTALL_DIR` and, on *every* launch, downloads uBlock Origin into
+  `<install dir>/addons/UBO` unless that directory already exists. The image does not bake it,
+  so on a read-only root every launch fails the `mkdir` with `EROFS` and runs without the
+  blocker it was configured with. An emptyDir at exactly that path lets the first launch fetch
+  it — the pod already has the internet egress the NetworkPolicy grants it — and every later
+  launch reuse it. Nothing else under `/app` or `/opt/camoufox` is written at runtime: the
+  image does bake the GeoLite2 database `camoufox-js` would otherwise download into the same
+  install directory on first launch.
 
   `/health` returns 503 until at least one browser is *live* and keeps returning 200 while the
   pool is merely saturated, so it is safe as all three probes: readiness gates the Service on
@@ -34,11 +42,14 @@
     ) | fromYaml }}
 {{- $ctx := dict "Values" $values "Chart" $.Chart "Release" $.Release "Capabilities" $.Capabilities "Template" $.Template "Files" $.Files }}
 {{- $home := "/home/trawl" }}
+{{- $addons := "/opt/camoufox/addons" }}
 {{- $mounts := list
       (dict "name" "home" "mountPath" $home)
+      (dict "name" "addons" "mountPath" $addons)
       (dict "name" "dshm" "mountPath" "/dev/shm") }}
 {{- $volumes := list
       (dict "name" "home" "emptyDir" dict)
+      (dict "name" "addons" "emptyDir" (dict "sizeLimit" "64Mi"))
       (dict "name" "dshm" "emptyDir" (dict "medium" "Memory" "sizeLimit" $trawl.shmSize)) }}
 {{- /*
   `BROWSER_POOL_SIZE` is always emitted: the image defaults to 3 warm Firefoxes, which does not

--- a/charts/tankovault/tests/security_test.yaml
+++ b/charts/tankovault/tests/security_test.yaml
@@ -136,6 +136,25 @@ tests:
               medium: Memory
               sizeLimit: 1Gi
 
+  - it: gives TRAWL a writable addons directory inside its install directory
+    # `camoufox-js` downloads uBlock Origin into `CAMOUFOX_INSTALL_DIR/addons` on every launch
+    # unless the directory is already there. Without this the mkdir fails with EROFS on the
+    # read-only root and the browser runs without the blocker.
+    template: trawl.yaml
+    documentIndex: 1
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: addons
+            mountPath: /opt/camoufox/addons
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: addons
+            emptyDir:
+              sizeLimit: 64Mi
+
   - it: gives the render tier the writable paths Chromium needs
     template: deployment.yaml
     documentSelector:


### PR DESCRIPTION
## What

Mounts a 64Mi `emptyDir` at `/opt/camoufox/addons` in the bundled TRAWL Deployment, and corrects the template comment that asserted nothing under `/opt/camoufox` is written at runtime.

## Why

`camoufox-js` resolves its addons under `CAMOUFOX_INSTALL_DIR` (`/opt/camoufox` in the TRAWL image) and, on **every** browser launch, calls `maybeDownloadAddons` → `mkdir <install dir>/addons/UBO` unless that directory already exists. The image does not bake it, so with `readOnlyRootFilesystem: true` the mkdir fails:

```
Failed to download and extract UBO: Error: EROFS: read-only file system, mkdir '/opt/camoufox/addons'
```

`camoufox-js` catches the error and launches Firefox anyway — without uBlock Origin. The result is silent degradation rather than a crash: every solve pulls the full ad and tracker payload of the target page, and the error repeats on each pool recycle.

The chart's own comment claimed the opposite ("Nothing under `/app` or `/opt/camoufox` is written at runtime"), which is why the volume was never provisioned in the first place.

## Notes for the reviewer

- **No NetworkPolicy change needed.** The TRAWL datastore rule already carries `internet: true`, so the first-launch fetch of the addon is permitted. If the download does fail (e.g. `addons.mozilla.org` unreachable), `camoufox-js` cleans up the directory and continues — the same graceful degradation as today, just without the `EROFS`.
- **Per pod, not per launch.** Once the first launch populates the emptyDir, `maybeDownloadAddons` short-circuits on the path-exists check for every subsequent launch and pool recycle in that pod.
- **Path is hardcoded** to `/opt/camoufox/addons`, matching the digest-pinned `trawl.image.tag`. It is not derivable from values; `CAMOUFOX_INSTALL_DIR` is set inside the image and cannot be overridden without hiding the baked browser binary and GeoLite2 database.
- **64Mi** is generous for the extracted uBO XPI (~15Mi). It is not exposed as a value since there is nothing meaningful for an operator to tune.
- Out of scope, but worth flagging: with the default `trawl.browserPoolSize: 1`, a routine recycle (`[pool] browser 0 restarting: tier3 blocked; 8 temporary contexts used`) takes the pool to `live: 0`, so `/health` returns 503 until the relaunch completes. Readiness tolerates ~30s of that, but concurrent requests in the window get a 429 after the 15s acquire timeout. Left at 1 because raising it is a resource-cost decision, not a bug fix.

## Testing

- New `security_test.yaml` case asserting the mount and the volume.
- `helm unittest charts/tankovault`: 129 passed, 11 suites, 0 failed.
- Chart bumped 3.0.3 → 3.0.4 with the README version badge.
