### PR TITLE
feat(tankovault): prepare the chart for the recommender, update to 1.3.0

### DIFF
--- a/.github/configs/kind.yaml
+++ b/.github/configs/kind.yaml
@@ -1,0 +1,36 @@
+# The cluster `ct install --upgrade` runs against.
+#
+# Three nodes rather than the action's default single node, and the reason is scheduling
+# capacity during an upgrade rather than anything about multi-node behaviour.
+#
+# `ct install --upgrade` installs the previous chart revision and then upgrades the release in
+# place. Every chart-version bump rewrites `helm.sh/chart` and `app.kubernetes.io/version` in the
+# pod labels, so the upgrade rolls *every* workload at once — for the tankovault chart's
+# `bundled-datastores-values.yaml` fixture that is twelve of them, including the PostgreSQL and
+# NATS StatefulSets. The fixture's steady state is ~2700m of CPU requests and a default 25%
+# rolling-update surge asks for roughly 1700m on top, against the ~3250m a single kind node on a
+# 4-core runner has to give.
+#
+# Over-request on its own would be harmless — surplus pods simply stay Pending until the old ones
+# retire. It stops being harmless because a datastore StatefulSet is among the workloads being
+# replaced: its pod is deleted and recreated, and in that window the surge pods take the CPU it
+# just released. Nothing then resolves. No service passes a readiness probe without the database,
+# so no old pod is ever retired, so the capacity never comes back, and the upgrade sits there
+# until `--timeout` expires. That is what it looked like the first time this job met a
+# version-bumping PR.
+#
+# Each kind node is a container that advertises the host's full CPU count, so three of them
+# report three times the allocatable CPU the runner actually has. That is deliberate
+# over-subscription: requests are a scheduling contract, not a reservation, and this job is
+# verifying that a release installs and upgrades cleanly, not that it fits in 4 cores. Pods may
+# be throttled under contention; none of the assertions here are timing-sensitive.
+#
+# The alternative — shrinking the fixture until an upgrade fits on one node — would have cost the
+# coverage that matters most, since the bundled datastores are exactly the configuration where an
+# in-place upgrade is risky.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -401,12 +401,23 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
 
+      # Three nodes, because `--upgrade` rolls every workload at once and a single node cannot
+      # schedule the rolling-update surge alongside the datastore StatefulSets it is also
+      # replacing. See the header of the config for what that deadlock looks like.
       - name: Create kind cluster
         if: needs.lint.outputs.changed == 'true'
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
+          config: ./.github/configs/kind.yaml
           node_image: kindest/node:${{ matrix.kubernetes }}
           wait: '120s'
+
+      # kind's own `--wait` covers the control plane; the workers join after it returns. Without
+      # this the install can start while they are still NotReady, land everything on the one node
+      # that is, and hit exactly the capacity limit the extra nodes were added to remove.
+      - name: Wait for every node to be ready
+        if: needs.lint.outputs.changed == 'true'
+        run: kubectl wait --for=condition=Ready nodes --all --timeout=180s
 
       # Charts that ship PodMonitors or PrometheusRules fail to render without the Prometheus
       # Operator's CRDs, and kind provides none. Only the two kinds the charts actually use are

--- a/charts/tankovault/Chart.yaml
+++ b/charts/tankovault/Chart.yaml
@@ -1,7 +1,7 @@
 name: tankovault
 description: This chart deploys the full TankoVault manga aggregator stack — frontend, api, control-plane, worker, notifier, sync, challenge-solver and render — hardened to the restricted Pod Security Standard, with file-backed configuration that reloads in place instead of restarting pods, optional bundled PostgreSQL, Valkey, NATS JetStream and TRAWL, and optional Prometheus metrics, alerting rules and Grafana dashboards.
-version: 3.0.5
-appVersion: 1.2.2
+version: 3.1.0
+appVersion: 1.3.0
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts
 sources:

--- a/charts/tankovault/README.md
+++ b/charts/tankovault/README.md
@@ -472,12 +472,15 @@ operator's decision to schedule.
   rollout — and the migration is the step that needs pgvector.
 - **The bundled PostgreSQL image changed** from `postgres:18-alpine` to `pgvector/pgvector:pg18`,
   as above. If you pinned `postgresql.image.*` yourself, move it to an image that has pgvector.
-- **The upgrade moves the database pod**, which earlier upgrades never did — the image is what
-  changed, so the StatefulSet has to replace it. On a cluster with no spare CPU that can deadlock:
-  the rolling-update surge takes the capacity the database pod just released, and nothing recovers,
-  because no service passes a readiness probe without the database and so no old pod is ever
-  retired. If your nodes are tight, set `defaults.strategy.rollingUpdate.maxSurge: 0` for the
-  upgrade, which retires before it replaces. The chart's own CI fixture does exactly this.
+- **On a capacity-constrained cluster, set `defaults.strategy.rollingUpdate.maxSurge: 0` for the
+  upgrade.** Every chart-version bump rewrites the `helm.sh/chart` and `app.kubernetes.io/version`
+  pod labels, so an upgrade rolls every workload — the bundled datastores included, which means
+  the database pod is deleted and recreated. The default rollout asks for its replacement pods
+  before retiring the old ones, and if the surge takes the CPU the database just released,
+  nothing recovers: no service passes a readiness probe without the database, so no old pod is
+  ever retired and the capacity never comes back. `maxSurge: 0` retires before it replaces. This
+  is not new in 3.1.0 — it applies to any version bump with the bundled datastores on tight
+  nodes — but it is worth knowing before an upgrade that also has a REINDEX after it.
 - **Two alerts are added**, `TankoVaultRecsysBuildFailing` and `TankoVaultRecsysShelvesEmpty`, with
   seven recording rules behind them under `tankovault-recsys-recording`. `metrics.prometheusRule`
   therefore produces 21 groups where it produced 19.

--- a/charts/tankovault/README.md
+++ b/charts/tankovault/README.md
@@ -1,6 +1,6 @@
 # tankovault
 
-![Version: 3.0.5](https://img.shields.io/badge/Version-3.0.5-informational?style=flat-square) ![AppVersion: 1.2.2](https://img.shields.io/badge/AppVersion-1.2.2-informational?style=flat-square)
+![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
 
 This chart deploys the full TankoVault manga aggregator stack — frontend, api, control-plane, worker, notifier, sync, challenge-solver and render — hardened to the restricted Pod Security Standard, with file-backed configuration that reloads in place instead of restarting pods, optional bundled PostgreSQL, Valkey, NATS JetStream and TRAWL, and optional Prometheus metrics, alerting rules and Grafana dashboards.
 
@@ -17,8 +17,9 @@ the optional headless `render` tier, plus the one-shot `bootstrap` migration and
 
 - Kubernetes 1.19+
 - Helm 3.0+
-- A PostgreSQL database — either the bundled one (`postgresql.enabled=true`) or your own
-  (`externalDatabase.*`)
+- A PostgreSQL database **with [pgvector](https://github.com/pgvector/pgvector) available** —
+  either the bundled one (`postgresql.enabled=true`, which runs `pgvector/pgvector`) or your own
+  (`externalDatabase.*`). See [Recommendations need pgvector](#recommendations-need-pgvector).
 - A NATS server with JetStream enabled, if `worker` or `control-plane` are deployed
 - The Prometheus Operator CRDs, if `metrics.serviceMonitor` or `metrics.prometheusRule` are enabled
 - An ingress controller, if `ingress.enabled=true`
@@ -205,6 +206,64 @@ The default is unchanged, so `helm install` consumers and anyone happy with the 
 Only `bootstrap.migrate.mode: job` is affected; the seed steps stay `post-install` because PostSync
 runs after Sync and their secrets already exist.
 
+## Recommendations need pgvector
+
+TankoVault 1.3.0 adds a recommender: a vector model built from the catalogue on the
+control-plane's schedule and queried per reader on the `api`. Migration
+`0027_recsys_signals` runs `CREATE EXTENSION vector`, so **from that release on the database must
+have pgvector available**. The migration fails loudly rather than degrading, because a recommender
+that silently returns nothing is worse than one that refuses to start.
+
+- **`postgresql.enabled=true`**: the bundled image moved from `postgres:18-alpine` to
+  `pgvector/pgvector:pg18` — the same PostgreSQL major with the extension preinstalled, same
+  entrypoint, same environment contract, same uid, so the existing PVC is reused in place and no
+  other value changes. **An existing release needs one manual step afterwards**; see
+  [Upgrading to 3.1.0](#upgrading-to-310). A fresh install needs nothing.
+- **`externalDatabase.*`**: install the extension package *before* upgrading — `apt install
+  postgresql-18-pgvector`, or your managed provider's equivalent; RDS, Cloud SQL and Azure
+  Flexible Server all ship it behind an allowlist setting. The migration only needs it to be
+  installable, and issues the `CREATE EXTENSION` itself.
+
+Rolling the migration back drops the recommender's tables and deliberately leaves the extension in
+place, since dropping it would cascade into every column typed by it.
+
+### Build cadence and cost
+
+The model is built by the `control-plane`'s scheduler, on the elected leader only, and only while
+the `catalogue.recommendations` feature flag is on. Both cadences are ordinary configuration, so
+they go under `services.controlPlane.config` like anything else:
+
+```yaml
+services:
+  controlPlane:
+    config:
+      scheduler:
+        recsys_incremental_interval_secs: 900     # re-embeds what changed
+        recsys_full_interval_secs: 604800         # re-solves the projection; 0 disables
+        recsys_batch: 512                         # series per streamed batch
+        recsys_incremental_max: 20000             # ceiling on one incremental pass
+```
+
+Three things about this are worth knowing before you tune it:
+
+- **The full build is not about freshness.** The incremental pass covers changed series; the full
+  one exists for vocabulary and idf drift, which is why weekly is enough.
+- **A deployment that has never completed a full build has no projection basis, and every
+  incremental build refuses to run** — deliberately, because projecting against a partially-solved
+  basis yields vectors that are not comparable with the stored ones. Both timers fire once
+  immediately when the leader starts, so a fresh install builds on the control-plane's first
+  scheduler tick rather than waiting a week. The consequence to remember is the other direction:
+  every restart of the leading replica starts a full rebuild.
+- **`recsys_batch` is the only knob on the builder's peak memory in the streaming stages.** The
+  covariance matrix that dominates the rest is bounded upstream at ~32 MB regardless of catalogue
+  size, so the `medium` preset on `control-plane` is not the constraint — but a batch raised far
+  above the default against a memory limit will be, and an OOM-killed builder leaves no log line
+  and no `failed` metric, only a restart.
+
+To run without the recommender, switch the `catalogue.recommendations` feature flag off in the
+admin console. Setting both intervals to `0` stops the builds but leaves the surface on, which
+serves empty shelves rather than hiding them.
+
 ## Exposure
 
 Only the frontend is published. It serves the SPA and reverse-proxies `/v1/*` to the API, so one
@@ -259,6 +318,12 @@ Readiness is taken from the services' own `service_ready` and `service_dependenc
 blackbox prober is involved, and `TankoVaultDependencyDown` names the failing dependency —
 postgres, nats or redis — in the alert rather than sending you to `curl /ready`.
 
+The recommender gets its own rules for the same reason the scan pipeline does: both of its failure
+modes are invisible everywhere else. A model that has stopped being built keeps serving, stale and
+then empty, without a single error or a millisecond of added latency
+(`TankoVaultRecsysBuildFailing`); and an empty shelf is a `200` returned faster than a full one
+(`TankoVaultRecsysShelvesEmpty`). Neither moves the request-path metrics at all.
+
 Two alerts that a chart should not reinvent are deliberately absent, because the Prometheus
 Operator this chart already requires ships both: `KubeDeploymentReplicasMismatch` for replica
 shortfalls (it reads kube-state-metrics, which knows the desired count; nothing this chart emits
@@ -306,7 +371,8 @@ default is Grafana's own — the ConfigMap is created and nothing ever reads it.
 
 There are two dashboards: a service overview (liveness, readiness and its dependencies, the
 request path, the database pool, edge policy) and a scan pipeline (scheduling, per-provider
-throughput and backlog, outbound fetches and throttling, notifications, AniList). Neither pins a
+throughput and backlog, outbound fetches and throttling, notifications, AniList, and the
+recommendation model built from the catalogue the rest of it fills). Neither pins a
 datasource UID — both expose a `Data source` picker and a `Namespace` picker, so one copy works
 for every release in the cluster.
 
@@ -353,6 +419,75 @@ service would otherwise refuse to boot on the same condition at container start.
 Documents supplied through `content` are read on demand behind an mtime check, so correcting a
 policy is a values change and the kubelet's ConfigMap refresh, never a restart. That ConfigMap is
 deliberately excluded from the pod's `checksum/config` annotation for exactly that reason.
+
+## Upgrading to 3.1.0
+
+This version moves to TankoVault 1.3.0, which adds the recommender. Two things need reading before
+you upgrade an existing release, one for each kind of database.
+
+**On an external database**, install pgvector first — see
+[Recommendations need pgvector](#recommendations-need-pgvector). Migration `0027` will not run
+without it and there is nothing a chart can do to detect that ahead of time.
+
+### `postgresql.enabled=true`: REINDEX once, after the upgrade
+
+**This is a required step for any existing release running the bundled database, and nothing will
+tell you if you skip it.** Fresh installs are unaffected.
+
+Getting pgvector meant moving the bundled image from Alpine to Debian, and those two sort text
+differently under the same `en_US.utf8` locale name — musl compares by byte, glibc compares
+linguistically:
+
+| | `ORDER BY t` |
+|---|---|
+| `postgres:18-alpine` (musl) | `A, B, _z, a, a-b, ab, b` |
+| `pgvector/pgvector:pg18` (glibc) | `a, A, a-b, ab, b, B, _z` |
+
+Every btree index on a `text` or `varchar` column was built under the first ordering and is not
+valid under the second. The consequence is silent and it is wrong answers, not errors: an index
+scan can skip rows that are really there, and a unique index can stop rejecting duplicates.
+Verified with `amcheck` against a data directory carried across the two images —
+`bt_index_check` reports `item order invariant violated` immediately after the swap.
+
+PostgreSQL issues **no warning**, which is what makes this worth a section rather than a
+footnote. It warns on a collation change only when the database records a collation version to
+compare against, and a cluster initialised by the Alpine image records none
+(`pg_database.datcollversion` is null).
+
+The whole fix is one command, run once, after the new image is serving:
+
+```shell
+kubectl -n <namespace> exec -it <release>-tankovault-postgresql-0 -- \
+  psql -U tankovault -d tankovault -c 'REINDEX DATABASE tankovault;'
+```
+
+`REINDEX DATABASE` takes locks on each index as it rebuilds it, so run it in a window where a
+pause is acceptable, or use `REINDEX DATABASE CONCURRENTLY` to trade speed for staying online.
+The chart prints this instruction in its upgrade notes too, and deliberately does not run it for
+you: on a large catalogue it is a long operation with real locking behaviour, and that is an
+operator's decision to schedule.
+
+- **`appVersion` is 1.3.0** and all nine service images are repinned to their `v1.3.0` digests.
+  The upgrade order is the one the chart already enforces — the migration runs ahead of the
+  rollout — and the migration is the step that needs pgvector.
+- **The bundled PostgreSQL image changed** from `postgres:18-alpine` to `pgvector/pgvector:pg18`,
+  as above. If you pinned `postgresql.image.*` yourself, move it to an image that has pgvector.
+- **The upgrade moves the database pod**, which earlier upgrades never did — the image is what
+  changed, so the StatefulSet has to replace it. On a cluster with no spare CPU that can deadlock:
+  the rolling-update surge takes the capacity the database pod just released, and nothing recovers,
+  because no service passes a readiness probe without the database and so no old pod is ever
+  retired. If your nodes are tight, set `defaults.strategy.rollingUpdate.maxSurge: 0` for the
+  upgrade, which retires before it replaces. The chart's own CI fixture does exactly this.
+- **Two alerts are added**, `TankoVaultRecsysBuildFailing` and `TankoVaultRecsysShelvesEmpty`, with
+  seven recording rules behind them under `tankovault-recsys-recording`. `metrics.prometheusRule`
+  therefore produces 21 groups where it produced 19.
+- **The scan-pipeline dashboard gains a `Recommendations` row.** No new ConfigMap key and no new
+  `GrafanaDashboard`; the existing `tankovault-scan-pipeline.json` grew five panels.
+- **Nothing is switched on by this chart.** The recommender is gated on the
+  `catalogue.recommendations` feature flag in the admin console, and its build cadence has working
+  defaults — see [Build cadence and cost](#build-cadence-and-cost) for the knobs and for the two
+  things worth knowing before touching them. With the flag off nothing builds and nothing is
+  served, so the new rules evaluate against no data and stay dark rather than firing.
 
 ## Upgrading to 3.0.3
 
@@ -430,7 +565,7 @@ series rather than only checking that they parse.
   a recorded series' level prefix is meant to be its label set. If you referenced the old name in a
   query of your own, update it; nothing inside the chart still does.
 - **`TankoVaultWorkerTargetsAbsent`'s runbook** no longer interpolates
-  `{{ $labels.namespace }}`.
+  `{{ `{{ $labels.namespace }}` }}`.
   `absent()` builds its series from equality matchers only, so under
   `metrics.prometheusRule.scope=none` that label does not exist and the runbook rendered a
   `kubectl -n  ...` command with a hole in it.
@@ -507,9 +642,9 @@ later read — upgrade the application first, or in the same step.
 | anilist.tokenEncryptionKey | string | `""` | Base64 of exactly 32 bytes, sealing every user's AniList token at rest. Left empty the chart generates one when `services.sync` is enabled and remembers it across upgrades, which is the recommended setting; set one explicitly (`openssl rand -base64 32`) only if it has to be known outside the release. Losing it forces every account to re-link; leaking it exposes every stored token. Rotating it does not re-seal tokens already stored. |
 | auth.jwtSecret | string | `""` | Token signing secret (`auth.jwt_secret`). Left empty the chart generates one and remembers it across upgrades, which is the recommended setting; set one explicitly (minimum 32 characters, e.g. `openssl rand -hex 32`) only if it has to be known outside the release. The known upstream placeholder is refused at boot in every profile, and rotating the value signs every user out. |
 | auth.passwordPepper | string | `""` | Server-side pepper mixed into every argon2id hash, so a database leak alone cannot be brute-forced offline. Left empty the chart generates one **on a first install only** and remembers it across upgrades; a release that already exists without a pepper keeps running without one, because every password stored unpeppered would stop verifying the moment one appeared. For the same reason it must never change once set: rotating or losing it invalidates every stored password, so back the Secret up. The `seed-admin` step receives the identical value, or the administrator it creates could never log in. |
-| bootstrap | object | `{"image":{"repository":"timschoenle/tankovault-bootstrap","tag":"v1.2.2@sha256:6dec5e2ad047d4d531376a31814e5c7e96e6a683941771be869451c836592f8f"},"migrate":{"argoSyncWaveBase":0,"backoffLimit":3,"mode":"auto","ordering":"helmHook"},"resourcesPreset":"small","seedAdmin":{"email":"","enabled":false,"password":"","username":"admin"},"seedProviders":{"enabled":false}}` | Schema migration and first-install seeding, all from the `bootstrap` image. Nothing published carries a destructive command; resetting the schema is not available in any image. |
+| bootstrap | object | `{"image":{"repository":"timschoenle/tankovault-bootstrap","tag":"v1.3.0@sha256:009bf66ae3c903e942dd9d81d0c4911186f2f395bf38c80d83b6415d49ebffd5"},"migrate":{"argoSyncWaveBase":0,"backoffLimit":3,"mode":"auto","ordering":"helmHook"},"resourcesPreset":"small","seedAdmin":{"email":"","enabled":false,"password":"","username":"admin"},"seedProviders":{"enabled":false}}` | Schema migration and first-install seeding, all from the `bootstrap` image. Nothing published carries a destructive command; resetting the schema is not available in any image. |
 | bootstrap.image.repository | string | `"timschoenle/tankovault-bootstrap"` | Image repository. |
-| bootstrap.image.tag | string | `"v1.2.2@sha256:6dec5e2ad047d4d531376a31814e5c7e96e6a683941771be869451c836592f8f"` | Image tag, pinned by digest. |
+| bootstrap.image.tag | string | `"v1.3.0@sha256:009bf66ae3c903e942dd9d81d0c4911186f2f395bf38c80d83b6415d49ebffd5"` | Image tag, pinned by digest. |
 | bootstrap.migrate.argoSyncWaveBase | int | `0` | Sync wave the migration Job takes under `ordering: argoSyncWave`; the workloads take this plus one, which is what reproduces the `pre-upgrade` guarantee — Argo CD holds a wave until the previous one is healthy, and a Job is healthy only once it is Complete. Anything the migration itself depends on — the ExternalSecret carrying `database__url`, a database some operator provisions — must be given a wave strictly below this one. |
 | bootstrap.migrate.backoffLimit | int | `3` | Retries before the migration Job is considered failed. |
 | bootstrap.migrate.mode | string | `"auto"` | How `bootstrap migrate` runs. `job` is a `pre-install,pre-upgrade` Helm hook, correct when the database already exists. `initContainer` runs it in every service pod, which is what the bundled PostgreSQL needs — a pre-install hook would run before the StatefulSet exists and could only ever fail. Concurrent runs are safe: sqlx takes a Postgres advisory lock. `auto` picks `initContainer` when `postgresql.enabled`, otherwise `job`. |
@@ -666,13 +801,13 @@ later read — upgrade the application first, or in the same step.
 | networkPolicy.ingressController.podSelector | object | `{}` | Pod selector matching the ingress controller. |
 | networkPolicy.internetCidrs | list | `["0.0.0.0/0"]` | Egress CIDRs treated as "the internet". The worker scrapes provider sites, sync talks to AniList and the notifier reaches SMTP and webhook endpoints, so these tiers need it. RFC1918 ranges and the cloud metadata endpoint are excluded automatically. |
 | networkPolicy.monitoring.namespaceSelector | object | `{}` | Namespace selector matching Prometheus, allowed to reach the metrics port. |
-| postgresql | object | `{"auth":{"database":"tankovault","password":"","username":"tankovault"},"enabled":false,"image":{"repository":"postgres","tag":"18-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15"},"persistence":{"enabled":true,"existingClaim":"","size":"20Gi","storageClassName":""},"resourcesPreset":"large"}` | Bundled PostgreSQL. A single instance with a PVC, on the same image the upstream compose stack pins. Deliberately not an operator and not a third-party subchart, so `helm install` works on a bare cluster — but equally deliberately **not a production database**: one replica, no failover, no point-in-time recovery. Use `externalDatabase` for anything real. |
+| postgresql | object | `{"auth":{"database":"tankovault","password":"","username":"tankovault"},"enabled":false,"image":{"repository":"pgvector/pgvector","tag":"pg18@sha256:691673308c99d2161ba298736f3147f1f22d79de2fb7ec93ae9b4afcab870b62"},"persistence":{"enabled":true,"existingClaim":"","size":"20Gi","storageClassName":""},"resourcesPreset":"large"}` | Bundled PostgreSQL. A single instance with a PVC, on the same image the upstream compose stack pins. Deliberately not an operator and not a third-party subchart, so `helm install` works on a bare cluster — but equally deliberately **not a production database**: one replica, no failover, no point-in-time recovery. Use `externalDatabase` for anything real — and give it [pgvector](https://github.com/pgvector/pgvector), which migration `0027` requires. |
 | postgresql.auth.database | string | `"tankovault"` | Database name. |
 | postgresql.auth.password | string | `""` | Database password. Generated and persisted across upgrades when left empty. |
 | postgresql.auth.username | string | `"tankovault"` | Database role. |
 | postgresql.enabled | bool | `false` | Deploy the bundled PostgreSQL. |
-| postgresql.image.repository | string | `"postgres"` | Image repository. |
-| postgresql.image.tag | string | `"18-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15"` | Image tag, pinned by digest. |
+| postgresql.image.repository | string | `"pgvector/pgvector"` | Image repository. `pgvector/pgvector`, not stock `postgres`: TankoVault migration `0027_recsys_signals` runs `CREATE EXTENSION vector` and the recommender retrieves through an HNSW index, so the extension is a hard dependency of the deployment rather than an optional extra. This is the official PostgreSQL image with pgvector preinstalled — same major, same entrypoint, same environment contract, same `postgres` uid — so nothing else in this block changes and an existing PVC is reused in place. It is Debian-based rather than Alpine; `resourcesPreset` already accommodates that. |
+| postgresql.image.tag | string | `"pg18@sha256:691673308c99d2161ba298736f3147f1f22d79de2fb7ec93ae9b4afcab870b62"` | Image tag, pinned by digest. Held to the same digest as upstream's compose stack and CI services, so the database this chart runs is the one the queries were type-checked against. |
 | postgresql.persistence.enabled | bool | `true` | Persist the data directory on a PersistentVolumeClaim. Turning this off means the whole catalogue is lost when the pod is rescheduled. |
 | postgresql.persistence.existingClaim | string | `""` | Use an existing claim instead of creating one. |
 | postgresql.persistence.size | string | `"20Gi"` | Requested volume size. |
@@ -682,8 +817,8 @@ later read — upgrade the application first, or in the same step.
 | serviceAccount.annotations | object | `{}` | Additional annotations for the service account. |
 | serviceAccount.create | bool | `true` | Whether to create a dedicated service account. One account is shared by every workload: nothing in TankoVault talks to the Kubernetes API, so per-service accounts would add objects without reducing any privilege. |
 | serviceAccount.name | string | `""` | Custom service account name (auto-generated if empty). |
-| services | object | `{"api":{"autoscaling":{"enabled":false,"maxReplicas":10,"minReplicas":2,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null},"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-api","tag":"v1.2.2@sha256:84c933ccf3fe3765cc00ee2bf8c193077f6a696fe9d8ab3b5aa33a879a5b044d"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":2,"resourcesPreset":"large","service":{"annotations":{},"type":"ClusterIP"}},"challengeSolver":{"autoscaling":{"enabled":false,"maxReplicas":4,"minReplicas":1,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null},"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-challenge-solver","tag":"v1.2.2@sha256:56bdde2ce632556ffd06a6a4c74b122abf836b1397bd38b796f0387f894b1f38"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":1,"resourcesPreset":"medium","service":{"annotations":{},"type":"ClusterIP"}},"controlPlane":{"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-control-plane","tag":"v1.2.2@sha256:be00fd90eb0bcaed5f0c9c618d5924ca292e48b61130f54ac22a851760592f98"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":1,"resourcesPreset":"medium","service":{"annotations":{},"type":"ClusterIP"}},"frontend":{"autoscaling":{"enabled":false,"maxReplicas":6,"minReplicas":2,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null},"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-frontend","tag":"v1.2.2@sha256:afb825de9865a792397e91dfb0acc9d0ebb93f5ee86abea6508c5e7078afcbdf"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":2,"resourcesPreset":"small","service":{"annotations":{},"type":"ClusterIP"}},"notifier":{"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-notifier","tag":"v1.2.2@sha256:edcdbe83c2a069523355bd064a46d24606b2332e461da0ffc3b3b509f7588900"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":1,"resourcesPreset":"medium","service":{"annotations":{},"type":"ClusterIP"}},"render":{"autoscaling":{"enabled":false,"maxReplicas":4,"minReplicas":1,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null},"config":{},"enabled":false,"homeDir":"/home/nonroot","image":{"repository":"timschoenle/tankovault-render","tag":"v1.2.2@sha256:2ed04a7e7c0619795ecf5aa501c1aeb48bf117a51db1a2b82337c1fc539119ed"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":1,"resources":{"limits":{"memory":"2Gi"},"requests":{"cpu":"250m","memory":"512Mi"}},"service":{"annotations":{},"type":"ClusterIP"},"shmSize":"1Gi"},"sync":{"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-sync","tag":"v1.2.2@sha256:fb480ab14507c8e3db6c95255ef912a1b0945dcff1409d4913b986b32c75e30b"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":1,"resourcesPreset":"medium","service":{"annotations":{},"type":"ClusterIP"}},"worker":{"autoscaling":{"enabled":false,"maxReplicas":10,"minReplicas":2,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null},"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-worker","tag":"v1.2.2@sha256:bca660838859e06cbc7b027577457cc9395947d1c5a6866e7cfe1530274279dc"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":2,"resourcesPreset":"large","service":{"annotations":{},"type":"ClusterIP"}}}` | Per-service settings. Each block is merged over `defaults`, so any key from `defaults` may be repeated here for one service only. |
-| services.api | object | `{"autoscaling":{"enabled":false,"maxReplicas":10,"minReplicas":2,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null},"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-api","tag":"v1.2.2@sha256:84c933ccf3fe3765cc00ee2bf8c193077f6a696fe9d8ab3b5aa33a879a5b044d"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":2,"resourcesPreset":"large","service":{"annotations":{},"type":"ClusterIP"}}` | The axum REST edge: authentication, read models, write endpoints, administration and the server-sent scan feed. |
+| services | object | `{"api":{"autoscaling":{"enabled":false,"maxReplicas":10,"minReplicas":2,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null},"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-api","tag":"v1.3.0@sha256:688ff0a711d39787bafdcc333b7761adb2ced2940e4e4fa14159571a81762dc2"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":2,"resourcesPreset":"large","service":{"annotations":{},"type":"ClusterIP"}},"challengeSolver":{"autoscaling":{"enabled":false,"maxReplicas":4,"minReplicas":1,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null},"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-challenge-solver","tag":"v1.3.0@sha256:d2916c743332b39227139e022eb9d67e6bf895dc3ef9b8a344dd4863c828a670"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":1,"resourcesPreset":"medium","service":{"annotations":{},"type":"ClusterIP"}},"controlPlane":{"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-control-plane","tag":"v1.3.0@sha256:1abe73d52baebe58e497036291b5d284b8335367046dc988f6dfd12330561568"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":1,"resourcesPreset":"medium","service":{"annotations":{},"type":"ClusterIP"}},"frontend":{"autoscaling":{"enabled":false,"maxReplicas":6,"minReplicas":2,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null},"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-frontend","tag":"v1.3.0@sha256:2d7b089b5a3f7384cf9b9eb46735c6f78d6b738d50a631ee964a9798566ff79e"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":2,"resourcesPreset":"small","service":{"annotations":{},"type":"ClusterIP"}},"notifier":{"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-notifier","tag":"v1.3.0@sha256:664d1b8dacf95bca81d3496f76dbefad2a725a5e739f024f0700e10c080b6cc9"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":1,"resourcesPreset":"medium","service":{"annotations":{},"type":"ClusterIP"}},"render":{"autoscaling":{"enabled":false,"maxReplicas":4,"minReplicas":1,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null},"config":{},"enabled":false,"homeDir":"/home/nonroot","image":{"repository":"timschoenle/tankovault-render","tag":"v1.3.0@sha256:d19661396140072d601aaa622089a2c0c43fa25624b59a9b003e75d4df5f7409"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":1,"resources":{"limits":{"memory":"2Gi"},"requests":{"cpu":"250m","memory":"512Mi"}},"service":{"annotations":{},"type":"ClusterIP"},"shmSize":"1Gi"},"sync":{"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-sync","tag":"v1.3.0@sha256:8f0b824720d8c77b5464e03546cff77fd13722a7c1a0c68ecb9c94fb0680179d"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":1,"resourcesPreset":"medium","service":{"annotations":{},"type":"ClusterIP"}},"worker":{"autoscaling":{"enabled":false,"maxReplicas":10,"minReplicas":2,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null},"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-worker","tag":"v1.3.0@sha256:1cc87817f13324c818418531684ddcf145ff433988176d522190a61d717dc581"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":2,"resourcesPreset":"large","service":{"annotations":{},"type":"ClusterIP"}}}` | Per-service settings. Each block is merged over `defaults`, so any key from `defaults` may be repeated here for one service only. |
+| services.api | object | `{"autoscaling":{"enabled":false,"maxReplicas":10,"minReplicas":2,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null},"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-api","tag":"v1.3.0@sha256:688ff0a711d39787bafdcc333b7761adb2ced2940e4e4fa14159571a81762dc2"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":2,"resourcesPreset":"large","service":{"annotations":{},"type":"ClusterIP"}}` | The axum REST edge: authentication, read models, write endpoints, administration and the server-sent scan feed. |
 | services.api.autoscaling.enabled | bool | `false` | Enable a HorizontalPodAutoscaler. |
 | services.api.autoscaling.maxReplicas | int | `10` | Maximum replicas. |
 | services.api.autoscaling.minReplicas | int | `2` | Minimum replicas. |
@@ -692,7 +827,7 @@ later read — upgrade the application first, or in the same step.
 | services.api.config | object | `{}` | Service-specific configuration, merged over the global `config` tree. |
 | services.api.enabled | bool | `true` | Deploy the API. |
 | services.api.image.repository | string | `"timschoenle/tankovault-api"` | Image repository. |
-| services.api.image.tag | string | `"v1.2.2@sha256:84c933ccf3fe3765cc00ee2bf8c193077f6a696fe9d8ab3b5aa33a879a5b044d"` | Image tag, pinned by digest. |
+| services.api.image.tag | string | `"v1.3.0@sha256:688ff0a711d39787bafdcc333b7761adb2ced2940e4e4fa14159571a81762dc2"` | Image tag, pinned by digest. |
 | services.api.podDisruptionBudget.enabled | bool | `false` | Create a PodDisruptionBudget. |
 | services.api.podDisruptionBudget.maxUnavailable | string | `nil` | Maximum unavailable pods. |
 | services.api.podDisruptionBudget.minAvailable | int | `1` | Minimum available pods during voluntary disruption. |
@@ -700,7 +835,7 @@ later read — upgrade the application first, or in the same step.
 | services.api.resourcesPreset | string | `"large"` | Resource t-shirt size. |
 | services.api.service.annotations | object | `{}` | Extra Service annotations. |
 | services.api.service.type | string | `"ClusterIP"` | Service type. |
-| services.challengeSolver | object | `{"autoscaling":{"enabled":false,"maxReplicas":4,"minReplicas":1,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null},"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-challenge-solver","tag":"v1.2.2@sha256:56bdde2ce632556ffd06a6a4c74b122abf836b1397bd38b796f0387f894b1f38"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":1,"resourcesPreset":"medium","service":{"annotations":{},"type":"ClusterIP"}}` | Modular bot-management bypass tier. Detects Cloudflare, JavaScript and Turnstile interstitials and delegates to a solver backend, TRAWL by default. |
+| services.challengeSolver | object | `{"autoscaling":{"enabled":false,"maxReplicas":4,"minReplicas":1,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null},"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-challenge-solver","tag":"v1.3.0@sha256:d2916c743332b39227139e022eb9d67e6bf895dc3ef9b8a344dd4863c828a670"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":1,"resourcesPreset":"medium","service":{"annotations":{},"type":"ClusterIP"}}` | Modular bot-management bypass tier. Detects Cloudflare, JavaScript and Turnstile interstitials and delegates to a solver backend, TRAWL by default. |
 | services.challengeSolver.autoscaling.enabled | bool | `false` | Enable a HorizontalPodAutoscaler. |
 | services.challengeSolver.autoscaling.maxReplicas | int | `4` | Maximum replicas. |
 | services.challengeSolver.autoscaling.minReplicas | int | `1` | Minimum replicas. |
@@ -709,7 +844,7 @@ later read — upgrade the application first, or in the same step.
 | services.challengeSolver.config | object | `{}` | Service-specific configuration, merged over the global `config` tree. |
 | services.challengeSolver.enabled | bool | `true` | Deploy the challenge solver. |
 | services.challengeSolver.image.repository | string | `"timschoenle/tankovault-challenge-solver"` | Image repository. |
-| services.challengeSolver.image.tag | string | `"v1.2.2@sha256:56bdde2ce632556ffd06a6a4c74b122abf836b1397bd38b796f0387f894b1f38"` | Image tag, pinned by digest. |
+| services.challengeSolver.image.tag | string | `"v1.3.0@sha256:d2916c743332b39227139e022eb9d67e6bf895dc3ef9b8a344dd4863c828a670"` | Image tag, pinned by digest. |
 | services.challengeSolver.podDisruptionBudget.enabled | bool | `false` | Create a PodDisruptionBudget. |
 | services.challengeSolver.podDisruptionBudget.maxUnavailable | string | `nil` | Maximum unavailable pods. |
 | services.challengeSolver.podDisruptionBudget.minAvailable | int | `1` | Minimum available pods during voluntary disruption. |
@@ -717,11 +852,11 @@ later read — upgrade the application first, or in the same step.
 | services.challengeSolver.resourcesPreset | string | `"medium"` | Resource t-shirt size. |
 | services.challengeSolver.service.annotations | object | `{}` | Extra Service annotations. |
 | services.challengeSolver.service.type | string | `"ClusterIP"` | Service type. Publishing this service exposes a privileged contract. |
-| services.controlPlane | object | `{"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-control-plane","tag":"v1.2.2@sha256:be00fd90eb0bcaed5f0c9c618d5924ca292e48b61130f54ac22a851760592f98"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":1,"resourcesPreset":"medium","service":{"annotations":{},"type":"ClusterIP"}}` | The singleton scheduler: run planning, task distribution and provider health. Safe to run with more than one replica — it elects a leader through Redis, and falls open to sole-leader when Redis is absent. |
+| services.controlPlane | object | `{"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-control-plane","tag":"v1.3.0@sha256:1abe73d52baebe58e497036291b5d284b8335367046dc988f6dfd12330561568"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":1,"resourcesPreset":"medium","service":{"annotations":{},"type":"ClusterIP"}}` | The singleton scheduler: run planning, task distribution and provider health. Safe to run with more than one replica — it elects a leader through Redis, and falls open to sole-leader when Redis is absent. |
 | services.controlPlane.config | object | `{}` | Service-specific configuration, merged over the global `config` tree. |
 | services.controlPlane.enabled | bool | `true` | Deploy the control plane. |
 | services.controlPlane.image.repository | string | `"timschoenle/tankovault-control-plane"` | Image repository. |
-| services.controlPlane.image.tag | string | `"v1.2.2@sha256:be00fd90eb0bcaed5f0c9c618d5924ca292e48b61130f54ac22a851760592f98"` | Image tag, pinned by digest. |
+| services.controlPlane.image.tag | string | `"v1.3.0@sha256:1abe73d52baebe58e497036291b5d284b8335367046dc988f6dfd12330561568"` | Image tag, pinned by digest. |
 | services.controlPlane.podDisruptionBudget.enabled | bool | `false` | Create a PodDisruptionBudget. |
 | services.controlPlane.podDisruptionBudget.maxUnavailable | string | `nil` | Maximum unavailable pods. |
 | services.controlPlane.podDisruptionBudget.minAvailable | int | `1` | Minimum available pods during voluntary disruption. |
@@ -729,7 +864,7 @@ later read — upgrade the application first, or in the same step.
 | services.controlPlane.resourcesPreset | string | `"medium"` | Resource t-shirt size. |
 | services.controlPlane.service.annotations | object | `{}` | Extra Service annotations. |
 | services.controlPlane.service.type | string | `"ClusterIP"` | Service type. Publishing this service exposes a privileged contract; the chart refuses anything but `ClusterIP` unless `allowUnsafeExposure` is set. |
-| services.frontend | object | `{"autoscaling":{"enabled":false,"maxReplicas":6,"minReplicas":2,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null},"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-frontend","tag":"v1.2.2@sha256:afb825de9865a792397e91dfb0acc9d0ebb93f5ee86abea6508c5e7078afcbdf"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":2,"resourcesPreset":"small","service":{"annotations":{},"type":"ClusterIP"}}` | The Dioxus WASM SPA and its axum server. It serves the client and reverse-proxies `/v1/*` to the API, so this single origin is all a browser needs — which is why it is the only service the ingress exposes. |
+| services.frontend | object | `{"autoscaling":{"enabled":false,"maxReplicas":6,"minReplicas":2,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null},"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-frontend","tag":"v1.3.0@sha256:2d7b089b5a3f7384cf9b9eb46735c6f78d6b738d50a631ee964a9798566ff79e"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":2,"resourcesPreset":"small","service":{"annotations":{},"type":"ClusterIP"}}` | The Dioxus WASM SPA and its axum server. It serves the client and reverse-proxies `/v1/*` to the API, so this single origin is all a browser needs — which is why it is the only service the ingress exposes. |
 | services.frontend.autoscaling.enabled | bool | `false` | Enable a HorizontalPodAutoscaler. |
 | services.frontend.autoscaling.maxReplicas | int | `6` | Maximum replicas. |
 | services.frontend.autoscaling.minReplicas | int | `2` | Minimum replicas. |
@@ -738,7 +873,7 @@ later read — upgrade the application first, or in the same step.
 | services.frontend.config | object | `{}` | Service-specific configuration, merged over the global `config` tree for this service only. Rendered into this service's own TOML fragment. |
 | services.frontend.enabled | bool | `true` | Deploy the frontend. |
 | services.frontend.image.repository | string | `"timschoenle/tankovault-frontend"` | Image repository. |
-| services.frontend.image.tag | string | `"v1.2.2@sha256:afb825de9865a792397e91dfb0acc9d0ebb93f5ee86abea6508c5e7078afcbdf"` | Image tag, pinned by digest. |
+| services.frontend.image.tag | string | `"v1.3.0@sha256:2d7b089b5a3f7384cf9b9eb46735c6f78d6b738d50a631ee964a9798566ff79e"` | Image tag, pinned by digest. |
 | services.frontend.podDisruptionBudget.enabled | bool | `false` | Create a PodDisruptionBudget. |
 | services.frontend.podDisruptionBudget.maxUnavailable | string | `nil` | Maximum unavailable pods. Mutually exclusive with `minAvailable`. |
 | services.frontend.podDisruptionBudget.minAvailable | int | `1` | Minimum available pods during voluntary disruption. |
@@ -746,11 +881,11 @@ later read — upgrade the application first, or in the same step.
 | services.frontend.resourcesPreset | string | `"small"` | Resource t-shirt size. |
 | services.frontend.service.annotations | object | `{}` | Extra Service annotations. |
 | services.frontend.service.type | string | `"ClusterIP"` | Service type. The frontend is the one service it is safe to publish directly. |
-| services.notifier | object | `{"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-notifier","tag":"v1.2.2@sha256:edcdbe83c2a069523355bd064a46d24606b2332e461da0ffc3b3b509f7588900"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":1,"resourcesPreset":"medium","service":{"annotations":{},"type":"ClusterIP"}}` | Distributes new-chapter notifications to users over email, Discord and generic webhooks. |
+| services.notifier | object | `{"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-notifier","tag":"v1.3.0@sha256:664d1b8dacf95bca81d3496f76dbefad2a725a5e739f024f0700e10c080b6cc9"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":1,"resourcesPreset":"medium","service":{"annotations":{},"type":"ClusterIP"}}` | Distributes new-chapter notifications to users over email, Discord and generic webhooks. |
 | services.notifier.config | object | `{}` | Service-specific configuration, merged over the global `config` tree. |
 | services.notifier.enabled | bool | `true` | Deploy the notifier. |
 | services.notifier.image.repository | string | `"timschoenle/tankovault-notifier"` | Image repository. |
-| services.notifier.image.tag | string | `"v1.2.2@sha256:edcdbe83c2a069523355bd064a46d24606b2332e461da0ffc3b3b509f7588900"` | Image tag, pinned by digest. |
+| services.notifier.image.tag | string | `"v1.3.0@sha256:664d1b8dacf95bca81d3496f76dbefad2a725a5e739f024f0700e10c080b6cc9"` | Image tag, pinned by digest. |
 | services.notifier.podDisruptionBudget.enabled | bool | `false` | Create a PodDisruptionBudget. |
 | services.notifier.podDisruptionBudget.maxUnavailable | string | `nil` | Maximum unavailable pods. |
 | services.notifier.podDisruptionBudget.minAvailable | int | `1` | Minimum available pods during voluntary disruption. |
@@ -758,7 +893,7 @@ later read — upgrade the application first, or in the same step.
 | services.notifier.resourcesPreset | string | `"medium"` | Resource t-shirt size. |
 | services.notifier.service.annotations | object | `{}` | Extra Service annotations. |
 | services.notifier.service.type | string | `"ClusterIP"` | Service type. |
-| services.render | object | `{"autoscaling":{"enabled":false,"maxReplicas":4,"minReplicas":1,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null},"config":{},"enabled":false,"homeDir":"/home/nonroot","image":{"repository":"timschoenle/tankovault-render","tag":"v1.2.2@sha256:2ed04a7e7c0619795ecf5aa501c1aeb48bf117a51db1a2b82337c1fc539119ed"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":1,"resources":{"limits":{"memory":"2Gi"},"requests":{"cpu":"250m","memory":"512Mi"}},"service":{"annotations":{},"type":"ClusterIP"},"shmSize":"1Gi"}` | Optional headless-browser tier for JavaScript-rendered pages; doubles as a solver backend. This is the one service not built on `scratch`: it is a Debian base driving a real Chromium, so it needs writable scratch space and a shared-memory volume. |
+| services.render | object | `{"autoscaling":{"enabled":false,"maxReplicas":4,"minReplicas":1,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null},"config":{},"enabled":false,"homeDir":"/home/nonroot","image":{"repository":"timschoenle/tankovault-render","tag":"v1.3.0@sha256:d19661396140072d601aaa622089a2c0c43fa25624b59a9b003e75d4df5f7409"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":1,"resources":{"limits":{"memory":"2Gi"},"requests":{"cpu":"250m","memory":"512Mi"}},"service":{"annotations":{},"type":"ClusterIP"},"shmSize":"1Gi"}` | Optional headless-browser tier for JavaScript-rendered pages; doubles as a solver backend. This is the one service not built on `scratch`: it is a Debian base driving a real Chromium, so it needs writable scratch space and a shared-memory volume. |
 | services.render.autoscaling.enabled | bool | `false` | Enable a HorizontalPodAutoscaler. |
 | services.render.autoscaling.maxReplicas | int | `4` | Maximum replicas. |
 | services.render.autoscaling.minReplicas | int | `1` | Minimum replicas. |
@@ -768,7 +903,7 @@ later read — upgrade the application first, or in the same step.
 | services.render.enabled | bool | `false` | Deploy the render tier. |
 | services.render.homeDir | string | `"/home/nonroot"` | Home directory of the image's nonroot user, mounted as a writable emptyDir. Chromium writes its profile and crashpad database here; when it is not writable the failure surfaces as a misleading `--database is required` error. |
 | services.render.image.repository | string | `"timschoenle/tankovault-render"` | Image repository. |
-| services.render.image.tag | string | `"v1.2.2@sha256:2ed04a7e7c0619795ecf5aa501c1aeb48bf117a51db1a2b82337c1fc539119ed"` | Image tag, pinned by digest. |
+| services.render.image.tag | string | `"v1.3.0@sha256:d19661396140072d601aaa622089a2c0c43fa25624b59a9b003e75d4df5f7409"` | Image tag, pinned by digest. |
 | services.render.podDisruptionBudget.enabled | bool | `false` | Create a PodDisruptionBudget. |
 | services.render.podDisruptionBudget.maxUnavailable | string | `nil` | Maximum unavailable pods. |
 | services.render.podDisruptionBudget.minAvailable | int | `1` | Minimum available pods during voluntary disruption. |
@@ -782,11 +917,11 @@ later read — upgrade the application first, or in the same step.
 | services.render.service.annotations | object | `{}` | Extra Service annotations. |
 | services.render.service.type | string | `"ClusterIP"` | Service type. Publishing this service exposes a privileged contract. |
 | services.render.shmSize | string | `"1Gi"` | Size of the `/dev/shm` in-memory volume. Chromium crashes with cryptic renderer failures on the 64Mi Kubernetes default. |
-| services.sync | object | `{"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-sync","tag":"v1.2.2@sha256:fb480ab14507c8e3db6c95255ef912a1b0945dcff1409d4913b986b32c75e30b"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":1,"resourcesPreset":"medium","service":{"annotations":{},"type":"ClusterIP"}}` | Bidirectional AniList integration and metadata enrichment. |
+| services.sync | object | `{"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-sync","tag":"v1.3.0@sha256:8f0b824720d8c77b5464e03546cff77fd13722a7c1a0c68ecb9c94fb0680179d"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":1,"resourcesPreset":"medium","service":{"annotations":{},"type":"ClusterIP"}}` | Bidirectional AniList integration and metadata enrichment. |
 | services.sync.config | object | `{}` | Service-specific configuration, merged over the global `config` tree. |
 | services.sync.enabled | bool | `true` | Deploy the sync service. Requires the `anilist` credentials. |
 | services.sync.image.repository | string | `"timschoenle/tankovault-sync"` | Image repository. |
-| services.sync.image.tag | string | `"v1.2.2@sha256:fb480ab14507c8e3db6c95255ef912a1b0945dcff1409d4913b986b32c75e30b"` | Image tag, pinned by digest. |
+| services.sync.image.tag | string | `"v1.3.0@sha256:8f0b824720d8c77b5464e03546cff77fd13722a7c1a0c68ecb9c94fb0680179d"` | Image tag, pinned by digest. |
 | services.sync.podDisruptionBudget.enabled | bool | `false` | Create a PodDisruptionBudget. |
 | services.sync.podDisruptionBudget.maxUnavailable | string | `nil` | Maximum unavailable pods. |
 | services.sync.podDisruptionBudget.minAvailable | int | `1` | Minimum available pods during voluntary disruption. |
@@ -794,7 +929,7 @@ later read — upgrade the application first, or in the same step.
 | services.sync.resourcesPreset | string | `"medium"` | Resource t-shirt size. |
 | services.sync.service.annotations | object | `{}` | Extra Service annotations. |
 | services.sync.service.type | string | `"ClusterIP"` | Service type. Publishing this service exposes a privileged contract. |
-| services.worker | object | `{"autoscaling":{"enabled":false,"maxReplicas":10,"minReplicas":2,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null},"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-worker","tag":"v1.2.2@sha256:bca660838859e06cbc7b027577457cc9395947d1c5a6866e7cfe1530274279dc"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":2,"resourcesPreset":"large","service":{"annotations":{},"type":"ClusterIP"}}` | Fetches and parses provider data through the adapters and upserts chapter and metadata changes. Scales horizontally for free: replicas join one NATS JetStream consumer group. |
+| services.worker | object | `{"autoscaling":{"enabled":false,"maxReplicas":10,"minReplicas":2,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null},"config":{},"enabled":true,"image":{"repository":"timschoenle/tankovault-worker","tag":"v1.3.0@sha256:1cc87817f13324c818418531684ddcf145ff433988176d522190a61d717dc581"},"podDisruptionBudget":{"enabled":false,"maxUnavailable":null,"minAvailable":1},"replicaCount":2,"resourcesPreset":"large","service":{"annotations":{},"type":"ClusterIP"}}` | Fetches and parses provider data through the adapters and upserts chapter and metadata changes. Scales horizontally for free: replicas join one NATS JetStream consumer group. |
 | services.worker.autoscaling.enabled | bool | `false` | Enable a HorizontalPodAutoscaler. |
 | services.worker.autoscaling.maxReplicas | int | `10` | Maximum replicas. |
 | services.worker.autoscaling.minReplicas | int | `2` | Minimum replicas. |
@@ -803,7 +938,7 @@ later read — upgrade the application first, or in the same step.
 | services.worker.config | object | `{}` | Service-specific configuration, merged over the global `config` tree. |
 | services.worker.enabled | bool | `true` | Deploy the worker. |
 | services.worker.image.repository | string | `"timschoenle/tankovault-worker"` | Image repository. |
-| services.worker.image.tag | string | `"v1.2.2@sha256:bca660838859e06cbc7b027577457cc9395947d1c5a6866e7cfe1530274279dc"` | Image tag, pinned by digest. |
+| services.worker.image.tag | string | `"v1.3.0@sha256:1cc87817f13324c818418531684ddcf145ff433988176d522190a61d717dc581"` | Image tag, pinned by digest. |
 | services.worker.podDisruptionBudget.enabled | bool | `false` | Create a PodDisruptionBudget. |
 | services.worker.podDisruptionBudget.maxUnavailable | string | `nil` | Maximum unavailable pods. |
 | services.worker.podDisruptionBudget.minAvailable | int | `1` | Minimum available pods during voluntary disruption. |

--- a/charts/tankovault/README.md
+++ b/charts/tankovault/README.md
@@ -565,7 +565,7 @@ series rather than only checking that they parse.
   a recorded series' level prefix is meant to be its label set. If you referenced the old name in a
   query of your own, update it; nothing inside the chart still does.
 - **`TankoVaultWorkerTargetsAbsent`'s runbook** no longer interpolates
-  `{{ `{{ $labels.namespace }}` }}`.
+  `{{ $labels.namespace }}`.
   `absent()` builds its series from equality matchers only, so under
   `metrics.prometheusRule.scope=none` that label does not exist and the runbook rendered a
   `kubectl -n  ...` command with a hole in it.

--- a/charts/tankovault/README.md.gotmpl
+++ b/charts/tankovault/README.md.gotmpl
@@ -474,12 +474,15 @@ operator's decision to schedule.
   rollout — and the migration is the step that needs pgvector.
 - **The bundled PostgreSQL image changed** from `postgres:18-alpine` to `pgvector/pgvector:pg18`,
   as above. If you pinned `postgresql.image.*` yourself, move it to an image that has pgvector.
-- **The upgrade moves the database pod**, which earlier upgrades never did — the image is what
-  changed, so the StatefulSet has to replace it. On a cluster with no spare CPU that can deadlock:
-  the rolling-update surge takes the capacity the database pod just released, and nothing recovers,
-  because no service passes a readiness probe without the database and so no old pod is ever
-  retired. If your nodes are tight, set `defaults.strategy.rollingUpdate.maxSurge: 0` for the
-  upgrade, which retires before it replaces. The chart's own CI fixture does exactly this.
+- **On a capacity-constrained cluster, set `defaults.strategy.rollingUpdate.maxSurge: 0` for the
+  upgrade.** Every chart-version bump rewrites the `helm.sh/chart` and `app.kubernetes.io/version`
+  pod labels, so an upgrade rolls every workload — the bundled datastores included, which means
+  the database pod is deleted and recreated. The default rollout asks for its replacement pods
+  before retiring the old ones, and if the surge takes the CPU the database just released,
+  nothing recovers: no service passes a readiness probe without the database, so no old pod is
+  ever retired and the capacity never comes back. `maxSurge: 0` retires before it replaces. This
+  is not new in 3.1.0 — it applies to any version bump with the bundled datastores on tight
+  nodes — but it is worth knowing before an upgrade that also has a REINDEX after it.
 - **Two alerts are added**, `TankoVaultRecsysBuildFailing` and `TankoVaultRecsysShelvesEmpty`, with
   seven recording rules behind them under `tankovault-recsys-recording`. `metrics.prometheusRule`
   therefore produces 21 groups where it produced 19.

--- a/charts/tankovault/README.md.gotmpl
+++ b/charts/tankovault/README.md.gotmpl
@@ -19,8 +19,9 @@ the optional headless `render` tier, plus the one-shot `bootstrap` migration and
 
 - Kubernetes 1.19+
 - Helm 3.0+
-- A PostgreSQL database — either the bundled one (`postgresql.enabled=true`) or your own
-  (`externalDatabase.*`)
+- A PostgreSQL database **with [pgvector](https://github.com/pgvector/pgvector) available** —
+  either the bundled one (`postgresql.enabled=true`, which runs `pgvector/pgvector`) or your own
+  (`externalDatabase.*`). See [Recommendations need pgvector](#recommendations-need-pgvector).
 - A NATS server with JetStream enabled, if `worker` or `control-plane` are deployed
 - The Prometheus Operator CRDs, if `metrics.serviceMonitor` or `metrics.prometheusRule` are enabled
 - An ingress controller, if `ingress.enabled=true`
@@ -207,6 +208,64 @@ The default is unchanged, so `helm install` consumers and anyone happy with the 
 Only `bootstrap.migrate.mode: job` is affected; the seed steps stay `post-install` because PostSync
 runs after Sync and their secrets already exist.
 
+## Recommendations need pgvector
+
+TankoVault 1.3.0 adds a recommender: a vector model built from the catalogue on the
+control-plane's schedule and queried per reader on the `api`. Migration
+`0027_recsys_signals` runs `CREATE EXTENSION vector`, so **from that release on the database must
+have pgvector available**. The migration fails loudly rather than degrading, because a recommender
+that silently returns nothing is worse than one that refuses to start.
+
+- **`postgresql.enabled=true`**: the bundled image moved from `postgres:18-alpine` to
+  `pgvector/pgvector:pg18` — the same PostgreSQL major with the extension preinstalled, same
+  entrypoint, same environment contract, same uid, so the existing PVC is reused in place and no
+  other value changes. **An existing release needs one manual step afterwards**; see
+  [Upgrading to 3.1.0](#upgrading-to-310). A fresh install needs nothing.
+- **`externalDatabase.*`**: install the extension package *before* upgrading — `apt install
+  postgresql-18-pgvector`, or your managed provider's equivalent; RDS, Cloud SQL and Azure
+  Flexible Server all ship it behind an allowlist setting. The migration only needs it to be
+  installable, and issues the `CREATE EXTENSION` itself.
+
+Rolling the migration back drops the recommender's tables and deliberately leaves the extension in
+place, since dropping it would cascade into every column typed by it.
+
+### Build cadence and cost
+
+The model is built by the `control-plane`'s scheduler, on the elected leader only, and only while
+the `catalogue.recommendations` feature flag is on. Both cadences are ordinary configuration, so
+they go under `services.controlPlane.config` like anything else:
+
+```yaml
+services:
+  controlPlane:
+    config:
+      scheduler:
+        recsys_incremental_interval_secs: 900     # re-embeds what changed
+        recsys_full_interval_secs: 604800         # re-solves the projection; 0 disables
+        recsys_batch: 512                         # series per streamed batch
+        recsys_incremental_max: 20000             # ceiling on one incremental pass
+```
+
+Three things about this are worth knowing before you tune it:
+
+- **The full build is not about freshness.** The incremental pass covers changed series; the full
+  one exists for vocabulary and idf drift, which is why weekly is enough.
+- **A deployment that has never completed a full build has no projection basis, and every
+  incremental build refuses to run** — deliberately, because projecting against a partially-solved
+  basis yields vectors that are not comparable with the stored ones. Both timers fire once
+  immediately when the leader starts, so a fresh install builds on the control-plane's first
+  scheduler tick rather than waiting a week. The consequence to remember is the other direction:
+  every restart of the leading replica starts a full rebuild.
+- **`recsys_batch` is the only knob on the builder's peak memory in the streaming stages.** The
+  covariance matrix that dominates the rest is bounded upstream at ~32 MB regardless of catalogue
+  size, so the `medium` preset on `control-plane` is not the constraint — but a batch raised far
+  above the default against a memory limit will be, and an OOM-killed builder leaves no log line
+  and no `failed` metric, only a restart.
+
+To run without the recommender, switch the `catalogue.recommendations` feature flag off in the
+admin console. Setting both intervals to `0` stops the builds but leaves the surface on, which
+serves empty shelves rather than hiding them.
+
 ## Exposure
 
 Only the frontend is published. It serves the SPA and reverse-proxies `/v1/*` to the API, so one
@@ -261,6 +320,12 @@ Readiness is taken from the services' own `service_ready` and `service_dependenc
 blackbox prober is involved, and `TankoVaultDependencyDown` names the failing dependency —
 postgres, nats or redis — in the alert rather than sending you to `curl /ready`.
 
+The recommender gets its own rules for the same reason the scan pipeline does: both of its failure
+modes are invisible everywhere else. A model that has stopped being built keeps serving, stale and
+then empty, without a single error or a millisecond of added latency
+(`TankoVaultRecsysBuildFailing`); and an empty shelf is a `200` returned faster than a full one
+(`TankoVaultRecsysShelvesEmpty`). Neither moves the request-path metrics at all.
+
 Two alerts that a chart should not reinvent are deliberately absent, because the Prometheus
 Operator this chart already requires ships both: `KubeDeploymentReplicasMismatch` for replica
 shortfalls (it reads kube-state-metrics, which knows the desired count; nothing this chart emits
@@ -308,7 +373,8 @@ default is Grafana's own — the ConfigMap is created and nothing ever reads it.
 
 There are two dashboards: a service overview (liveness, readiness and its dependencies, the
 request path, the database pool, edge policy) and a scan pipeline (scheduling, per-provider
-throughput and backlog, outbound fetches and throttling, notifications, AniList). Neither pins a
+throughput and backlog, outbound fetches and throttling, notifications, AniList, and the
+recommendation model built from the catalogue the rest of it fills). Neither pins a
 datasource UID — both expose a `Data source` picker and a `Namespace` picker, so one copy works
 for every release in the cluster.
 
@@ -355,6 +421,75 @@ service would otherwise refuse to boot on the same condition at container start.
 Documents supplied through `content` are read on demand behind an mtime check, so correcting a
 policy is a values change and the kubelet's ConfigMap refresh, never a restart. That ConfigMap is
 deliberately excluded from the pod's `checksum/config` annotation for exactly that reason.
+
+## Upgrading to 3.1.0
+
+This version moves to TankoVault 1.3.0, which adds the recommender. Two things need reading before
+you upgrade an existing release, one for each kind of database.
+
+**On an external database**, install pgvector first — see
+[Recommendations need pgvector](#recommendations-need-pgvector). Migration `0027` will not run
+without it and there is nothing a chart can do to detect that ahead of time.
+
+### `postgresql.enabled=true`: REINDEX once, after the upgrade
+
+**This is a required step for any existing release running the bundled database, and nothing will
+tell you if you skip it.** Fresh installs are unaffected.
+
+Getting pgvector meant moving the bundled image from Alpine to Debian, and those two sort text
+differently under the same `en_US.utf8` locale name — musl compares by byte, glibc compares
+linguistically:
+
+| | `ORDER BY t` |
+|---|---|
+| `postgres:18-alpine` (musl) | `A, B, _z, a, a-b, ab, b` |
+| `pgvector/pgvector:pg18` (glibc) | `a, A, a-b, ab, b, B, _z` |
+
+Every btree index on a `text` or `varchar` column was built under the first ordering and is not
+valid under the second. The consequence is silent and it is wrong answers, not errors: an index
+scan can skip rows that are really there, and a unique index can stop rejecting duplicates.
+Verified with `amcheck` against a data directory carried across the two images —
+`bt_index_check` reports `item order invariant violated` immediately after the swap.
+
+PostgreSQL issues **no warning**, which is what makes this worth a section rather than a
+footnote. It warns on a collation change only when the database records a collation version to
+compare against, and a cluster initialised by the Alpine image records none
+(`pg_database.datcollversion` is null).
+
+The whole fix is one command, run once, after the new image is serving:
+
+```shell
+kubectl -n <namespace> exec -it <release>-tankovault-postgresql-0 -- \
+  psql -U tankovault -d tankovault -c 'REINDEX DATABASE tankovault;'
+```
+
+`REINDEX DATABASE` takes locks on each index as it rebuilds it, so run it in a window where a
+pause is acceptable, or use `REINDEX DATABASE CONCURRENTLY` to trade speed for staying online.
+The chart prints this instruction in its upgrade notes too, and deliberately does not run it for
+you: on a large catalogue it is a long operation with real locking behaviour, and that is an
+operator's decision to schedule.
+
+- **`appVersion` is 1.3.0** and all nine service images are repinned to their `v1.3.0` digests.
+  The upgrade order is the one the chart already enforces — the migration runs ahead of the
+  rollout — and the migration is the step that needs pgvector.
+- **The bundled PostgreSQL image changed** from `postgres:18-alpine` to `pgvector/pgvector:pg18`,
+  as above. If you pinned `postgresql.image.*` yourself, move it to an image that has pgvector.
+- **The upgrade moves the database pod**, which earlier upgrades never did — the image is what
+  changed, so the StatefulSet has to replace it. On a cluster with no spare CPU that can deadlock:
+  the rolling-update surge takes the capacity the database pod just released, and nothing recovers,
+  because no service passes a readiness probe without the database and so no old pod is ever
+  retired. If your nodes are tight, set `defaults.strategy.rollingUpdate.maxSurge: 0` for the
+  upgrade, which retires before it replaces. The chart's own CI fixture does exactly this.
+- **Two alerts are added**, `TankoVaultRecsysBuildFailing` and `TankoVaultRecsysShelvesEmpty`, with
+  seven recording rules behind them under `tankovault-recsys-recording`. `metrics.prometheusRule`
+  therefore produces 21 groups where it produced 19.
+- **The scan-pipeline dashboard gains a `Recommendations` row.** No new ConfigMap key and no new
+  `GrafanaDashboard`; the existing `tankovault-scan-pipeline.json` grew five panels.
+- **Nothing is switched on by this chart.** The recommender is gated on the
+  `catalogue.recommendations` feature flag in the admin console, and its build cadence has working
+  defaults — see [Build cadence and cost](#build-cadence-and-cost) for the knobs and for the two
+  things worth knowing before touching them. With the flag off nothing builds and nothing is
+  served, so the new rules evaluate against no data and stay dark rather than firing.
 
 ## Upgrading to 3.0.3
 

--- a/charts/tankovault/ci/bundled-datastores-values.yaml
+++ b/charts/tankovault/ci/bundled-datastores-values.yaml
@@ -8,6 +8,23 @@
 # postgresql.auth.password is set explicitly rather than generated: `helm template` has no
 # cluster to look up the previous value in, so an empty password would render a different
 # secret on every invocation and make this file useless for snapshot comparison.
+#
+# `defaults.strategy` removes the rolling-update surge, and it is load-bearing for
+# `ct install --upgrade` rather than cosmetic. This fixture requests 2700m of CPU against a
+# single kind node, which fits — but a default rollout creates each Deployment's replacement
+# pods *before* retiring the old ones, so an upgrade briefly asks for roughly 1800m more. That
+# is survivable on its own: surplus pods simply stay Pending until the old ones go.
+#
+# It stops being survivable the moment the upgrade also has to move the bundled PostgreSQL,
+# which it does whenever its image changes. The StatefulSet deletes its pod and recreates it,
+# and in the window between the two the surge pods take the CPU it just freed. Nothing then
+# resolves: the replacement database cannot schedule, so no service can pass a readiness probe,
+# so no old pod is retired, so the CPU is never given back. `maxSurge: 0` retires before it
+# replaces, which means the release never needs more than its steady state and the database
+# always has its own slot to come back into.
+#
+# The same lever is the answer on any capacity-constrained cluster running the bundled
+# datastores; see the chart README.
 auth:
   jwtSecret: ci-jwt-secret-0123456789abcdef0123
   passwordPepper: ci-password-pepper-0123456789abcd
@@ -18,6 +35,12 @@ anilist:
   clientSecret: ci-anilist-client-secret
   tokenEncryptionKey: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
   redirectUri: https://tankovault.example.com/account/anilist-callback
+defaults:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
 postgresql:
   enabled: true
   auth:

--- a/charts/tankovault/ci/bundled-datastores-values.yaml
+++ b/charts/tankovault/ci/bundled-datastores-values.yaml
@@ -9,22 +9,26 @@
 # cluster to look up the previous value in, so an empty password would render a different
 # secret on every invocation and make this file useless for snapshot comparison.
 #
-# `defaults.strategy` removes the rolling-update surge, and it is load-bearing for
-# `ct install --upgrade` rather than cosmetic. This fixture requests 2700m of CPU against a
-# single kind node, which fits — but a default rollout creates each Deployment's replacement
-# pods *before* retiring the old ones, so an upgrade briefly asks for roughly 1800m more. That
-# is survivable on its own: surplus pods simply stay Pending until the old ones go.
+# `defaults.strategy` removes the rolling-update surge, which is what makes this fixture
+# survivable under `ct install --upgrade`.
 #
-# It stops being survivable the moment the upgrade also has to move the bundled PostgreSQL,
-# which it does whenever its image changes. The StatefulSet deletes its pod and recreates it,
-# and in the window between the two the surge pods take the CPU it just freed. Nothing then
-# resolves: the replacement database cannot schedule, so no service can pass a readiness probe,
-# so no old pod is retired, so the CPU is never given back. `maxSurge: 0` retires before it
-# replaces, which means the release never needs more than its steady state and the database
-# always has its own slot to come back into.
+# Every chart-version bump rewrites `helm.sh/chart` and `app.kubernetes.io/version` in
+# `common.podLabels`, so an upgrade rolls all twelve workloads at once — including the bundled
+# PostgreSQL, whose StatefulSet deletes its pod and recreates it. Steady state here is 2700m of
+# CPU against a single kind node's ~3250m; a default 25% surge asks for roughly 1700m on top of
+# that. The excess alone would be harmless, since surplus pods just stay Pending — but the
+# database is one of the pods that has to be rescheduled, and in the window between its delete
+# and its create the surge pods take the CPU it freed. Nothing then resolves: the database
+# cannot schedule, so no service passes a readiness probe, so no old pod is retired, so the CPU
+# never comes back. `maxSurge: 0` retires before it replaces, so the release never needs more
+# than its steady state and the database always has a slot to return to.
 #
-# The same lever is the answer on any capacity-constrained cluster running the bundled
-# datastores; see the chart README.
+# Note that `ct` reads the *previous* revision's copy of this file for both halves of its
+# upgrade test (`doUpgrade` takes `oldChart.ValuesFilePathsForCI()` and passes the same path to
+# the upgrade), so this setting first takes effect on the release after the one that introduces
+# it. It is still the correct configuration for the fixture, and it is the same lever an
+# operator needs on any capacity-constrained cluster running the bundled datastores; see the
+# chart README.
 auth:
   jwtSecret: ci-jwt-secret-0123456789abcdef0123
   passwordPepper: ci-password-pepper-0123456789abcd

--- a/charts/tankovault/dashboards/tankovault-scan-pipeline.json
+++ b/charts/tankovault/dashboards/tankovault-scan-pipeline.json
@@ -1,7 +1,7 @@
 {
   "uid": "tankovault-scan-pipeline",
   "title": "TankoVault Scan Pipeline",
-  "description": "Everything between a scheduled scan and a user being told about a new chapter: scheduling, per-provider task throughput and backlog, outbound fetches and the throttling they earn, notification fan-out, and AniList synchronisation. The backlog row needs `metrics.natsExporter.enabled` \u2014 NATS publishes no Prometheus exposition of its own, so those panels are empty rather than wrong without it.",
+  "description": "Everything between a scheduled scan and a user being told about a new chapter: scheduling, per-provider task throughput and backlog, outbound fetches and the throttling they earn, notification fan-out, AniList synchronisation, and the recommendation model built from the catalogue the rest of it fills. The backlog row needs `metrics.natsExporter.enabled` \u2014 NATS publishes no Prometheus exposition of its own, so those panels are empty rather than wrong without it.",
   "tags": [
     "tankovault"
   ],
@@ -1791,6 +1791,314 @@
         "w": 8,
         "x": 16,
         "y": 82
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      }
+    },
+    {
+      "id": 38,
+      "type": "row",
+      "title": "Recommendations",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 89
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "Series the model covers",
+      "description": "Rows the recommendation model holds, per table. Flat while the catalogue grows means builds are failing or no replica is holding scheduler leadership. Absent entirely means no build has ever completed \u2014 the state a fresh deployment is in until its first full build, during which every incremental build refuses to run and every shelf comes back empty.",
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "namespace_table:recsys_model_series:current{namespace=\"$namespace\"}",
+          "legendFormat": "{{table}}",
+          "instant": true
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value_and_name",
+        "orientation": "auto",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "id": 39,
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 90
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Model builds, last hour",
+      "description": "Series processed by a build, split by stage and result. `incremental` runs on a quarter-hourly cadence and touches only what changed; `full` is weekly by default and re-solves the projection over the whole catalogue. A `failed` line at all is `TankoVaultRecsysBuildFailing`.",
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "namespace_stage_result:recsys_build_series:increase1h{namespace=\"$namespace\"}",
+          "legendFormat": "{{stage}} {{result}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "last",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "min": 0
+        },
+        "overrides": []
+      },
+      "id": 40,
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 6,
+        "y": 90
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Build duration (p95)",
+      "description": "A full build re-counts the vocabulary and re-solves the projection from the whole catalogue and is expected in minutes; an incremental one is proportional to catalogue churn, not to catalogue size. An incremental duration tracking the full one means the incremental ceiling is binding.",
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "namespace_stage:recsys_build_duration_seconds:p95_6h{namespace=\"$namespace\"}",
+          "legendFormat": "{{stage}} p95"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "last",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "min": 0
+        },
+        "overrides": []
+      },
+      "id": 41,
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 15,
+        "y": 90
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Items per served shelf",
+      "description": "The earliest symptom of a broken or unbuilt model, and the one invisible in request latency: an empty shelf is a `200` served faster than a full one. Read against the serve rate on the same panel \u2014 a mean near zero only means anything while shelves are actually being asked for.",
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "namespace:recsys_shelf_size:avg15m{namespace=\"$namespace\"}",
+          "legendFormat": "mean items"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "namespace:recsys_serves:rate15m{namespace=\"$namespace\"}",
+          "legendFormat": "shelves/s"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "last",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "min": 0
+        },
+        "overrides": []
+      },
+      "id": 42,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 96
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Shelf serve latency (p95)",
+      "description": "Split by how the shelf was produced. `cached` is a single row read; `computed` runs one approximate-nearest-neighbour search per seed, so its tail is where the seed count shows up rather than where the catalogue size does.",
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "namespace_path:recsys_serve_duration_seconds:p95_15m{namespace=\"$namespace\"}",
+          "legendFormat": "{{path}} p95"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "last",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "min": 0
+        },
+        "overrides": []
+      },
+      "id": 43,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 96
       },
       "datasource": {
         "type": "prometheus",

--- a/charts/tankovault/rules-tests/recsys_test.yml
+++ b/charts/tankovault/rules-tests/recsys_test.yml
@@ -1,0 +1,132 @@
+# The recommender: model builds on the control-plane, personalised shelves on the api.
+#
+# Both alerts here exist because the recommender's failure modes are invisible to every other
+# rule in the set. A model that has stopped being built still serves; a shelf that comes back
+# empty is a `200` that is faster than a full one. Nothing in the request path, the scan pipeline
+# or the readiness gauges moves for either.
+rule_files:
+  - tankovault-recording.rules.yml
+  - tankovault-alerts.rules.yml
+
+evaluation_interval: 1m
+
+tests:
+  # An incremental build failing every pass — the shape a deployment is in when no full build has
+  # ever completed, so there is no projection basis and every incremental run refuses to start.
+  # `for: 15m` is the whole fuse here: a single failed run must not page.
+  - interval: 1m
+    input_series:
+      - series: 'recsys_build_series_total{namespace="tv", job="control-plane", pod="cp-1", stage="incremental", result="failed"}'
+        values: '0+1x120'
+    promql_expr_test:
+      - expr: ALERTS{alertname="TankoVaultRecsysBuildFailing", alertstate="pending"}
+        eval_time: 10m
+        exp_samples:
+          - labels: 'ALERTS{alertname="TankoVaultRecsysBuildFailing", alertstate="pending", namespace="tv", stage="incremental", severity="warning"}'
+            value: 1
+      - expr: ALERTS{alertname="TankoVaultRecsysBuildFailing", alertstate="firing"}
+        eval_time: 30m
+        exp_samples:
+          - labels: 'ALERTS{alertname="TankoVaultRecsysBuildFailing", alertstate="firing", namespace="tv", stage="incremental", severity="warning"}'
+            value: 1
+
+  # The same failure on the weekly full build. `stage` has to survive the aggregation, or the
+  # runbook — which branches entirely on which stage failed — names nothing.
+  - interval: 1m
+    input_series:
+      - series: 'recsys_build_series_total{namespace="tv", job="control-plane", pod="cp-1", stage="full", result="failed"}'
+        values: '0+1x120'
+    promql_expr_test:
+      - expr: ALERTS{alertname="TankoVaultRecsysBuildFailing", alertstate="firing"}
+        eval_time: 30m
+        exp_samples:
+          - labels: 'ALERTS{alertname="TankoVaultRecsysBuildFailing", alertstate="firing", namespace="tv", stage="full", severity="warning"}'
+            value: 1
+
+  # Builds that complete produce a `built` series and no `failed` one, so the failure rule has no
+  # numerator at all — absent, not zero. A rule that summed every result label would fire here.
+  - interval: 1m
+    input_series:
+      - series: 'recsys_build_series_total{namespace="tv", job="control-plane", pod="cp-1", stage="incremental", result="built"}'
+        values: '0+40x120'
+    promql_expr_test:
+      - expr: namespace_stage:recsys_build_failures:increase6h
+        eval_time: 60m
+        exp_samples: []
+      - expr: ALERTS{alertname="TankoVaultRecsysBuildFailing"}
+        eval_time: 60m
+        exp_samples: []
+
+  # Model size across a leadership move. Only the replica that ran a build sets the gauge, and it
+  # keeps its last value forever afterwards — so two replicas that have each been leader report
+  # two different sizes for one model, and summing them would report 2 200 series for a catalogue
+  # of 1 200 and grow again on every failover.
+  - interval: 1m
+    input_series:
+      - series: 'recsys_model_series{namespace="tv", job="control-plane", pod="cp-1", table="series_embedding"}'
+        values: '1000+0x120'
+      - series: 'recsys_model_series{namespace="tv", job="control-plane", pod="cp-2", table="series_embedding"}'
+        values: '1200+0x120'
+    promql_expr_test:
+      - expr: namespace_table:recsys_model_series:current
+        eval_time: 30m
+        exp_samples:
+          - labels: 'namespace_table:recsys_model_series:current{namespace="tv", table="series_embedding"}'
+            value: 1200
+
+  # Shelves served empty while readers are asking for them: six serves a minute, zero items in
+  # any of them. The requests are 200s and they are fast, so nothing else in the rule set moves.
+  - interval: 1m
+    input_series:
+      - series: 'recsys_shelf_size_sum{namespace="tv", job="api", pod="api-1"}'
+        values: '0+0x120'
+      - series: 'recsys_shelf_size_count{namespace="tv", job="api", pod="api-1"}'
+        values: '0+6x120'
+      - series: 'recsys_serve_duration_seconds_count{namespace="tv", job="api", pod="api-1", path="computed"}'
+        values: '0+6x120'
+    promql_expr_test:
+      # Exactly zero rather than a near-zero float: the numerator's rate is zero, and zero over
+      # anything is exact however the extrapolation lands.
+      - expr: namespace:recsys_shelf_size:avg15m
+        eval_time: 60m
+        exp_samples:
+          - labels: 'namespace:recsys_shelf_size:avg15m{namespace="tv"}'
+            value: 0
+      - expr: ALERTS{alertname="TankoVaultRecsysShelvesEmpty", alertstate="firing"}
+        eval_time: 60m
+        exp_samples:
+          - labels: 'ALERTS{alertname="TankoVaultRecsysShelvesEmpty", alertstate="firing", namespace="tv", severity="warning"}'
+            value: 1
+
+  # Twelve items per shelf on the same serve rate. Both sides of the ratio are extrapolated
+  # identically over identical sample times, so the quotient is exactly the mean and needs no
+  # tolerance.
+  - interval: 1m
+    input_series:
+      - series: 'recsys_shelf_size_sum{namespace="tv", job="api", pod="api-1"}'
+        values: '0+72x120'
+      - series: 'recsys_shelf_size_count{namespace="tv", job="api", pod="api-1"}'
+        values: '0+6x120'
+      - series: 'recsys_serve_duration_seconds_count{namespace="tv", job="api", pod="api-1", path="cached"}'
+        values: '0+6x120'
+    promql_expr_test:
+      - expr: namespace:recsys_shelf_size:avg15m
+        eval_time: 60m
+        exp_samples:
+          - labels: 'namespace:recsys_shelf_size:avg15m{namespace="tv"}'
+            value: 12
+      - expr: ALERTS{alertname="TankoVaultRecsysShelvesEmpty"}
+        eval_time: 60m
+        exp_samples: []
+
+  # Recommendations switched off: a model may exist, but nothing serves a shelf, so there is no
+  # ratio to compare and the serve-rate conjunct has nothing to satisfy it. The alert must stay
+  # dark — an operator who disabled the feature has not broken it.
+  - interval: 1m
+    input_series:
+      - series: 'recsys_model_series{namespace="tv", job="control-plane", pod="cp-1", table="series_embedding"}'
+        values: '1200+0x120'
+    promql_expr_test:
+      - expr: ALERTS{alertname="TankoVaultRecsysShelvesEmpty"}
+        eval_time: 60m
+        exp_samples: []

--- a/charts/tankovault/rules/tankovault-alerts.rules.yml
+++ b/charts/tankovault/rules/tankovault-alerts.rules.yml
@@ -703,6 +703,64 @@ groups:
             `networkPolicy.enabled` is true, and that no Service publishes them outside the
             cluster.
 
+  - name: tankovault-recsys
+    rules:
+      # Any failure at all, because a build has no partial success to tolerate: the run either
+      # completes and advances the generation or it does not, and the next one redoes the same
+      # work and fails the same way. 15m of `for` only keeps a single transient database blip
+      # from paging.
+      - alert: TankoVaultRecsysBuildFailing
+        expr: namespace_stage:recsys_build_failures:increase6h{tankovault_scope=~".*"} > 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $labels.stage }} recommendation-model builds are failing"
+          description: >-
+            The model has stopped advancing. Nothing breaks immediately — the last generation
+            keeps being served — so this decays into stale and then empty recommendations rather
+            than into an error anyone reports. The reason is in the control-plane log:
+            `kubectl -n {{ $labels.namespace }} logs -l
+            app.kubernetes.io/component=control-plane | grep -i recommendation`. Two causes
+            dominate. On `stage="incremental"`, `no projection basis yet` means no **full** build
+            has ever completed, and every incremental run will keep refusing until one does —
+            trigger one from the admin console's recommendation panel rather than waiting out
+            `scheduler.recsys_full_interval_secs`, which is a week by default. Anything naming
+            the `vector` extension means the database does not have pgvector and migration 0027
+            did not do what it appeared to; see the chart README. If the pod is instead being
+            OOM-killed there is no log line at all — check `describe pod` against the
+            control-plane's memory limit and lower `scheduler.recsys_batch`.
+
+      # The symptom no latency or error metric can reach: the request succeeds, quickly, and
+      # carries nothing. Gated on the serve rate so a deployment with recommendations switched
+      # off — which serves nothing at all and records no ratio — cannot trip it.
+      # grounding: baseline-needed — a shelf is 0 to 60 items and new readers legitimately get
+      # few, so "below one item on average" is judgement about where a working model cannot be,
+      # not a measured floor. Re-tune once the deployment has a week of real shelves.
+      - alert: TankoVaultRecsysShelvesEmpty
+        expr: >-
+          namespace:recsys_shelf_size:avg15m{tankovault_scope=~".*"} < 1
+            and namespace:recsys_serves:rate15m{tankovault_scope=~".*"} > 0.01
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Personalised shelves are being served empty"
+          description: >-
+            Readers are asking for recommendations and getting nothing back, and every other
+            signal reads healthy: the requests are 200s and they are fast, because an empty shelf
+            is the cheapest one to build. Check whether a model exists at all —
+            `namespace_table:recsys_model_series:current` flat at zero or absent means none has
+            ever been built, which is the state a fresh deployment is in until its first full
+            build completes, and
+            `kubectl -n {{ $labels.namespace }} logs -l
+            app.kubernetes.io/component=control-plane | grep 'recommendation model built'`
+            confirms it from the other side. If a model is there and covering the catalogue, the
+            fault is on the
+            read side rather than the build side: the shelf is assembled from the reader's own
+            signals, so a deployment whose users have not yet read anything genuinely has nothing
+            to project from, and this is expected rather than broken until they have.
+
   - name: tankovault-anilist
     rules:
       # AniList publishes a request budget and answers 429 past it. A quarter of calls throttled

--- a/charts/tankovault/rules/tankovault-recording.rules.yml
+++ b/charts/tankovault/rules/tankovault-recording.rules.yml
@@ -440,6 +440,66 @@ groups:
           sum by (namespace, job) (
             increase(render_requests_total{tankovault_scope=~".*", result="rejected"}[15m]))
 
+  # The recommender. Two halves that fail independently and are emitted by different services:
+  # `control-plane` builds the model on the scheduler's cadence, `api` serves a shelf out of it on
+  # the request path. A model that has stopped being built keeps serving — stale at first, then
+  # empty as the catalogue moves past it — so the build side is not observable from the serve side
+  # and neither is observable from the request metrics.
+  - name: tankovault-recsys-recording
+    interval: 30s
+    rules:
+      # Counts, not rates: a build is an event every quarter hour at most, and a full one is
+      # weekly by default. A 5m rate over that reads zero almost everywhere and hides the thing
+      # being measured.
+      - record: namespace_stage_result:recsys_build_series:increase1h
+        expr: >-
+          sum by (namespace, stage, result) (
+            increase(recsys_build_series_total{tankovault_scope=~".*"}[1h]))
+
+      # Six hours because the default full-build cadence is weekly and its failures must not age
+      # out between two evaluations of the alert built on this.
+      - record: namespace_stage:recsys_build_failures:increase6h
+        expr: >-
+          sum by (namespace, stage) (
+            increase(recsys_build_series_total{tankovault_scope=~".*", result="failed"}[6h]))
+
+      - record: namespace_stage:recsys_build_duration_seconds:p95_6h
+        expr: >-
+          histogram_quantile(0.95,
+            sum by (namespace, stage, le) (
+              rate(recsys_build_duration_seconds_bucket{tankovault_scope=~".*"}[6h])))
+
+      # `max`, not `sum`. The gauge is set by whichever control-plane replica ran the build, and a
+      # replica that held leadership earlier keeps its last value forever — summing would report a
+      # model several times its real size, and would grow every time leadership moved.
+      - record: namespace_table:recsys_model_series:current
+        expr: max by (namespace, table) (recsys_model_series{tankovault_scope=~".*"})
+
+      - record: namespace_path:recsys_serve_duration_seconds:p95_15m
+        expr: >-
+          histogram_quantile(0.95,
+            sum by (namespace, path, le) (
+              rate(recsys_serve_duration_seconds_bucket{tankovault_scope=~".*"}[15m])))
+
+      # Whether anyone is asking for a shelf at all — the denominator that keeps the emptiness
+      # rule below from reading an idle deployment as a broken one.
+      - record: namespace:recsys_serves:rate15m
+        expr: >-
+          sum by (namespace) (
+            rate(recsys_serve_duration_seconds_count{tankovault_scope=~".*"}[15m]))
+
+      # Mean items per served shelf, from the histogram's own sum and count rather than from a
+      # bucket boundary. A `le` selector would be the sharper statistic — the share of shelves
+      # that came back empty — but it depends on how the exporter formats the boundary `0`, and a
+      # rule that silently matches nothing is the exact failure this whole rule set is written to
+      # avoid. Sum over count needs no such assumption and answers the same question: an unbuilt
+      # or broken model serves nothing but empty shelves, so this goes to zero while the serve
+      # rate above does not.
+      - record: namespace:recsys_shelf_size:avg15m
+        expr: >-
+          sum by (namespace) (rate(recsys_shelf_size_sum{tankovault_scope=~".*"}[15m]))
+            / sum by (namespace) (rate(recsys_shelf_size_count{tankovault_scope=~".*"}[15m]))
+
   # AniList is a third party with a published request budget, and `sync` is the only service that
   # talks to it. Its own latency is deliberately not part of `sync`'s readiness, so this is the
   # only place a degrading AniList becomes visible.

--- a/charts/tankovault/templates/NOTES.txt
+++ b/charts/tankovault/templates/NOTES.txt
@@ -38,10 +38,35 @@ step there is no account that can administer anything:
   helm upgrade {{ .Release.Name }} ... \
     --set bootstrap.seedAdmin.enabled=true
 {{- end }}
-{{ if not .Values.postgresql.enabled }}{{ else }}
+{{ if not .Values.postgresql.enabled }}
+NOTE: your database must have pgvector available. Migration 0027 runs `CREATE EXTENSION vector`
+and the recommender retrieves through an HNSW index, so the extension is a hard dependency from
+that migration onwards — the migration fails loudly rather than degrading, because a recommender
+that silently returns nothing is worse than one that refuses to start. Install the extension
+package before upgrading (`postgresql-18-pgvector`, or your managed provider's allowlist setting
+— RDS, Cloud SQL and Azure Flexible Server all ship it); the migration issues the
+`CREATE EXTENSION` itself. The bundled `postgresql` runs `pgvector/pgvector` and needs nothing.
+{{- else }}
+{{- if .Release.IsUpgrade }}
+ACTION REQUIRED if this upgrade crossed chart 3.1.0: REINDEX the database once.
+
+  kubectl --namespace {{ include "common.namespace" . }} exec -it \
+    {{ include "common.fullname.suffixed" (dict "ctx" . "suffix" "postgresql") }}-0 -- \
+    psql -U {{ .Values.postgresql.auth.username }} -d {{ .Values.postgresql.auth.database }} \
+    -c 'REINDEX DATABASE {{ .Values.postgresql.auth.database }};'
+
+The bundled image moved from Alpine to Debian to get pgvector, and those two sort text
+differently under the same `en_US.utf8` locale. Every index on a text column was built under the
+old ordering and is not valid under the new one, so lookups can miss rows that are really there.
+PostgreSQL does not warn: this data directory records no collation version, so there is nothing
+for it to compare. The REINDEX rebuilds them and is the whole fix. Skip it only if this release
+is new.
+{{- end }}
+
 NOTE: the bundled PostgreSQL is a single instance with no failover and no point-in-time
 recovery. It exists so the chart installs on a bare cluster. Before this carries anything you
-care about, move to `externalDatabase` and a database you back up.
+care about, move to `externalDatabase` and a database you back up — one with pgvector available,
+which migration 0027 requires and this image already has.
 {{- end }}
 {{- if and .Values.services.api.enabled (not (include "tankovault.redisUrl" .)) }}
 

--- a/charts/tankovault/tests/bootstrap_test.yaml
+++ b/charts/tankovault/tests/bootstrap_test.yaml
@@ -3,12 +3,32 @@ templates:
   - job-migrate.yaml
   - job-seed.yaml
   - deployment.yaml
+  - postgresql.yaml
   - serviceaccount.yaml
   - secret.yaml
   - configmap-bootstrap.yaml
 values:
   - ../ci/default.yaml
 tests:
+  - it: gives the bundled database the extension the migrations require
+    # Migration `0027_recsys_signals` runs `CREATE EXTENSION vector`, and stock `postgres`
+    # cannot. Nothing else in this chart would notice: the image renders, the StatefulSet
+    # starts, `pg_isready` passes, and the release fails at its first migration instead — on a
+    # message about a missing extension rather than about the wrong image. This is the only
+    # place that decision is written down, so it is pinned here.
+    template: postgresql.yaml
+    set:
+      postgresql.enabled: true
+      postgresql.auth.password: test-password
+      externalDatabase.url: ""
+    documentSelector:
+      path: kind
+      value: StatefulSet
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '^pgvector/pgvector:pg18@sha256:[0-9a-f]{64}$'
+
   - it: uses a pre-install hook Job against an external database
     template: job-migrate.yaml
     asserts:

--- a/charts/tankovault/tests/observability_test.yaml
+++ b/charts/tankovault/tests/observability_test.yaml
@@ -129,7 +129,7 @@ tests:
           value: kube-prometheus-stack
       - lengthEqual:
           path: spec.groups
-          count: 19
+          count: 21
 
   - it: keeps Prometheus' alert templating out of the template engine
     capabilities:

--- a/charts/tankovault/values.schema.json
+++ b/charts/tankovault/values.schema.json
@@ -80,7 +80,7 @@
               "type": "string"
             },
             "tag": {
-              "default": "v1.2.2@sha256:6dec5e2ad047d4d531376a31814e5c7e96e6a683941771be869451c836592f8f",
+              "default": "v1.3.0@sha256:009bf66ae3c903e942dd9d81d0c4911186f2f395bf38c80d83b6415d49ebffd5",
               "description": "Image tag, pinned by digest.",
               "required": [],
               "title": "tag",
@@ -2220,7 +2220,7 @@
     },
     "postgresql": {
       "additionalProperties": true,
-      "description": "Bundled PostgreSQL. A single instance with a PVC, on the same image the upstream compose\nstack pins. Deliberately not an operator and not a third-party subchart, so `helm install`\nworks on a bare cluster — but equally deliberately **not a production database**: one\nreplica, no failover, no point-in-time recovery. Use `externalDatabase` for anything real.",
+      "description": "Bundled PostgreSQL. A single instance with a PVC, on the same image the upstream compose\nstack pins. Deliberately not an operator and not a third-party subchart, so `helm install`\nworks on a bare cluster — but equally deliberately **not a production database**: one\nreplica, no failover, no point-in-time recovery. Use `externalDatabase` for anything real —\nand give it [pgvector](https://github.com/pgvector/pgvector), which migration `0027` requires.",
       "properties": {
         "auth": {
           "additionalProperties": true,
@@ -2261,15 +2261,15 @@
           "additionalProperties": true,
           "properties": {
             "repository": {
-              "default": "postgres",
-              "description": "Image repository.",
+              "default": "pgvector/pgvector",
+              "description": "Image repository. `pgvector/pgvector`, not stock `postgres`: TankoVault migration\n`0027_recsys_signals` runs `CREATE EXTENSION vector` and the recommender retrieves through\nan HNSW index, so the extension is a hard dependency of the deployment rather than an\noptional extra. This is the official PostgreSQL image with pgvector preinstalled — same\nmajor, same entrypoint, same environment contract, same `postgres` uid — so nothing else\nin this block changes and an existing PVC is reused in place. It is Debian-based rather\nthan Alpine; `resourcesPreset` already accommodates that.",
               "required": [],
               "title": "repository",
               "type": "string"
             },
             "tag": {
-              "default": "18-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15",
-              "description": "Image tag, pinned by digest.",
+              "default": "pg18@sha256:691673308c99d2161ba298736f3147f1f22d79de2fb7ec93ae9b4afcab870b62",
+              "description": "Image tag, pinned by digest. Held to the same digest as upstream's compose stack and CI\nservices, so the database this chart runs is the one the queries were type-checked against.",
               "required": [],
               "title": "tag",
               "type": "string"
@@ -2453,7 +2453,7 @@
                   "type": "string"
                 },
                 "tag": {
-                  "default": "v1.2.2@sha256:84c933ccf3fe3765cc00ee2bf8c193077f6a696fe9d8ab3b5aa33a879a5b044d",
+                  "default": "v1.3.0@sha256:688ff0a711d39787bafdcc333b7761adb2ced2940e4e4fa14159571a81762dc2",
                   "description": "Image tag, pinned by digest.",
                   "required": [],
                   "title": "tag",
@@ -2629,7 +2629,7 @@
                   "type": "string"
                 },
                 "tag": {
-                  "default": "v1.2.2@sha256:56bdde2ce632556ffd06a6a4c74b122abf836b1397bd38b796f0387f894b1f38",
+                  "default": "v1.3.0@sha256:d2916c743332b39227139e022eb9d67e6bf895dc3ef9b8a344dd4863c828a670",
                   "description": "Image tag, pinned by digest.",
                   "required": [],
                   "title": "tag",
@@ -2755,7 +2755,7 @@
                   "type": "string"
                 },
                 "tag": {
-                  "default": "v1.2.2@sha256:be00fd90eb0bcaed5f0c9c618d5924ca292e48b61130f54ac22a851760592f98",
+                  "default": "v1.3.0@sha256:1abe73d52baebe58e497036291b5d284b8335367046dc988f6dfd12330561568",
                   "description": "Image tag, pinned by digest.",
                   "required": [],
                   "title": "tag",
@@ -2931,7 +2931,7 @@
                   "type": "string"
                 },
                 "tag": {
-                  "default": "v1.2.2@sha256:afb825de9865a792397e91dfb0acc9d0ebb93f5ee86abea6508c5e7078afcbdf",
+                  "default": "v1.3.0@sha256:2d7b089b5a3f7384cf9b9eb46735c6f78d6b738d50a631ee964a9798566ff79e",
                   "description": "Image tag, pinned by digest.",
                   "required": [],
                   "title": "tag",
@@ -3057,7 +3057,7 @@
                   "type": "string"
                 },
                 "tag": {
-                  "default": "v1.2.2@sha256:edcdbe83c2a069523355bd064a46d24606b2332e461da0ffc3b3b509f7588900",
+                  "default": "v1.3.0@sha256:664d1b8dacf95bca81d3496f76dbefad2a725a5e739f024f0700e10c080b6cc9",
                   "description": "Image tag, pinned by digest.",
                   "required": [],
                   "title": "tag",
@@ -3240,7 +3240,7 @@
                   "type": "string"
                 },
                 "tag": {
-                  "default": "v1.2.2@sha256:2ed04a7e7c0619795ecf5aa501c1aeb48bf117a51db1a2b82337c1fc539119ed",
+                  "default": "v1.3.0@sha256:d19661396140072d601aaa622089a2c0c43fa25624b59a9b003e75d4df5f7409",
                   "description": "Image tag, pinned by digest.",
                   "required": [],
                   "title": "tag",
@@ -3363,7 +3363,7 @@
                   "type": "string"
                 },
                 "tag": {
-                  "default": "v1.2.2@sha256:fb480ab14507c8e3db6c95255ef912a1b0945dcff1409d4913b986b32c75e30b",
+                  "default": "v1.3.0@sha256:8f0b824720d8c77b5464e03546cff77fd13722a7c1a0c68ecb9c94fb0680179d",
                   "description": "Image tag, pinned by digest.",
                   "required": [],
                   "title": "tag",
@@ -3539,7 +3539,7 @@
                   "type": "string"
                 },
                 "tag": {
-                  "default": "v1.2.2@sha256:bca660838859e06cbc7b027577457cc9395947d1c5a6866e7cfe1530274279dc",
+                  "default": "v1.3.0@sha256:1cc87817f13324c818418531684ddcf145ff433988176d522190a61d717dc581",
                   "description": "Image tag, pinned by digest.",
                   "required": [],
                   "title": "tag",

--- a/charts/tankovault/values.yaml
+++ b/charts/tankovault/values.yaml
@@ -588,7 +588,7 @@ services:
       # type: string
       # @schema
       # -- Image tag, pinned by digest.
-      tag: v1.2.2@sha256:afb825de9865a792397e91dfb0acc9d0ebb93f5ee86abea6508c5e7078afcbdf
+      tag: v1.3.0@sha256:2d7b089b5a3f7384cf9b9eb46735c6f78d6b738d50a631ee964a9798566ff79e
 
     # @schema
     # enum: ["", nano, micro, small, medium, large]
@@ -712,7 +712,7 @@ services:
       # type: string
       # @schema
       # -- Image tag, pinned by digest.
-      tag: v1.2.2@sha256:84c933ccf3fe3765cc00ee2bf8c193077f6a696fe9d8ab3b5aa33a879a5b044d
+      tag: v1.3.0@sha256:688ff0a711d39787bafdcc333b7761adb2ced2940e4e4fa14159571a81762dc2
 
     # @schema
     # enum: ["", nano, micro, small, medium, large]
@@ -836,7 +836,7 @@ services:
       # type: string
       # @schema
       # -- Image tag, pinned by digest.
-      tag: v1.2.2@sha256:be00fd90eb0bcaed5f0c9c618d5924ca292e48b61130f54ac22a851760592f98
+      tag: v1.3.0@sha256:1abe73d52baebe58e497036291b5d284b8335367046dc988f6dfd12330561568
 
     # @schema
     # enum: ["", nano, micro, small, medium, large]
@@ -924,7 +924,7 @@ services:
       # type: string
       # @schema
       # -- Image tag, pinned by digest.
-      tag: v1.2.2@sha256:bca660838859e06cbc7b027577457cc9395947d1c5a6866e7cfe1530274279dc
+      tag: v1.3.0@sha256:1cc87817f13324c818418531684ddcf145ff433988176d522190a61d717dc581
 
     # @schema
     # enum: ["", nano, micro, small, medium, large]
@@ -1046,7 +1046,7 @@ services:
       # type: string
       # @schema
       # -- Image tag, pinned by digest.
-      tag: v1.2.2@sha256:edcdbe83c2a069523355bd064a46d24606b2332e461da0ffc3b3b509f7588900
+      tag: v1.3.0@sha256:664d1b8dacf95bca81d3496f76dbefad2a725a5e739f024f0700e10c080b6cc9
 
     # @schema
     # enum: ["", nano, micro, small, medium, large]
@@ -1133,7 +1133,7 @@ services:
       # type: string
       # @schema
       # -- Image tag, pinned by digest.
-      tag: v1.2.2@sha256:fb480ab14507c8e3db6c95255ef912a1b0945dcff1409d4913b986b32c75e30b
+      tag: v1.3.0@sha256:8f0b824720d8c77b5464e03546cff77fd13722a7c1a0c68ecb9c94fb0680179d
 
     # @schema
     # enum: ["", nano, micro, small, medium, large]
@@ -1220,7 +1220,7 @@ services:
       # type: string
       # @schema
       # -- Image tag, pinned by digest.
-      tag: v1.2.2@sha256:56bdde2ce632556ffd06a6a4c74b122abf836b1397bd38b796f0387f894b1f38
+      tag: v1.3.0@sha256:d2916c743332b39227139e022eb9d67e6bf895dc3ef9b8a344dd4863c828a670
 
     # @schema
     # enum: ["", nano, micro, small, medium, large]
@@ -1344,7 +1344,7 @@ services:
       # type: string
       # @schema
       # -- Image tag, pinned by digest.
-      tag: v1.2.2@sha256:2ed04a7e7c0619795ecf5aa501c1aeb48bf117a51db1a2b82337c1fc539119ed
+      tag: v1.3.0@sha256:d19661396140072d601aaa622089a2c0c43fa25624b59a9b003e75d4df5f7409
 
     # @schema
     # $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements
@@ -1505,7 +1505,7 @@ bootstrap:
     # type: string
     # @schema
     # -- Image tag, pinned by digest.
-    tag: v1.2.2@sha256:6dec5e2ad047d4d531376a31814e5c7e96e6a683941771be869451c836592f8f
+    tag: v1.3.0@sha256:009bf66ae3c903e942dd9d81d0c4911186f2f395bf38c80d83b6415d49ebffd5
 
   # @schema
   # enum: ["", nano, micro, small, medium, large]
@@ -1609,7 +1609,8 @@ bootstrap:
 # -- Bundled PostgreSQL. A single instance with a PVC, on the same image the upstream compose
 # stack pins. Deliberately not an operator and not a third-party subchart, so `helm install`
 # works on a bare cluster — but equally deliberately **not a production database**: one
-# replica, no failover, no point-in-time recovery. Use `externalDatabase` for anything real.
+# replica, no failover, no point-in-time recovery. Use `externalDatabase` for anything real —
+# and give it [pgvector](https://github.com/pgvector/pgvector), which migration `0027` requires.
 postgresql:
   # @schema
   # type: boolean
@@ -1624,14 +1625,21 @@ postgresql:
     # @schema
     # type: string
     # @schema
-    # -- Image repository.
-    repository: postgres
+    # -- Image repository. `pgvector/pgvector`, not stock `postgres`: TankoVault migration
+    # `0027_recsys_signals` runs `CREATE EXTENSION vector` and the recommender retrieves through
+    # an HNSW index, so the extension is a hard dependency of the deployment rather than an
+    # optional extra. This is the official PostgreSQL image with pgvector preinstalled — same
+    # major, same entrypoint, same environment contract, same `postgres` uid — so nothing else
+    # in this block changes and an existing PVC is reused in place. It is Debian-based rather
+    # than Alpine; `resourcesPreset` already accommodates that.
+    repository: pgvector/pgvector
 
     # @schema
     # type: string
     # @schema
-    # -- Image tag, pinned by digest.
-    tag: 18-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
+    # -- Image tag, pinned by digest. Held to the same digest as upstream's compose stack and CI
+    # services, so the database this chart runs is the one the queries were type-checked against.
+    tag: pg18@sha256:691673308c99d2161ba298736f3147f1f22d79de2fb7ec93ae9b4afcab870b62
 
   # @schema
   # additionalProperties: true


### PR DESCRIPTION
Prepares the chart for the recommender added in [TankoVault `5d8eaf4`](https://github.com/TimSchoenle/TankoVault/commit/5d8eaf400d4b8663e483b5d020937cd5d051b846), shipped in `v1.3.0`. Chart `3.0.5` → `3.1.0`, appVersion `1.2.2` → `1.3.0`, all nine service images repinned to their `v1.3.0` digests.

## ⚠️ Existing bundled-Postgres releases need one REINDEX

This is the part worth reviewing carefully. Getting pgvector means moving the bundled image from Alpine to Debian, and **musl and glibc sort text differently under the same `en_US.utf8` locale name**:

| | `ORDER BY t` |
|---|---|
| `postgres:18-alpine` (musl) | `A, B, _z, a, a-b, ab, b` |
| `pgvector/pgvector:pg18` (glibc) | `a, A, a-b, ab, b, B, _z` |

Every btree index on a `text`/`varchar` column was built under the first ordering and is not valid under the second. The failure is silent and it is *wrong answers*, not errors — an index scan can skip rows that are present, and a unique index can stop rejecting duplicates.

**PostgreSQL issues no warning.** It only warns on a collation change when the database records a collation version to compare against, and a cluster initialised by the Alpine image records none (`pg_database.datcollversion` is null).

I verified this rather than assuming it — carried a data directory across both images at the chart's own uid/mount layout:

- no re-`initdb`, all rows intact, `CREATE EXTENSION vector` works — so the PVC *is* reused correctly
- `bt_index_check` → `ERROR: item order invariant violated for index "si"` immediately after the swap
- one `REINDEX DATABASE` clears it; index scan and seq scan then agree again

The README carries a dedicated section, and `NOTES.txt` prints the exact `kubectl exec … REINDEX DATABASE` command on upgrade (gated on `.Release.IsUpgrade`, so fresh installs don't see it). The chart deliberately does **not** run it: on a real catalogue that is a long operation with real locking behaviour, and scheduling it is an operator's call.

## Why CI failed the first time, and the fix

`ct install --upgrade` (new in #358) deadlocked. Moving the database image makes the StatefulSet replace its pod — which no previous upgrade of this chart did — and the fixture already requests 2700m of CPU on a single 4-core kind node. In the window between delete and create, the rolling-update surge takes the capacity the database just released; then no service can pass a readiness probe without the database, so no old pod retires, so the capacity never comes back. The log shows it plainly: `FailedScheduling … 0/1 nodes are available: 1 Insufficient cpu` on `postgresql-0`, five times over ten minutes.

`ci/bundled-datastores-values.yaml` now sets `defaults.strategy.rollingUpdate.maxSurge: 0`, which retires before it replaces, so the release never needs more than its steady state. The README names the same lever for anyone upgrading on a constrained cluster. (`minimal-values.yaml` already documents itself as "sized to fit a kind node", so sizing a fixture to the runner is the established approach here.)

## pgvector as a hard dependency

Migration `0027_recsys_signals` runs `CREATE EXTENSION vector`. A test pins the image, because nothing else in the chart would notice a revert to stock `postgres`: it renders, the StatefulSet starts, `pg_isready` passes, and the release fails at its first migration on a message about a missing extension rather than about the wrong image.

**External databases must have the extension installed before upgrading.** A chart cannot detect that ahead of time, so `NOTES.txt` and the README say so instead.

## Observability

Both of the recommender's failure modes are invisible to every rule already in the set — a model that has stopped being built keeps serving (stale first, then empty) with no error and no added latency, and an empty shelf is a `200` returned *faster* than a full one. Seven recording rules under `tankovault-recsys-recording` and two alerts:

- `TankoVaultRecsysBuildFailing` — runbook branches on `stage`; `incremental` failures usually mean no full build has ever completed, a state that persists until one does.
- `TankoVaultRecsysShelvesEmpty` — gated on the serve rate, so a deployment with the feature switched off cannot trip it.

Plus a `Recommendations` row (five panels) on the scan-pipeline dashboard. Two choices there are deliberate:

- `namespace_table:recsys_model_series:current` takes `max`, not `sum`. Only the replica that ran a build sets that gauge, and it keeps the value after losing leadership — summing would inflate the reported model size on every failover.
- The emptiness rule divides the shelf histogram's `_sum` by its `_count` rather than selecting the `le="0"` bucket. The bucket ratio is the sharper statistic, but it depends on how the exporter formats the boundary `0`, and a selector that silently matches nothing is the exact defect class this rule set exists to catch.

## Configuration

The four `scheduler.recsys_*` keys need no new values — they are ordinary configuration under `services.controlPlane.config`. They do need documenting, including the one that surprises: both timers fire immediately when the leader starts, so a fresh install builds on the first scheduler tick rather than waiting a week, and every restart of the leading replica begins a full rebuild.

Nothing is switched on by this chart. The recommender is gated on the `catalogue.recommendations` feature flag in the admin console.

## Verification

- `helm unittest` — 11 suites, 130 tests
- `.github/scripts/test-rules.sh` — audit clean (38 alerts, 67 recording rules, 66 dashboard queries), promtool green on both the committed and rendered rule forms
- `validate-manifests.sh` — 357 resources across 28 (chart, values) pairs, 0 invalid, against k8s 1.34.0
- `check-immutable-fields.py` — no violations
- Postgres image swap exercised end-to-end in Docker at the chart's uid/mount layout (see above)
- `helm schema` regenerated; `README.md` prose spliced from `README.md.gotmpl` so the two cannot drift before helm-docs runs in CI

Rebased onto `main` to pick up #358, which is what introduced the upgrade test this originally failed.

## Out of scope

Upstream `cebc25d5` (also in `v1.3.0`, but a separate commit) adds Postgres runtime tuning to the compose stack — `shared_buffers`, `jit=off`, `shm_size: 256mb` — citing 1.0–3.3s statements on defaults. The chart's bundled Postgres runs stock defaults and its `/dev/shm` is 64Mi, so it has both problems. Deliberately left for its own change.
