### PR TITLE
feat: migrate every chart to the file-based configuration and secret system

### DIFF
--- a/.github/testdata/common-fixture/Chart.yaml
+++ b/.github/testdata/common-fixture/Chart.yaml
@@ -12,5 +12,5 @@ version: 0.0.0
 appVersion: "1.2.3"
 dependencies:
   - name: common
-    version: 1.3.0
+    version: 1.4.0
     repository: "file://../../../charts/common"

--- a/.github/testdata/common-fixture/templates/configmap.yaml
+++ b/.github/testdata/common-fixture/templates/configmap.yaml
@@ -8,4 +8,6 @@ metadata:
     {{- include "common.labels" . | nindent 4 }}
 data:
   PORT: {{ .Values.containerPort | quote }}
+  config.toml: |
+    {{- include "common.configToml" (dict "ctx" . "maps" (list .Values.config)) | nindent 4 }}
 {{- end }}

--- a/.github/testdata/common-fixture/templates/fileconfig.yaml
+++ b/.github/testdata/common-fixture/templates/fileconfig.yaml
@@ -1,0 +1,44 @@
+{{- /*
+Exercises the file-backed configuration partials the way a real consuming chart uses them:
+`common.fileConfig.secretData` into a Secret, and the volumes, mounts and loader variables onto
+a pod. The `config.toml` itself lives in `configmap.yaml`, because `common.fileConfig.volumes`
+names the config volume after `common.configMapName` and the two have to agree.
+
+A `Pod` rather than a second Deployment, so the assertions in `fileconfig_test.yaml` can select
+it without competing with the Deployment the rest of the fixture renders.
+*/ -}}
+{{- $secrets := .Values.fileConfigSecrets | default dict -}}
+{{- $secretKeys := include "common.fileConfig.secretKeys" (dict "ctx" . "data" $secrets) | fromYamlArray -}}
+{{- if (include "common.fileConfig.createSecret" (dict "ctx" . "data" $secrets)) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.fullname" . }}
+  namespace: {{ include "common.namespace" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- include "common.fileConfig.secretData" (dict "data" $secrets) | nindent 2 }}
+---
+{{- end }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "common.fullname" . }}-fileconfig
+  namespace: {{ include "common.namespace" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+spec:
+  {{- include "common.podSpec.common" . | nindent 2 }}
+  containers:
+    {{- include "common.container" (dict
+          "ctx" $
+          "name" "fileconfig"
+          "env" (include "common.fileConfig.env" (dict "ctx" $ "prefix" "FIXTURE" "secretKeys" $secretKeys) | fromYamlArray)
+          "volumeMounts" (include "common.fileConfig.volumeMounts" (dict "ctx" $ "secretKeys" $secretKeys) | fromYamlArray)
+        ) | nindent 4 }}
+  {{- with (include "common.volumes" (dict "ctx" $ "volumes" (include "common.fileConfig.volumes" (dict "ctx" $ "secretKeys" $secretKeys) | fromYamlArray))) }}
+  volumes:
+    {{- . | nindent 4 }}
+  {{- end }}

--- a/.github/testdata/common-fixture/tests/fileconfig_test.yaml
+++ b/.github/testdata/common-fixture/tests/fileconfig_test.yaml
@@ -1,0 +1,218 @@
+suite: file-backed configuration partials
+# Covers `common.toml` and `common.fileConfig.*`, which every application chart in this
+# repository composes to hand a workload its settings as files instead of as environment
+# variables. The library owns the shape; this is where it is asserted.
+templates:
+  - fileconfig.yaml
+  - configmap.yaml
+tests:
+  - it: renders the configuration tree as TOML
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[server\]\nhost = "0\.0\.0\.0"\nport = 8080'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[telemetry\]\nlog_level = "info"'
+
+  # In TOML a key belongs to the most recent `[table]` header, so a top-level scalar emitted
+  # after a sibling table would be silently reparented into it.
+  - it: emits scalars before the tables that would swallow them
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    set:
+      config:
+        zeta: "top-level"
+        alpha:
+          nested: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\Azeta = "top-level"\n\n\[alpha\]\nnested = true'
+
+  # TOML bare keys are [A-Za-z0-9_-]+. A request path or a regex emitted bare does not parse.
+  - it: quotes keys outside the bare-key alphabet, and only those
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    set:
+      config:
+        entries:
+          "docs/handbook":
+            bucket: media
+          plain_key:
+            bucket: media
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[entries\."docs/handbook"\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[entries\.plain_key\]'
+
+  # `toJson` would HTML-escape these into \uXXXX. TOML parses that back to the same string, so
+  # it was never wrong — only unreadable in a diff, which is the whole point of a mounted file.
+  - it: leaves URL punctuation readable instead of escaping it
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    set:
+      config:
+        telemetry:
+          sentry_dsn: "https://key@sentry.example.invalid/1?a=1&b=2"
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'sentry_dsn = "https://key@sentry\.example\.invalid/1\?a=1&b=2"'
+
+  - it: appends configExtraToml verbatim
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    set:
+      configExtraToml: |
+        [[rewrite]]
+        from = "/a"
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[\[rewrite\]\]\nfrom = "/a"'
+
+  - it: mounts the configuration read-only and names it to the loader
+    documentSelector:
+      path: kind
+      value: Pod
+    asserts:
+      - contains:
+          path: spec.volumes
+          content:
+            name: config
+            configMap:
+              name: RELEASE-NAME-common-fixture
+      - contains:
+          path: spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /etc/common-fixture/config
+            readOnly: true
+      - contains:
+          path: spec.containers[0].env
+          content:
+            name: FIXTURE_CONFIG
+            value: /etc/common-fixture/config
+
+  # A configured secrets directory that cannot be read is a boot failure naming the path, not
+  # an empty layer — so the variable, the volume and the mount appear and disappear together.
+  - it: names no secrets directory when no credential is configured
+    documentSelector:
+      path: kind
+      value: Pod
+    asserts:
+      - notContains:
+          path: spec.containers[0].env
+          content:
+            name: FIXTURE_SECRETS_DIR
+            value: /etc/common-fixture/secrets
+      - notContains:
+          path: spec.containers[0].volumeMounts
+          content:
+            name: secrets
+            mountPath: /etc/common-fixture/secrets
+            readOnly: true
+
+  - it: projects only the credentials that were actually set
+    documentSelector:
+      path: kind
+      value: Pod
+    set:
+      fileConfigSecrets.auth__token: t0ken
+    asserts:
+      - contains:
+          path: spec.volumes
+          content:
+            name: secrets
+            projected:
+              defaultMode: 256
+              sources:
+                - secret:
+                    name: RELEASE-NAME-common-fixture
+                    optional: true
+                    items:
+                      - key: auth__token
+                        path: auth__token
+      - contains:
+          path: spec.containers[0].env
+          content:
+            name: FIXTURE_SECRETS_DIR
+            value: /etc/common-fixture/secrets
+
+  # The chart cannot see inside an operator's Secret, so it projects every key it knows how to
+  # consume rather than only the ones it happens to hold values for.
+  - it: projects every known key from an existing Secret
+    documentSelector:
+      path: kind
+      value: Pod
+    set:
+      existingSecret: my-secret
+    asserts:
+      - contains:
+          path: spec.volumes
+          content:
+            name: secrets
+            projected:
+              defaultMode: 256
+              sources:
+                - secret:
+                    name: my-secret
+                    optional: true
+                    items:
+                      - key: auth__password
+                        path: auth__password
+                      - key: auth__token
+                        path: auth__token
+
+  - it: follows an existingConfigMap for the configuration volume
+    documentSelector:
+      path: kind
+      value: Pod
+    set:
+      existingConfigMap: my-config
+    asserts:
+      - contains:
+          path: spec.volumes
+          content:
+            name: config
+            configMap:
+              name: my-config
+
+  # An empty optional credential is still a *supplied* value to the loader, so it is omitted
+  # rather than written as an empty file.
+  - it: writes only non-empty credentials into the Secret
+    documentSelector:
+      path: kind
+      value: Secret
+    set:
+      fileConfigSecrets.auth__token: t0ken
+    asserts:
+      - equal:
+          path: stringData.auth__token
+          value: t0ken
+      - notExists:
+          path: stringData.auth__password
+
+  - it: renders no Secret at all when nothing is configured
+    asserts:
+      - notExists:
+          path: $[?(@.kind == "Secret")]
+
+  - it: renders no Secret when an existing one is supplied
+    set:
+      existingSecret: my-secret
+      fileConfigSecrets.auth__token: t0ken
+    asserts:
+      - notExists:
+          path: $[?(@.kind == "Secret")]

--- a/.github/testdata/common-fixture/tests/toml_guard_test.yaml
+++ b/.github/testdata/common-fixture/tests/toml_guard_test.yaml
@@ -1,0 +1,20 @@
+suite: common.toml array-of-tables guard
+# Its own suite, and scoped to the one template that renders the tree: helm-unittest requires a
+# `failedTemplate` assertion to hold for every template a suite lists, and the rest of the
+# fixture renders fine on the same values.
+templates:
+  - configmap.yaml
+tests:
+  # An array of tables is `[[name]]` in TOML, which this renderer cannot express. Emitting the
+  # JSON array instead would produce a file the service rejects at boot, so the render fails
+  # here and names both the key and the escape hatch that does express it.
+  - it: refuses an array of tables rather than emitting invalid TOML
+    set:
+      config:
+        rewrite:
+          - from: /a
+    asserts:
+      - failedTemplate:
+          errorPattern: 'config key "rewrite" is an array of tables'
+      - failedTemplate:
+          errorPattern: "configExtraToml"

--- a/.github/testdata/common-fixture/values.yaml
+++ b/.github/testdata/common-fixture/values.yaml
@@ -120,3 +120,26 @@ grafanaDashboard:
 
 # Stand-in for the rendered pod spec the real callers of `common.fullname.hashed` digest.
 hashedContent: baseline-content
+
+# The file-backed configuration contract `common.fileConfig.*` and `common.toml` expect.
+config:
+  server:
+    host: 0.0.0.0
+    port: 8080
+  telemetry:
+    log_level: info
+
+configExtraToml: ""
+
+configMount:
+  configDir: /etc/common-fixture/config
+  secretsDir: /etc/common-fixture/secrets
+
+existingConfigMap: ""
+existingSecret: ""
+
+# Stand-in for a consuming chart's own credential values, keyed the way a file in the secrets
+# directory has to be named.
+fileConfigSecrets:
+  auth__token: ""
+  auth__password: ""

--- a/charts/cloudflare-access-webhook-redirect/Chart.yaml
+++ b/charts/cloudflare-access-webhook-redirect/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cloudflare-access-webhook-redirect
 description: A Helm chart for deploying the Cloudflare Access Webhook Redirect service. This service acts as an authentication proxy that validates requests using Cloudflare Access Service Auth tokens before forwarding them to target backend services.
 type: application
-version: 3.0.9
-appVersion: v0.3.22
+version: 4.0.0
+appVersion: v1.0.0
 keywords:
   - cloudflare
   - webhook
@@ -18,5 +18,5 @@ maintainers:
     url: https://github.com/TimSchoenle
 dependencies:
   - name: common
-    version: 1.3.0
+    version: 1.4.0
     repository: "file://../common"

--- a/charts/cloudflare-access-webhook-redirect/README.md
+++ b/charts/cloudflare-access-webhook-redirect/README.md
@@ -1,6 +1,6 @@
 # cloudflare-access-webhook-redirect
 
-![Version: 3.0.9](https://img.shields.io/badge/Version-3.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.22](https://img.shields.io/badge/AppVersion-v0.3.22-informational?style=flat-square)
+![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 A Helm chart for deploying the Cloudflare Access Webhook Redirect service. This service acts as an authentication proxy that validates requests using Cloudflare Access Service Auth tokens before forwarding them to target backend services.
 
@@ -29,15 +29,13 @@ helm install [RELEASE_NAME] timschoenle/cloudflare-access-webhook-redirect \
 with `values.yaml`:
 
 ```yaml
-application:
-  handler:
-    targetBase: http://backend-service:8080
-    paths:
-      api/webhook:
-        - POST
+webhook:
+  targetBase: http://backend-service:8080
+  paths:
+    "/api/webhook/.*":
+      - POST
 
-  cloudflareAccess:
-    secretName: cloudflare-access-secret
+existingSecret: cloudflare-access-secret
 ```
 
 Upgrade with `helm upgrade [RELEASE_NAME] timschoenle/cloudflare-access-webhook-redirect -n [NAMESPACE]`,
@@ -45,48 +43,75 @@ remove with `helm uninstall [RELEASE_NAME] -n [NAMESPACE]`.
 
 ## Credentials
 
-Create the Secret yourself and reference it by name. The keys have to be called `client_id`
-and `client_secret`:
+Create the Secret yourself and reference it by name. **The keys are the configuration paths the
+service reads, not free-form names** — the proxy takes the key out of the file name, so
+`cloudflare__client_id` is required and `client_id` is not read at all:
 
 ```shell
-kubectl create secret generic cloudflare-access-secret \
-  --namespace [NAMESPACE] \
-  --from-literal=client_id='...' \
-  --from-literal=client_secret='...'
+kubectl create secret generic cloudflare-access-secret   --namespace [NAMESPACE]   --from-literal=cloudflare__client_id='...'   --from-literal=cloudflare__client_secret='...'
 ```
 
 ```yaml
-application:
-  cloudflareAccess:
-    secretName: cloudflare-access-secret
+existingSecret: cloudflare-access-secret
 ```
 
-`application.cloudflareAccess.clientId` / `.clientSecret` are accepted as an alternative and
-make the chart render the Secret itself. That puts the credentials into `values.yaml` and into
-the Helm release object, where anyone who can run `helm get values` can read them — use it for
-a throwaway cluster, not for anything real. `secretName` wins if both are set.
+`cloudflare.clientId` / `.clientSecret` are accepted as an alternative and make the chart render
+the Secret itself. That puts the credentials into `values.yaml` and into the Helm release
+object, where anyone who can run `helm get values` can read them — use it for a throwaway
+cluster, not for anything real. `existingSecret` wins if both are set.
+
+Either way the credentials arrive as files in a projected volume, which the proxy watches: a
+rotated Secret is picked up in place, with no rollout and no window in which the pod is serving
+on a credential you have already revoked.
+
+## Configuration
+
+Everything the service reads is rendered into one `config.toml`, mounted as a ConfigMap and
+pointed at by `WEBHOOK_REDIRECT_CONFIG`. Nothing is passed as an environment variable, and that
+is deliberate: the loader **fails the boot on a key supplied by both the environment and a
+file** rather than resolving it by precedence, and a value that lives in a file is one the
+kubelet can rotate under a running process.
+
+The values above cover the whole documented surface. `config` takes the raw TOML tree for
+anything they do not, merged over the derived one:
+
+```yaml
+config:
+  server:
+    host: 127.0.0.1
+```
+
+and `configExtraToml` is appended verbatim for what the renderer cannot express, notably arrays
+of tables.
+
+Because the proxy rebuilds its client, path patterns, credentials and listener in place when a
+mount changes, this chart publishes **no `checksum/*` pod annotations by default** — a
+configuration change reloads rather than rolls. Set `configMount.rolloutOnChange: true` to make
+it behave like an ordinary image bump instead. `telemetry.*` is installed once per process and
+needs a restart either way.
 
 ## Declaring what gets forwarded
 
-`application.handler.paths` is an allowlist, keyed by path, valued by the methods permitted on
+`webhook.paths` is an allowlist, keyed by a path **regex**, valued by the methods permitted on
 it. Nothing outside it is proxied, so a backend endpoint you did not list stays unreachable
 through this service even though `targetBase` points at the same host.
 
+Patterns are anchored: `/webhook/.*` matches `/webhook/github` but not `/api/webhook/github`.
+
 ```yaml
-application:
-  handler:
-    targetBase: http://backend-service:8080
-    paths:
-      api/webhook:      # every method
-        - ALL
-      api/data:         # reads and writes
-        - GET
-        - POST
-      health:           # reads only
-        - GET
+webhook:
+  targetBase: http://backend-service:8080
+  paths:
+    "/api/webhook/.*":   # every method
+      - ALL
+    "/api/data/.*":      # reads and writes
+      - GET
+      - POST
+    "/health":           # reads only
+      - GET
 ```
 
-Methods: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`, `OPTIONS`, or `ALL`.
+Methods: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, or `ALL`.
 
 Keep the list as narrow as the caller actually needs. `ALL` on a path that only ever receives
 webhooks also exposes `DELETE` on it.
@@ -94,8 +119,8 @@ webhooks also exposes `DELETE` on it.
 ## Request flow
 
 1. A client reaches the service, usually through an Ingress.
-2. The path and method are checked against `application.handler.paths`; anything not declared
-   is rejected here.
+2. The path and method are checked against `webhook.paths`; anything not declared is rejected
+   here.
 3. The request is authenticated with the Cloudflare Access Service Auth credentials.
 4. It is forwarded to `targetBase`, and the backend's response is returned unchanged.
 
@@ -183,26 +208,62 @@ Every rule you add must carry its own `to:`. A rule that lists only `ports:` is 
 restriction — the NetworkPolicy API reads a missing `to` as *any destination*, which includes
 the cloud instance metadata endpoint at `169.254.169.254`.
 
+## Upgrading
+
+### 3.x to 4.0
+
+Chart 4.0 tracks the service's 1.0 release, which replaced its environment-only configuration
+with the layered, file-first loader every chart in this repository now uses. The values that
+described that environment are gone; a `helm upgrade` with 3.x values fails schema validation
+naming the offending key rather than starting a pod on the defaults.
+
+| Before | After |
+|---|---|
+| `application.server.host` | `server.host` |
+| `application.server.port` | `server.port` |
+| `application.handler.targetBase` | `webhook.targetBase` |
+| `application.handler.paths` | `webhook.paths` |
+| `application.logLevel` | `telemetry.logLevel` |
+| `application.sentryDsn` | `telemetry.sentryDsn` |
+| `application.cloudflareAccess.clientId` | `cloudflare.clientId` |
+| `application.cloudflareAccess.clientSecret` | `cloudflare.clientSecret` |
+| `application.cloudflareAccess.secretName` | `existingSecret` |
+
+Two changes need work beyond a rename:
+
+**Path keys are regexes and are anchored.** `api/webhook` matched a prefix before; write
+`"/api/webhook/.*"` for the same reach, and quote it — it is no longer a bare key.
+
+**An existing Secret has to be re-keyed.** The proxy reads each credential out of the *file
+name*, so the keys are now `cloudflare__client_id` and `cloudflare__client_secret`. A Secret
+still holding `client_id` / `client_secret` mounts cleanly and supplies nothing, and the proxy
+refuses to boot naming the missing credential.
+
+```shell
+kubectl create secret generic cloudflare-access-secret   --namespace [NAMESPACE]   --from-literal=cloudflare__client_id="$(kubectl get secret cloudflare-access-secret -n [NAMESPACE] -o jsonpath='{.data.client_id}' | base64 -d)"   --from-literal=cloudflare__client_secret="$(kubectl get secret cloudflare-access-secret -n [NAMESPACE] -o jsonpath='{.data.client_secret}' | base64 -d)"   --dry-run=client -o yaml | kubectl apply -f -
+```
+
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Pod affinity rules |
-| application.cloudflareAccess.secretName | string | `""` | Existing secret name containing Cloudflare Access credentials Must contain client_id and client_secret keys |
-| application.handler.paths | object | `{}` | Path configurations with allowed HTTP methods Example:   api/webhook:     - ALL   test:     - GET     - POST |
-| application.handler.targetBase | string | `""` | Base URL for redirect targets |
-| application.logLevel | string | `"info"` | Application log level |
-| application.sentryDsn | string | `""` | Sentry DSN for error tracking (empty disables) |
-| application.server.host | string | `"0.0.0.0"` | Server bind address |
-| application.server.port | int | `8080` | HTTP server port |
 | automountServiceAccountToken | bool | `false` | Mount the ServiceAccount API token into the pod. Set on the pod itself, which is what actually keeps the token out of the container: the ServiceAccount-level setting is ignored as soon as a pod names a different account. |
 | autoscaling.enabled | bool | `false` | Enable Horizontal Pod Autoscaler (HPA) |
 | autoscaling.maxReplicas | int | `5` | Maximum replicas |
 | autoscaling.minReplicas | int | `1` | Minimum replicas |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization (%) |
 | autoscaling.targetMemoryUtilizationPercentage | int | `80` | Target memory utilization (%) |
+| cloudflare.clientId | string | `""` | Cloudflare Access service token client ID (`cloudflare.client_id`). Rendered into the chart's Secret and mounted as a file, so a rotation is picked up without a restart. Required unless `existingSecret` supplies it. |
+| cloudflare.clientSecret | string | `""` | Cloudflare Access service token client secret (`cloudflare.client_secret`). Required unless `existingSecret` supplies it. |
 | commonAnnotations | object | `{}` | Annotations added to every object this chart creates. |
 | commonLabels | object | `{}` | Labels added to every object this chart creates. |
+| config | object | `{}` | Extra configuration, expressed as the TOML tree of [the service's README](https://github.com/TimSchoenle/cloudflare-access-webhook-redirect#-configuration) (`server.host`, `webhook.target_base`, ...). Merged over everything the chart derives from the values above, so it can both extend and override them. Rendered into the mounted ConfigMap — never into the environment, which the loader refuses to combine with a file. |
+| configExtraToml | string | `""` | Verbatim TOML appended after the rendered configuration. The escape hatch for anything the chart's TOML renderer cannot express, notably arrays of tables. |
+| configMount.configDir | string | `"/etc/cloudflare-access-webhook-redirect/config"` | Directory the rendered `config.toml` is mounted at, passed as `WEBHOOK_REDIRECT_CONFIG`. |
+| configMount.rolloutOnChange | bool | `false` | Add `checksum/*` pod annotations so a configuration change rolls the Deployment. Off by default, and deliberately so: the proxy watches the directories its configuration came from and rebuilds its client, path patterns, credentials and listener in place when the kubelet updates the mounted ConfigMap or Secret, which is strictly better than a rollout. Turn this on only if you want configuration changes to behave like an ordinary image bump. `telemetry.*` is installed once per process and needs a restart either way. |
+| configMount.secretsDir | string | `"/etc/cloudflare-access-webhook-redirect/secrets"` | Directory the credential files are mounted at, passed as `WEBHOOK_REDIRECT_SECRETS_DIR`. |
+| existingSecret | string | `""` | Name of an existing Secret holding the Cloudflare Access credentials, which keeps them out of `values.yaml` and out of the Helm release object. **Its keys are the configuration paths, not free-form names**: `cloudflare__client_id` and `cloudflare__client_secret`, because the file name is what the loader parses. Set, the chart renders no Secret of its own and `cloudflare.clientId` / `cloudflare.clientSecret` are ignored. |
 | extraEnv | list | `[]` | Additional environment variables for the application container. |
 | extraVolumeMounts | list | `[]` | Additional volume mounts (e.g., /cache) |
 | extraVolumes | list | `[]` | Additional volumes (e.g., cache, tmp) |
@@ -210,7 +271,7 @@ the cloud instance metadata endpoint at `169.254.169.254`.
 | image.pullPolicy | string | `""` | Image pull policy. Empty resolves automatically from the tag/digest. |
 | image.registry | string | `""` | Registry host. Empty means Docker Hub. |
 | image.repository | string | `"timmi6790/cloudflare-access-webhook-redirect"` | Container image repository (e.g. docker.io/user/image) |
-| image.tag | string | `"v0.3.22@sha256:41b63717cbb575be525386d6b1c731d24e1c515b2b1d5f8421bc050a64f5375c"` | The container image tag, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the pull, while the tag stays on as the readable version marker. Defaults to the chart's `appVersion` when empty. |
+| image.tag | string | `"v1.0.0@sha256:90a8c511781fa563bca7b78149975ab34dc5a6736b469b4afc7cdd8c2b4e7afd"` | The container image tag, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the pull, while the tag stays on as the readable version marker. Defaults to the chart's `appVersion` when empty. |
 | imagePullSecrets | list | `[]` | Optional image pull secrets for private registries |
 | ingress.annotations | object | `{}` | Additional ingress annotations Example:   cert-manager.io/cluster-issuer: letsencrypt-prod   nginx.ingress.kubernetes.io/rate-limit: "100" |
 | ingress.enabled | bool | `false` | Enable ingress resource |
@@ -281,6 +342,8 @@ the cloud instance metadata endpoint at `169.254.169.254`.
 | revisionHistoryLimit | int | `3` | Number of old ReplicaSets retained for rollback. |
 | securityContext | object | `{}` | Container security context, merged over the preset. The preset mounts the root filesystem read-only; a writable /tmp is provided automatically via an emptyDir volume. |
 | securityContextPreset | string | `"restricted"` | Container security context baseline. `restricted` drops all Linux capabilities and forbids privilege escalation, running as root and a writable root filesystem. |
+| server.host | string | `"0.0.0.0"` | Bind address (`server.host`). The application's own default is `127.0.0.1`, which in a container answers nothing; `0.0.0.0` is what makes the Service reach it. |
+| server.port | int | `8080` | Bind port (`server.port`). Also the container port, the Service target and what every probe and NetworkPolicy rule is written against. |
 | service.annotations | object | `{}` | Additional service annotations |
 | service.port | int | `80` | Service port |
 | service.type | string | `"ClusterIP"` | Kubernetes service type |
@@ -297,9 +360,13 @@ the cloud instance metadata endpoint at `169.254.169.254`.
 | startupProbe.successThreshold | int | `1` | Success threshold |
 | startupProbe.timeoutSeconds | int | `3` | Probe timeout |
 | strategy | object | `{}` | Deployment update strategy. Empty uses the Kubernetes default rolling update. |
+| telemetry.logLevel | string | `"info"` | Log level (`telemetry.log_level`). |
+| telemetry.sentryDsn | string | `""` | Sentry DSN (`telemetry.sentry_dsn`). Empty disables Sentry entirely. |
 | terminationGracePeriodSeconds | int | `30` | Grace period for pod shutdown. |
 | tolerations | list | `[]` | Tolerations for taints |
 | topologySpreadConstraints | list | `[]` | Pod topology spread constraints for availability |
+| webhook.paths | object | `{}` | Path regex to the methods allowed on it (`webhook.paths`). Patterns are anchored, so `/webhook/.*` matches `/webhook/github` but not `/api/webhook/github`. Methods are `ALL`, `GET`, `POST`, `PUT`, `PATCH` or `DELETE`. Required — a proxy with no allowed path forwards nothing. Example:   "/webhook/.*":     - ALL   "/api/public/.*":     - GET     - POST |
+| webhook.targetBase | string | `""` | The Cloudflare Access protected service every allowed path is joined onto (`webhook.target_base`). Required. |
 
 ## Source Code
 

--- a/charts/cloudflare-access-webhook-redirect/README.md.gotmpl
+++ b/charts/cloudflare-access-webhook-redirect/README.md.gotmpl
@@ -31,15 +31,13 @@ helm install [RELEASE_NAME] timschoenle/{{ template "chart.name" . }} \
 with `values.yaml`:
 
 ```yaml
-application:
-  handler:
-    targetBase: http://backend-service:8080
-    paths:
-      api/webhook:
-        - POST
+webhook:
+  targetBase: http://backend-service:8080
+  paths:
+    "/api/webhook/.*":
+      - POST
 
-  cloudflareAccess:
-    secretName: cloudflare-access-secret
+existingSecret: cloudflare-access-secret
 ```
 
 Upgrade with `helm upgrade [RELEASE_NAME] timschoenle/{{ template "chart.name" . }} -n [NAMESPACE]`,
@@ -47,48 +45,75 @@ remove with `helm uninstall [RELEASE_NAME] -n [NAMESPACE]`.
 
 ## Credentials
 
-Create the Secret yourself and reference it by name. The keys have to be called `client_id`
-and `client_secret`:
+Create the Secret yourself and reference it by name. **The keys are the configuration paths the
+service reads, not free-form names** — the proxy takes the key out of the file name, so
+`cloudflare__client_id` is required and `client_id` is not read at all:
 
 ```shell
-kubectl create secret generic cloudflare-access-secret \
-  --namespace [NAMESPACE] \
-  --from-literal=client_id='...' \
-  --from-literal=client_secret='...'
+kubectl create secret generic cloudflare-access-secret   --namespace [NAMESPACE]   --from-literal=cloudflare__client_id='...'   --from-literal=cloudflare__client_secret='...'
 ```
 
 ```yaml
-application:
-  cloudflareAccess:
-    secretName: cloudflare-access-secret
+existingSecret: cloudflare-access-secret
 ```
 
-`application.cloudflareAccess.clientId` / `.clientSecret` are accepted as an alternative and
-make the chart render the Secret itself. That puts the credentials into `values.yaml` and into
-the Helm release object, where anyone who can run `helm get values` can read them — use it for
-a throwaway cluster, not for anything real. `secretName` wins if both are set.
+`cloudflare.clientId` / `.clientSecret` are accepted as an alternative and make the chart render
+the Secret itself. That puts the credentials into `values.yaml` and into the Helm release
+object, where anyone who can run `helm get values` can read them — use it for a throwaway
+cluster, not for anything real. `existingSecret` wins if both are set.
+
+Either way the credentials arrive as files in a projected volume, which the proxy watches: a
+rotated Secret is picked up in place, with no rollout and no window in which the pod is serving
+on a credential you have already revoked.
+
+## Configuration
+
+Everything the service reads is rendered into one `config.toml`, mounted as a ConfigMap and
+pointed at by `WEBHOOK_REDIRECT_CONFIG`. Nothing is passed as an environment variable, and that
+is deliberate: the loader **fails the boot on a key supplied by both the environment and a
+file** rather than resolving it by precedence, and a value that lives in a file is one the
+kubelet can rotate under a running process.
+
+The values above cover the whole documented surface. `config` takes the raw TOML tree for
+anything they do not, merged over the derived one:
+
+```yaml
+config:
+  server:
+    host: 127.0.0.1
+```
+
+and `configExtraToml` is appended verbatim for what the renderer cannot express, notably arrays
+of tables.
+
+Because the proxy rebuilds its client, path patterns, credentials and listener in place when a
+mount changes, this chart publishes **no `checksum/*` pod annotations by default** — a
+configuration change reloads rather than rolls. Set `configMount.rolloutOnChange: true` to make
+it behave like an ordinary image bump instead. `telemetry.*` is installed once per process and
+needs a restart either way.
 
 ## Declaring what gets forwarded
 
-`application.handler.paths` is an allowlist, keyed by path, valued by the methods permitted on
+`webhook.paths` is an allowlist, keyed by a path **regex**, valued by the methods permitted on
 it. Nothing outside it is proxied, so a backend endpoint you did not list stays unreachable
 through this service even though `targetBase` points at the same host.
 
+Patterns are anchored: `/webhook/.*` matches `/webhook/github` but not `/api/webhook/github`.
+
 ```yaml
-application:
-  handler:
-    targetBase: http://backend-service:8080
-    paths:
-      api/webhook:      # every method
-        - ALL
-      api/data:         # reads and writes
-        - GET
-        - POST
-      health:           # reads only
-        - GET
+webhook:
+  targetBase: http://backend-service:8080
+  paths:
+    "/api/webhook/.*":   # every method
+      - ALL
+    "/api/data/.*":      # reads and writes
+      - GET
+      - POST
+    "/health":           # reads only
+      - GET
 ```
 
-Methods: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`, `OPTIONS`, or `ALL`.
+Methods: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, or `ALL`.
 
 Keep the list as narrow as the caller actually needs. `ALL` on a path that only ever receives
 webhooks also exposes `DELETE` on it.
@@ -96,8 +121,8 @@ webhooks also exposes `DELETE` on it.
 ## Request flow
 
 1. A client reaches the service, usually through an Ingress.
-2. The path and method are checked against `application.handler.paths`; anything not declared
-   is rejected here.
+2. The path and method are checked against `webhook.paths`; anything not declared is rejected
+   here.
 3. The request is authenticated with the Cloudflare Access Service Auth credentials.
 4. It is forwarded to `targetBase`, and the backend's response is returned unchanged.
 
@@ -184,6 +209,41 @@ networkPolicy:
 Every rule you add must carry its own `to:`. A rule that lists only `ports:` is not a
 restriction — the NetworkPolicy API reads a missing `to` as *any destination*, which includes
 the cloud instance metadata endpoint at `169.254.169.254`.
+
+## Upgrading
+
+### 3.x to 4.0
+
+Chart 4.0 tracks the service's 1.0 release, which replaced its environment-only configuration
+with the layered, file-first loader every chart in this repository now uses. The values that
+described that environment are gone; a `helm upgrade` with 3.x values fails schema validation
+naming the offending key rather than starting a pod on the defaults.
+
+| Before | After |
+|---|---|
+| `application.server.host` | `server.host` |
+| `application.server.port` | `server.port` |
+| `application.handler.targetBase` | `webhook.targetBase` |
+| `application.handler.paths` | `webhook.paths` |
+| `application.logLevel` | `telemetry.logLevel` |
+| `application.sentryDsn` | `telemetry.sentryDsn` |
+| `application.cloudflareAccess.clientId` | `cloudflare.clientId` |
+| `application.cloudflareAccess.clientSecret` | `cloudflare.clientSecret` |
+| `application.cloudflareAccess.secretName` | `existingSecret` |
+
+Two changes need work beyond a rename:
+
+**Path keys are regexes and are anchored.** `api/webhook` matched a prefix before; write
+`"/api/webhook/.*"` for the same reach, and quote it — it is no longer a bare key.
+
+**An existing Secret has to be re-keyed.** The proxy reads each credential out of the *file
+name*, so the keys are now `cloudflare__client_id` and `cloudflare__client_secret`. A Secret
+still holding `client_id` / `client_secret` mounts cleanly and supplies nothing, and the proxy
+refuses to boot naming the missing credential.
+
+```shell
+kubectl create secret generic cloudflare-access-secret   --namespace [NAMESPACE]   --from-literal=cloudflare__client_id="$(kubectl get secret cloudflare-access-secret -n [NAMESPACE] -o jsonpath='{.data.client_id}' | base64 -d)"   --from-literal=cloudflare__client_secret="$(kubectl get secret cloudflare-access-secret -n [NAMESPACE] -o jsonpath='{.data.client_secret}' | base64 -d)"   --dry-run=client -o yaml | kubectl apply -f -
+```
 
 {{ template "chart.valuesSection" . }}
 

--- a/charts/cloudflare-access-webhook-redirect/ci/networkpolicy-values.yaml
+++ b/charts/cloudflare-access-webhook-redirect/ci/networkpolicy-values.yaml
@@ -1,12 +1,12 @@
-application:
-  handler:
-    targetBase: "https://test.google.com"
-    paths:
-      api/webhook:
-        - ALL
-  cloudflareAccess:
-    clientId: "testId"
-    clientSecret: "testSecret"
+webhook:
+  targetBase: "https://test.google.com"
+  paths:
+    "/api/webhook/.*":
+      - ALL
+
+cloudflare:
+  clientId: "testId"
+  clientSecret: "testSecret"
 
 networkPolicy:
   enabled: true

--- a/charts/cloudflare-access-webhook-redirect/ci/no-ingress-values.yaml
+++ b/charts/cloudflare-access-webhook-redirect/ci/no-ingress-values.yaml
@@ -1,13 +1,12 @@
-application:
-  handler:
-    targetBase: "https://test.google.com"
-    paths:
-      api/webhook:
-        - ALL
+webhook:
+  targetBase: "https://test.google.com"
+  paths:
+    "/api/webhook/.*":
+      - ALL
 
-  cloudflareAccess:
-    clientId: "testId"
-    clientSecret: "testSecret"
+cloudflare:
+  clientId: "testId"
+  clientSecret: "testSecret"
 
 ingress:
   enabled: false

--- a/charts/cloudflare-access-webhook-redirect/ci/scaling-values.yaml
+++ b/charts/cloudflare-access-webhook-redirect/ci/scaling-values.yaml
@@ -1,12 +1,12 @@
-application:
-  handler:
-    targetBase: "https://test.google.com"
-    paths:
-      api/webhook:
-        - ALL
-  cloudflareAccess:
-    clientId: "testId"
-    clientSecret: "testSecret"
+webhook:
+  targetBase: "https://test.google.com"
+  paths:
+    "/api/webhook/.*":
+      - ALL
+
+cloudflare:
+  clientId: "testId"
+  clientSecret: "testSecret"
 
 replicaCount: 2
 

--- a/charts/cloudflare-access-webhook-redirect/ci/test-values.yaml
+++ b/charts/cloudflare-access-webhook-redirect/ci/test-values.yaml
@@ -1,16 +1,15 @@
-application:
-  handler:
-    targetBase: "https://test.google.com"
-    paths:
-      api/webhook:
-        - ALL
-      api/webhook2:
-        - GET
-        - POST
+webhook:
+  targetBase: "https://test.google.com"
+  paths:
+    "/api/webhook/.*":
+      - ALL
+    "/api/webhook2/.*":
+      - GET
+      - POST
 
-  cloudflareAccess:
-    clientId: "testId"
-    clientSecret: "testSecret"
+cloudflare:
+  clientId: "testId"
+  clientSecret: "testSecret"
 
 ingress:
   enabled: true

--- a/charts/cloudflare-access-webhook-redirect/templates/_helpers.tpl
+++ b/charts/cloudflare-access-webhook-redirect/templates/_helpers.tpl
@@ -1,10 +1,102 @@
 {{/*
-Create the name of the secret to use
+The configuration the chart derives from its own first-class values, as the TOML tree the
+service reads.
+
+Optional keys are omitted rather than written empty: an empty `telemetry.sentry_dsn` is a
+*supplied* value to the loader, and "Sentry configured with a blank DSN" is not what an
+operator who left it unset meant.
 */}}
-{{- define "cloudflare-access-webhook-redirect.access-secretName" -}}
-{{- if .Values.application.cloudflareAccess.secretName }}
-{{- .Values.application.cloudflareAccess.secretName }}
-{{- else }}
-{{- include "common.fullname" . }}
+{{- define "cloudflare-access-webhook-redirect.derivedConfig" -}}
+server:
+  host: {{ .Values.server.host | quote }}
+  port: {{ .Values.server.port }}
+telemetry:
+  log_level: {{ .Values.telemetry.logLevel | quote }}
+  {{- with .Values.telemetry.sentryDsn }}
+  sentry_dsn: {{ . | quote }}
+  {{- end }}
+{{- if or .Values.webhook.targetBase .Values.webhook.paths }}
+webhook:
+  {{- with .Values.webhook.targetBase }}
+  target_base: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.webhook.paths }}
+  paths:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}
-{{- end }}
+{{- end -}}
+
+{{/*
+The configuration that actually reaches the service: the derived tree with the operator's own
+`config` tree merged over it, so `config` can both extend and override the values above.
+
+Not included: `configExtraToml`, which is appended verbatim and never parsed.
+*/}}
+{{- define "cloudflare-access-webhook-redirect.effectiveConfig" -}}
+{{- $derived := include "cloudflare-access-webhook-redirect.derivedConfig" . | fromYaml -}}
+{{- toYaml (mergeOverwrite $derived (deepCopy (.Values.config | default dict))) -}}
+{{- end -}}
+
+{{/*
+The complete `config.toml`: the effective tree, then the verbatim escape hatch.
+*/}}
+{{- define "cloudflare-access-webhook-redirect.configToml" -}}
+{{- $config := include "cloudflare-access-webhook-redirect.effectiveConfig" . | fromYaml -}}
+{{- include "common.configToml" (dict "ctx" . "maps" (list $config)) -}}
+{{- end -}}
+
+{{/*
+Refuse a render that could only produce a proxy which forwards nothing.
+
+Checked against the *effective* tree rather than against `.Values.webhook`, so supplying either
+key through `config` is as valid as supplying it through the first-class value. `configExtraToml`
+is appended verbatim and never parsed, so a chart that has one steps out of the way rather than
+rejecting a configuration it cannot see.
+*/}}
+{{- define "cloudflare-access-webhook-redirect.validateValues" -}}
+{{- if not .Values.configExtraToml -}}
+{{- $config := include "cloudflare-access-webhook-redirect.effectiveConfig" . | fromYaml -}}
+{{- $messages := list -}}
+{{- if not ($config | dig "webhook" "target_base" "") -}}
+{{- $messages = append $messages "  - webhook.targetBase is required but was not set" -}}
+{{- end -}}
+{{- if not ($config | dig "webhook" "paths" dict) -}}
+{{- $messages = append $messages "  - webhook.paths is required but was not set: a proxy with no allowed path forwards nothing" -}}
+{{- end -}}
+{{- if $messages -}}
+{{- fail (printf "\n\nVALUES VALIDATION FAILED for chart %q:\n%s\n" .Chart.Name (join "\n" $messages)) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+The credentials this chart manages, keyed by the file name the loader reads them from: a
+configuration path with `__` for nesting and no dots, because a `.` in the name is refused
+rather than treated as a separator.
+*/}}
+{{- define "cloudflare-access-webhook-redirect.secretData" -}}
+cloudflare__client_id: {{ .Values.cloudflare.clientId | quote }}
+cloudflare__client_secret: {{ .Values.cloudflare.clientSecret | quote }}
+{{- end -}}
+
+{{/*
+The secret file names this pod projects, as a YAML list. Parse with `fromYamlArray`.
+*/}}
+{{- define "cloudflare-access-webhook-redirect.secretKeys" -}}
+{{- $data := include "cloudflare-access-webhook-redirect.secretData" . | fromYaml -}}
+{{- include "common.fileConfig.secretKeys" (dict "ctx" . "data" $data) -}}
+{{- end -}}
+
+{{/*
+The pod template annotations.
+
+Deliberately without the `checksum/*` annotations the other charts in this repository use by
+default: the proxy watches its configuration and secrets directories and rebuilds itself when
+the kubelet refreshes either mount, so rolling the Deployment on a configuration change would
+throw that property away. `configMount.rolloutOnChange` restores the conventional behaviour.
+*/}}
+{{- define "cloudflare-access-webhook-redirect.podAnnotations" -}}
+{{- $templates := ternary (list "configmap.yaml" "secret.yaml") (list) .Values.configMount.rolloutOnChange -}}
+{{- include "common.podAnnotations" (dict "ctx" . "templates" $templates) -}}
+{{- end -}}

--- a/charts/cloudflare-access-webhook-redirect/templates/configmap.yaml
+++ b/charts/cloudflare-access-webhook-redirect/templates/configmap.yaml
@@ -1,8 +1,4 @@
-{{- include "common.validateValues" (dict "ctx" $ "required" (list
-     "application.server.host"
-     "application.server.port"
-     "application.handler.targetBase"
-   )) }}
+{{- include "cloudflare-access-webhook-redirect.validateValues" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -15,24 +11,12 @@ metadata:
     {{- . | nindent 4 }}
   {{- end }}
 data:
-  SERVER.HOST: {{ .Values.application.server.host | quote }}
-  SERVER.PORT: {{ .Values.application.server.port | quote }}
-  WEBHOOK.TARGET_BASE: {{ .Values.application.handler.targetBase | quote }}
-  WEBHOOK.PATHS: {{ include "config.paths" . }}
-  LOG_LEVEL: {{ .Values.application.logLevel | quote }}
-  {{- with .Values.application.sentryDsn }}
-  SENTRY_DSN: {{ . | quote }}
-  {{- end }}
-
-
-{{/*
-Convert path values to the correct format
-Example: api/webhook:ALL; test:GET,POST
-*/}}
-{{- define "config.paths" -}}
-{{- $list := list -}}
-{{- range $k, $v := .Values.application.handler.paths -}}
-{{- $list = append $list (printf "%s:%s" $k (join "," $v)) -}}
-{{- end -}}
-{{ join "; " $list }}
-{{- end -}}
+  {{- /*
+    One file rather than a set of fragments. The loader does merge every `*.toml` in the
+    directory, but relying on that would put the precedence of one value against another inside
+    a merge this chart does not own or test. Merging in the template instead makes the effective
+    configuration readable with `kubectl get configmap -o yaml`, which is what an operator wants
+    to look at when a reload did not do what they expected.
+  */}}
+  config.toml: |
+    {{- include "cloudflare-access-webhook-redirect.configToml" . | nindent 4 }}

--- a/charts/cloudflare-access-webhook-redirect/templates/deployment.yaml
+++ b/charts/cloudflare-access-webhook-redirect/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       {{- include "common.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with (include "common.podAnnotations" (dict "ctx" $ "templates" (list "configmap.yaml" "secret.yaml"))) }}
+      {{- with (include "cloudflare-access-webhook-redirect.podAnnotations" .) }}
       annotations:
         {{- . | nindent 8 }}
       {{- end }}
@@ -32,17 +32,20 @@ spec:
     spec:
       {{- include "common.podSpec.common" . | nindent 6 }}
       containers:
-        {{- $secret := include "cloudflare-access-webhook-redirect.access-secretName" . }}
+        {{- /*
+          Configuration reaches the container as files, never as environment variables: the
+          loader fails the boot on a key supplied by both, and only a file can be rotated under
+          a running process. The two variables below decide what the file layers *are*, so they
+          are the one thing that cannot itself be file-sourced.
+        */}}
+        {{- $secretKeys := include "cloudflare-access-webhook-redirect.secretKeys" . | fromYamlArray }}
         {{- include "common.container" (dict
               "ctx" $
-              "ports" (list (dict "name" "http" "containerPort" (int .Values.application.server.port) "protocol" "TCP"))
-              "envFrom" (list (dict "configMapRef" (dict "name" (include "common.fullname" .))))
-              "env" (list
-                (dict "name" "CLOUDFLARE.CLIENT_ID" "valueFrom" (dict "secretKeyRef" (dict "name" $secret "key" "client_id")))
-                (dict "name" "CLOUDFLARE.CLIENT_SECRET" "valueFrom" (dict "secretKeyRef" (dict "name" $secret "key" "client_secret")))
-              )
+              "ports" (list (dict "name" "http" "containerPort" (int .Values.server.port) "protocol" "TCP"))
+              "env" (include "common.fileConfig.env" (dict "ctx" $ "prefix" "WEBHOOK_REDIRECT" "secretKeys" $secretKeys) | fromYamlArray)
+              "volumeMounts" (include "common.fileConfig.volumeMounts" (dict "ctx" $ "secretKeys" $secretKeys) | fromYamlArray)
             ) | nindent 8 }}
-      {{- with (include "common.volumes" (dict "ctx" $)) }}
+      {{- with (include "common.volumes" (dict "ctx" $ "volumes" (include "common.fileConfig.volumes" (dict "ctx" $ "secretKeys" $secretKeys) | fromYamlArray))) }}
       volumes:
         {{- . | nindent 8 }}
       {{- end }}

--- a/charts/cloudflare-access-webhook-redirect/templates/secret.yaml
+++ b/charts/cloudflare-access-webhook-redirect/templates/secret.yaml
@@ -1,4 +1,5 @@
-{{- if and (not .Values.application.cloudflareAccess.secretName) .Values.application.cloudflareAccess.clientId .Values.application.cloudflareAccess.clientSecret }}
+{{- $data := include "cloudflare-access-webhook-redirect.secretData" . | fromYaml }}
+{{- if (include "common.fileConfig.createSecret" (dict "ctx" . "data" $data)) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,6 +13,11 @@ metadata:
   {{- end }}
 type: Opaque
 stringData:
-  client_id: {{ .Values.application.cloudflareAccess.clientId | quote }}
-  client_secret: {{ .Values.application.cloudflareAccess.clientSecret | quote }}
+  {{- /*
+    Key names are configuration paths with `__` for nesting and no dots, because that is how a
+    file in `WEBHOOK_REDIRECT_SECRETS_DIR` has to be named — the loader reads the key out of the
+    file *name*. Rendered as `stringData` so the values stay readable in a diff review;
+    Kubernetes stores them base64-encoded either way.
+  */}}
+  {{- include "common.fileConfig.secretData" (dict "data" $data) | nindent 2 }}
 {{- end }}

--- a/charts/cloudflare-access-webhook-redirect/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/cloudflare-access-webhook-redirect/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2,11 +2,19 @@ matches the committed Deployment snapshot:
   1: |
     apiVersion: v1
     data:
-      LOG_LEVEL: info
-      SERVER.HOST: 0.0.0.0
-      SERVER.PORT: "8080"
-      WEBHOOK.PATHS: null
-      WEBHOOK.TARGET_BASE: https://example.invalid
+      config.toml: |
+        [server]
+        host = "0.0.0.0"
+        port = 8080
+
+        [telemetry]
+        log_level = "info"
+
+        [webhook]
+        target_base = "https://example.invalid"
+
+        [webhook.paths]
+        "/api/webhook/.*" = ["ALL"]
     kind: ConfigMap
     metadata:
       labels:
@@ -38,8 +46,6 @@ matches the committed Deployment snapshot:
           app.kubernetes.io/name: cloudflare-access-webhook-redirect
       template:
         metadata:
-          annotations:
-            checksum/configmap: ef5f72b54178ba13ca6d4e482b2ad65d79e79456740a8345f125088f47777d13
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -49,19 +55,8 @@ matches the committed Deployment snapshot:
           automountServiceAccountToken: false
           containers:
             - env:
-                - name: CLOUDFLARE.CLIENT_ID
-                  valueFrom:
-                    secretKeyRef:
-                      key: client_id
-                      name: RELEASE-NAME-cloudflare-access-webhook-redirect
-                - name: CLOUDFLARE.CLIENT_SECRET
-                  valueFrom:
-                    secretKeyRef:
-                      key: client_secret
-                      name: RELEASE-NAME-cloudflare-access-webhook-redirect
-              envFrom:
-                - configMapRef:
-                    name: RELEASE-NAME-cloudflare-access-webhook-redirect
+                - name: WEBHOOK_REDIRECT_CONFIG
+                  value: /etc/cloudflare-access-webhook-redirect/config
               image: timmi6790/cloudflare-access-webhook-redirect:v0.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -111,6 +106,9 @@ matches the committed Deployment snapshot:
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp
+                - mountPath: /etc/cloudflare-access-webhook-redirect/config
+                  name: config
+                  readOnly: true
           securityContext:
             fsGroup: 10001
             fsGroupChangePolicy: OnRootMismatch
@@ -124,15 +122,26 @@ matches the committed Deployment snapshot:
           volumes:
             - emptyDir: {}
               name: tmp
+            - configMap:
+                name: RELEASE-NAME-cloudflare-access-webhook-redirect
+              name: config
 matches the committed Deployment snapshot with network policies and probes on:
   1: |
     apiVersion: v1
     data:
-      LOG_LEVEL: info
-      SERVER.HOST: 0.0.0.0
-      SERVER.PORT: "8080"
-      WEBHOOK.PATHS: null
-      WEBHOOK.TARGET_BASE: https://example.invalid
+      config.toml: |
+        [server]
+        host = "0.0.0.0"
+        port = 8080
+
+        [telemetry]
+        log_level = "info"
+
+        [webhook]
+        target_base = "https://example.invalid"
+
+        [webhook.paths]
+        "/api/webhook/.*" = ["ALL"]
     kind: ConfigMap
     metadata:
       labels:
@@ -164,8 +173,6 @@ matches the committed Deployment snapshot with network policies and probes on:
           app.kubernetes.io/name: cloudflare-access-webhook-redirect
       template:
         metadata:
-          annotations:
-            checksum/configmap: ef5f72b54178ba13ca6d4e482b2ad65d79e79456740a8345f125088f47777d13
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -185,19 +192,8 @@ matches the committed Deployment snapshot with network policies and probes on:
           automountServiceAccountToken: false
           containers:
             - env:
-                - name: CLOUDFLARE.CLIENT_ID
-                  valueFrom:
-                    secretKeyRef:
-                      key: client_id
-                      name: RELEASE-NAME-cloudflare-access-webhook-redirect
-                - name: CLOUDFLARE.CLIENT_SECRET
-                  valueFrom:
-                    secretKeyRef:
-                      key: client_secret
-                      name: RELEASE-NAME-cloudflare-access-webhook-redirect
-              envFrom:
-                - configMapRef:
-                    name: RELEASE-NAME-cloudflare-access-webhook-redirect
+                - name: WEBHOOK_REDIRECT_CONFIG
+                  value: /etc/cloudflare-access-webhook-redirect/config
               image: timmi6790/cloudflare-access-webhook-redirect:v0.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -247,6 +243,9 @@ matches the committed Deployment snapshot with network policies and probes on:
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp
+                - mountPath: /etc/cloudflare-access-webhook-redirect/config
+                  name: config
+                  readOnly: true
           nodeSelector:
             kubernetes.io/os: linux
           securityContext:
@@ -262,3 +261,6 @@ matches the committed Deployment snapshot with network policies and probes on:
           volumes:
             - emptyDir: {}
               name: tmp
+            - configMap:
+                name: RELEASE-NAME-cloudflare-access-webhook-redirect
+              name: config

--- a/charts/cloudflare-access-webhook-redirect/tests/checksum_test.yaml
+++ b/charts/cloudflare-access-webhook-redirect/tests/checksum_test.yaml
@@ -1,19 +1,40 @@
 suite: config checksums
-# Guards `common.configChecksum`. The checksum exists to roll pods when mounted configuration
-# changes, so it must react to `data`/`stringData` and to nothing else. Hashing the rendered
-# manifest instead — the previous behaviour — made every chart version bump and every label
-# change roll every pod, which trains people to ignore the rollout entirely.
+# Guards `common.configChecksum` and the chart's decision not to use it by default.
+#
+# The proxy watches its configuration and secrets directories and rebuilds itself in place, so
+# rolling the Deployment on every configuration change would throw that property away. The
+# checksums are therefore opt-in — and when they are on they must react to `data`/`stringData`
+# and to nothing else. Hashing the rendered manifest instead made every chart version bump and
+# every label change roll every pod, which trains people to ignore the rollout entirely.
 templates:
   - deployment.yaml
   - configmap.yaml
   - secret.yaml
 set:
-  application.handler.targetBase: https://example.invalid
+  webhook.targetBase: https://example.invalid
+  webhook.paths:
+    "/api/webhook/.*":
+      - ALL
 tests:
+  - it: publishes no checksum by default, so a config change reloads instead of rolling
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      cloudflare.clientId: some-client-id
+      cloudflare.clientSecret: some-client-secret
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations["checksum/configmap"]
+      - notExists:
+          path: spec.template.metadata.annotations["checksum/secret"]
+
   - it: omits the checksum for a Secret that does not render
     documentSelector:
       path: kind
       value: Deployment
+    set:
+      configMount.rolloutOnChange: true
     asserts:
       - exists:
           path: spec.template.metadata.annotations["checksum/configmap"]
@@ -25,8 +46,9 @@ tests:
       path: kind
       value: Deployment
     set:
-      application.cloudflareAccess.clientId: some-client-id
-      application.cloudflareAccess.clientSecret: some-client-secret
+      configMount.rolloutOnChange: true
+      cloudflare.clientId: some-client-id
+      cloudflare.clientSecret: some-client-secret
     asserts:
       - exists:
           path: spec.template.metadata.annotations["checksum/secret"]
@@ -35,16 +57,19 @@ tests:
     documentSelector:
       path: kind
       value: Deployment
+    set:
+      configMount.rolloutOnChange: true
     asserts:
       - equal:
           path: spec.template.metadata.annotations["checksum/configmap"]
-          value: ef5f72b54178ba13ca6d4e482b2ad65d79e79456740a8345f125088f47777d13
+          value: 47f88d7e467a38d9d7769515e58f7c82eba11e741f22624008c74afaa3e45713
 
   - it: holds the checksum steady across manifest metadata that pods do not mount
     documentSelector:
       path: kind
       value: Deployment
     set:
+      configMount.rolloutOnChange: true
       commonAnnotations:
         example.invalid/owner: platform
       commonLabels:
@@ -52,15 +77,16 @@ tests:
     asserts:
       - equal:
           path: spec.template.metadata.annotations["checksum/configmap"]
-          value: ef5f72b54178ba13ca6d4e482b2ad65d79e79456740a8345f125088f47777d13
+          value: 47f88d7e467a38d9d7769515e58f7c82eba11e741f22624008c74afaa3e45713
 
   - it: moves the checksum when mounted configuration actually changes
     documentSelector:
       path: kind
       value: Deployment
     set:
-      application.logLevel: debug
+      configMount.rolloutOnChange: true
+      telemetry.logLevel: debug
     asserts:
       - notEqual:
           path: spec.template.metadata.annotations["checksum/configmap"]
-          value: ef5f72b54178ba13ca6d4e482b2ad65d79e79456740a8345f125088f47777d13
+          value: 47f88d7e467a38d9d7769515e58f7c82eba11e741f22624008c74afaa3e45713

--- a/charts/cloudflare-access-webhook-redirect/tests/configmap_test.yaml
+++ b/charts/cloudflare-access-webhook-redirect/tests/configmap_test.yaml
@@ -2,43 +2,123 @@ suite: configmap
 templates:
   - configmap.yaml
 set:
-  application.handler.targetBase: https://example.invalid
+  webhook.targetBase: https://example.invalid
+  webhook.paths:
+    "/api/webhook/.*":
+      - ALL
 tests:
-  - it: carries the server and webhook configuration
+  - it: renders the configuration as a single TOML file
     asserts:
       - isKind:
           of: ConfigMap
-      - equal:
-          path: data["SERVER.PORT"]
-          value: "8080"
-      - equal:
-          path: data["WEBHOOK.TARGET_BASE"]
-          value: https://example.invalid
-      - equal:
-          path: data.LOG_LEVEL
-          value: info
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[server\]\nhost = "0\.0\.0\.0"\nport = 8080'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[telemetry\]\nlog_level = "info"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'target_base = "https://example\.invalid"'
 
-  - it: flattens webhook paths into the expected wire format
+  # A path pattern is not a TOML bare key. Emitted unquoted it would not parse, and the
+  # service would fail the boot on a file the chart wrote.
+  - it: quotes path patterns, which are not bare TOML keys
     set:
-      application.handler.paths:
-        api/webhook:
+      webhook.paths:
+        "/api/webhook/.*":
           - ALL
-        test:
+        "/public/.*":
           - GET
           - POST
     asserts:
-      - equal:
-          path: data["WEBHOOK.PATHS"]
-          value: "api/webhook:ALL; test:GET,POST"
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[webhook\.paths\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '"/api/webhook/\.\*" = \["ALL"\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '"/public/\.\*" = \["GET","POST"\]'
 
-  # One pass reports everything that is missing, rather than one `required` failure per
-  # render.
+  # An empty optional value is still a *supplied* value to the loader, and "Sentry configured
+  # with a blank DSN" is not what leaving it unset meant.
+  - it: omits an unset Sentry DSN rather than writing it empty
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'sentry_dsn'
+
+  - it: writes the Sentry DSN once it is set
+    set:
+      telemetry.sentryDsn: https://key@sentry.example.invalid/1
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'sentry_dsn = "https://key@sentry\.example\.invalid/1"'
+
+  - it: merges the raw config tree over the derived values
+    set:
+      config:
+        server:
+          host: 127.0.0.1
+        extra:
+          knob: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'host = "127\.0\.0\.1"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[extra\]\nknob = true'
+
+  - it: appends configExtraToml verbatim
+    set:
+      configExtraToml: |
+        [[webhook.rewrite]]
+        from = "/a"
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[\[webhook\.rewrite\]\]\nfrom = "/a"'
+
+  # One pass reports everything that is missing, rather than one `required` failure per render.
   - it: reports every missing required value at once
     set:
-      application.handler.targetBase: ""
-      application.server.host: ""
+      webhook.targetBase: ""
+      webhook.paths: null
     asserts:
       - failedTemplate:
-          errorPattern: "application.server.host is required but was not set"
+          errorPattern: "webhook.targetBase is required but was not set"
       - failedTemplate:
-          errorPattern: "application.handler.targetBase is required but was not set"
+          errorPattern: "webhook.paths is required but was not set"
+
+  # Validation reads the effective tree, so supplying a required key through `config` is as
+  # valid as supplying it through the first-class value.
+  - it: accepts a required value supplied through the raw config tree
+    set:
+      webhook.targetBase: ""
+      webhook.paths: null
+      config:
+        webhook:
+          target_base: https://example.invalid
+          paths:
+            "/hook/.*":
+              - ALL
+    asserts:
+      - isKind:
+          of: ConfigMap
+
+  # `configExtraToml` is appended verbatim and never parsed, so the chart cannot see what it
+  # supplies and must not reject a configuration on the strength of what it cannot read.
+  - it: steps out of the way when verbatim TOML is in play
+    set:
+      webhook.targetBase: ""
+      webhook.paths: null
+      configExtraToml: |
+        [webhook]
+        target_base = "https://example.invalid"
+    asserts:
+      - isKind:
+          of: ConfigMap

--- a/charts/cloudflare-access-webhook-redirect/tests/deployment_test.yaml
+++ b/charts/cloudflare-access-webhook-redirect/tests/deployment_test.yaml
@@ -4,7 +4,10 @@ templates:
   - configmap.yaml
   - secret.yaml
 set:
-  application.handler.targetBase: https://example.invalid
+  webhook.targetBase: https://example.invalid
+  webhook.paths:
+    "/api/webhook/.*":
+      - ALL
 tests:
   - it: creates a Deployment named after the release
     documentSelector:
@@ -22,7 +25,7 @@ tests:
       path: kind
       value: Deployment
     set:
-      application.server.port: 9090
+      server.port: 9090
     asserts:
       - equal:
           path: spec.template.spec.containers[0].ports
@@ -31,70 +34,118 @@ tests:
               name: http
               protocol: TCP
 
-  - it: reads Cloudflare Access credentials from the generated Secret
-    documentSelector:
-      path: kind
-      value: Deployment
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: CLOUDFLARE.CLIENT_ID
-            valueFrom:
-              secretKeyRef:
-                name: RELEASE-NAME-cloudflare-access-webhook-redirect
-                key: client_id
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: CLOUDFLARE.CLIENT_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: RELEASE-NAME-cloudflare-access-webhook-redirect
-                key: client_secret
-
-  - it: reads them from an existing Secret when one is given
+  # The whole point of the migration: the loader refuses a key supplied by both the environment
+  # and a file, and only a file can be rotated under a running process. The only variables left
+  # are the two that decide what the file layers are.
+  - it: passes configuration as files, not as environment
     documentSelector:
       path: kind
       value: Deployment
     set:
-      application.cloudflareAccess.secretName: my-access-secret
+      cloudflare.clientId: test-id
+      cloudflare.clientSecret: test-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env
+          value:
+            - name: WEBHOOK_REDIRECT_CONFIG
+              value: /etc/cloudflare-access-webhook-redirect/config
+            - name: WEBHOOK_REDIRECT_SECRETS_DIR
+              value: /etc/cloudflare-access-webhook-redirect/secrets
+      - notExists:
+          path: spec.template.spec.containers[0].envFrom
+
+  - it: mounts the rendered configuration read-only
+    documentSelector:
+      path: kind
+      value: Deployment
     asserts:
       - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+            configMap:
+              name: RELEASE-NAME-cloudflare-access-webhook-redirect
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /etc/cloudflare-access-webhook-redirect/config
+            readOnly: true
+
+  # A projected volume, so the kubelet keeps it up to date in place and the proxy — which
+  # follows the `..data` symlink — sees a rotated credential without a restart.
+  - it: projects the credentials the service reads by file name
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      cloudflare.clientId: test-id
+      cloudflare.clientSecret: test-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: secrets
+            projected:
+              defaultMode: 256
+              sources:
+                - secret:
+                    name: RELEASE-NAME-cloudflare-access-webhook-redirect
+                    optional: true
+                    items:
+                      - key: cloudflare__client_id
+                        path: cloudflare__client_id
+                      - key: cloudflare__client_secret
+                        path: cloudflare__client_secret
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: secrets
+            mountPath: /etc/cloudflare-access-webhook-redirect/secrets
+            readOnly: true
+
+  - it: projects an existing Secret when one is given
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      existingSecret: my-access-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: secrets
+            projected:
+              defaultMode: 256
+              sources:
+                - secret:
+                    name: my-access-secret
+                    optional: true
+                    items:
+                      - key: cloudflare__client_id
+                        path: cloudflare__client_id
+                      - key: cloudflare__client_secret
+                        path: cloudflare__client_secret
+
+  # A configured secrets directory that cannot be read is a boot failure naming the path, not
+  # an empty layer — so the variable and the mount have to appear and disappear together.
+  - it: names no secrets directory when no credential is configured
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - notContains:
           path: spec.template.spec.containers[0].env
           content:
-            name: CLOUDFLARE.CLIENT_ID
-            valueFrom:
-              secretKeyRef:
-                name: my-access-secret
-                key: client_id
-
-  # The chart used to declare a `config` volume from the ConfigMap that no container ever
-  # mounted; only the /tmp scratch volume should exist.
-  - it: mounts no dead volumes
-    documentSelector:
-      path: kind
-      value: Deployment
-    asserts:
-      - lengthEqual:
-          path: spec.template.spec.volumes
-          count: 1
-      - equal:
-          path: spec.template.spec.volumes[0].name
-          value: tmp
-
-  - it: loads configuration from the ConfigMap and rolls on change
-    documentSelector:
-      path: kind
-      value: Deployment
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].envFrom
+            name: WEBHOOK_REDIRECT_SECRETS_DIR
+            value: /etc/cloudflare-access-webhook-redirect/secrets
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
           content:
-            configMapRef:
-              name: RELEASE-NAME-cloudflare-access-webhook-redirect
-      - exists:
-          path: spec.template.metadata.annotations["checksum/configmap"]
+            name: secrets
+            mountPath: /etc/cloudflare-access-webhook-redirect/secrets
+            readOnly: true
 
   - it: hands replica count to the autoscaler when one is enabled
     documentSelector:

--- a/charts/cloudflare-access-webhook-redirect/tests/ingress_test.yaml
+++ b/charts/cloudflare-access-webhook-redirect/tests/ingress_test.yaml
@@ -2,7 +2,10 @@ suite: ingress
 templates:
   - ingress.yaml
 set:
-  application.handler.targetBase: https://example.invalid
+  webhook.targetBase: https://example.invalid
+  webhook.paths:
+    "/api/webhook/.*":
+      - ALL
 tests:
   - it: creates no Ingress by default
     asserts:

--- a/charts/cloudflare-access-webhook-redirect/tests/secret_test.yaml
+++ b/charts/cloudflare-access-webhook-redirect/tests/secret_test.yaml
@@ -7,10 +7,12 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: creates a Secret from inline credentials
+  # The key names are the configuration paths: the loader reads the key out of the file *name*,
+  # so `client_id` next to `cloudflare__client_id` is not a cosmetic difference.
+  - it: creates a Secret keyed by configuration path
     set:
-      application.cloudflareAccess.clientId: test-id
-      application.cloudflareAccess.clientSecret: test-secret
+      cloudflare.clientId: test-id
+      cloudflare.clientSecret: test-secret
     asserts:
       - isKind:
           of: Secret
@@ -18,17 +20,27 @@ tests:
           path: type
           value: Opaque
       - equal:
-          path: stringData.client_id
+          path: stringData.cloudflare__client_id
           value: test-id
       - equal:
-          path: stringData.client_secret
+          path: stringData.cloudflare__client_secret
           value: test-secret
+
+  - it: omits a credential that was left unset rather than writing an empty file
+    set:
+      cloudflare.clientId: test-id
+    asserts:
+      - equal:
+          path: stringData.cloudflare__client_id
+          value: test-id
+      - notExists:
+          path: stringData.cloudflare__client_secret
 
   - it: creates nothing when an existing Secret is supplied
     set:
-      application.cloudflareAccess.secretName: my-access-secret
-      application.cloudflareAccess.clientId: test-id
-      application.cloudflareAccess.clientSecret: test-secret
+      existingSecret: my-access-secret
+      cloudflare.clientId: test-id
+      cloudflare.clientSecret: test-secret
     asserts:
       - hasDocuments:
           count: 0

--- a/charts/cloudflare-access-webhook-redirect/tests/security_test.yaml
+++ b/charts/cloudflare-access-webhook-redirect/tests/security_test.yaml
@@ -9,7 +9,10 @@ documentSelector:
   path: kind
   value: Deployment
 set:
-  application.handler.targetBase: https://example.invalid
+  webhook.targetBase: https://example.invalid
+  webhook.paths:
+    "/api/webhook/.*":
+      - ALL
 tests:
   - it: satisfies the restricted Pod Security Standard
     documentSelector:

--- a/charts/cloudflare-access-webhook-redirect/tests/service_test.yaml
+++ b/charts/cloudflare-access-webhook-redirect/tests/service_test.yaml
@@ -3,7 +3,10 @@ templates:
   - service.yaml
   - serviceaccount.yaml
 set:
-  application.handler.targetBase: https://example.invalid
+  webhook.targetBase: https://example.invalid
+  webhook.paths:
+    "/api/webhook/.*":
+      - ALL
 tests:
   - it: creates a ClusterIP Service on the configured port
     template: service.yaml

--- a/charts/cloudflare-access-webhook-redirect/tests/snapshot_test.yaml
+++ b/charts/cloudflare-access-webhook-redirect/tests/snapshot_test.yaml
@@ -14,7 +14,10 @@ chart:
   version: 0.0.0
   appVersion: 0.0.0
 set:
-  application.handler.targetBase: https://example.invalid
+  webhook.targetBase: https://example.invalid
+  webhook.paths:
+    "/api/webhook/.*":
+      - ALL
   image.tag: v0.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
 tests:
   - it: matches the committed Deployment snapshot

--- a/charts/cloudflare-access-webhook-redirect/values.schema.json
+++ b/charts/cloudflare-access-webhook-redirect/values.schema.json
@@ -6,93 +6,6 @@
       "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity",
       "required": []
     },
-    "application": {
-      "additionalProperties": true,
-      "properties": {
-        "cloudflareAccess": {
-          "additionalProperties": true,
-          "properties": {
-            "secretName": {
-              "default": "",
-              "description": "Existing secret name containing Cloudflare Access credentials\nMust contain client_id and client_secret keys",
-              "required": [],
-              "title": "secretName",
-              "type": "string"
-            }
-          },
-          "required": [],
-          "title": "cloudflareAccess"
-        },
-        "handler": {
-          "additionalProperties": true,
-          "properties": {
-            "paths": {
-              "additionalProperties": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "description": "Path configurations with allowed HTTP methods\nExample:\n  api/webhook:\n    - ALL\n  test:\n    - GET\n    - POST",
-              "required": [],
-              "title": "paths",
-              "type": "object"
-            },
-            "targetBase": {
-              "default": "",
-              "description": "Base URL for redirect targets",
-              "required": [],
-              "title": "targetBase",
-              "type": "string"
-            }
-          },
-          "required": [],
-          "title": "handler"
-        },
-        "logLevel": {
-          "default": "info",
-          "description": "Application log level",
-          "enum": [
-            "debug",
-            "info",
-            "warn",
-            "error"
-          ],
-          "required": [],
-          "title": "logLevel"
-        },
-        "sentryDsn": {
-          "default": "",
-          "description": "Sentry DSN for error tracking (empty disables)",
-          "required": [],
-          "title": "sentryDsn",
-          "type": "string"
-        },
-        "server": {
-          "additionalProperties": true,
-          "properties": {
-            "host": {
-              "default": "0.0.0.0",
-              "description": "Server bind address",
-              "required": [],
-              "title": "host",
-              "type": "string"
-            },
-            "port": {
-              "default": 8080,
-              "description": "HTTP server port",
-              "required": [],
-              "title": "port",
-              "type": "integer"
-            }
-          },
-          "required": [],
-          "title": "server"
-        }
-      },
-      "required": [],
-      "title": "application"
-    },
     "automountServiceAccountToken": {
       "default": false,
       "description": "Mount the ServiceAccount API token into the pod.\nSet on the pod itself, which is what actually keeps the token out of the container: the\nServiceAccount-level setting is ignored as soon as a pod names a different account.",
@@ -148,6 +61,27 @@
       "required": [],
       "title": "autoscaling"
     },
+    "cloudflare": {
+      "additionalProperties": true,
+      "properties": {
+        "clientId": {
+          "default": "",
+          "description": "Cloudflare Access service token client ID (`cloudflare.client_id`). Rendered into the\nchart's Secret and mounted as a file, so a rotation is picked up without a restart.\nRequired unless `existingSecret` supplies it.",
+          "required": [],
+          "title": "clientId",
+          "type": "string"
+        },
+        "clientSecret": {
+          "default": "",
+          "description": "Cloudflare Access service token client secret (`cloudflare.client_secret`). Required\nunless `existingSecret` supplies it.",
+          "required": [],
+          "title": "clientSecret",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "cloudflare"
+    },
     "common": {
       "description": "Shared template partials for the TimSchoenle Helm charts",
       "properties": {
@@ -183,6 +117,42 @@
           "title": "component",
           "type": "string"
         },
+        "config": {
+          "additionalProperties": true,
+          "description": "Application configuration, expressed as the TOML tree the service documents. Rendered by\n`common.toml` into the ConfigMap the pod mounts, never passed as environment variables: the\nloader every application shares refuses a key supplied by both the environment and a file,\nand a value that lives in a file is one the kubelet can rotate under a running process.",
+          "required": [],
+          "title": "config",
+          "type": "object"
+        },
+        "configExtraToml": {
+          "default": "",
+          "description": "Verbatim TOML appended after the rendered `config` tree. The escape hatch for anything\n`common.toml` cannot express, notably arrays of tables.",
+          "required": [],
+          "title": "configExtraToml",
+          "type": "string"
+        },
+        "configMount": {
+          "additionalProperties": true,
+          "description": "Where the rendered configuration and the credential files land in the container. Consumed\nby `common.fileConfig.*`, which also passes both directories to the application as\n`\u003cPREFIX\u003e_CONFIG` and `\u003cPREFIX\u003e_SECRETS_DIR`.",
+          "properties": {
+            "configDir": {
+              "default": "",
+              "description": "Directory the rendered `config.toml` is mounted at.",
+              "required": [],
+              "title": "configDir",
+              "type": "string"
+            },
+            "secretsDir": {
+              "default": "",
+              "description": "Directory the credential files are mounted at, one file per configuration key.",
+              "required": [],
+              "title": "secretsDir",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "configMount"
+        },
         "dnsConfig": {
           "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodDNSConfig",
           "required": []
@@ -192,6 +162,20 @@
           "description": "Pod DNS policy.",
           "required": [],
           "title": "dnsPolicy",
+          "type": "string"
+        },
+        "existingConfigMap": {
+          "default": "",
+          "description": "Name of an existing ConfigMap holding `config.toml`, replacing the one this chart renders.",
+          "required": [],
+          "title": "existingConfigMap",
+          "type": "string"
+        },
+        "existingSecret": {
+          "default": "",
+          "description": "Name of an existing Secret holding the credential files, replacing the one this chart\nrenders. Its keys must be the configuration paths the service reads, with `__` for nesting\nand no dots — that is the file name the loader parses.",
+          "required": [],
+          "title": "existingSecret",
           "type": "string"
         },
         "extraEnv": {
@@ -959,6 +943,55 @@
       "title": "commonLabels",
       "type": "object"
     },
+    "config": {
+      "additionalProperties": true,
+      "description": "Extra configuration, expressed as the TOML tree of\n[the service's README](https://github.com/TimSchoenle/cloudflare-access-webhook-redirect#-configuration)\n(`server.host`, `webhook.target_base`, ...). Merged over everything the chart derives from\nthe values above, so it can both extend and override them. Rendered into the mounted\nConfigMap — never into the environment, which the loader refuses to combine with a file.",
+      "required": [],
+      "title": "config",
+      "type": "object"
+    },
+    "configExtraToml": {
+      "default": "",
+      "description": "Verbatim TOML appended after the rendered configuration. The escape hatch for anything the\nchart's TOML renderer cannot express, notably arrays of tables.",
+      "required": [],
+      "title": "configExtraToml",
+      "type": "string"
+    },
+    "configMount": {
+      "additionalProperties": true,
+      "properties": {
+        "configDir": {
+          "default": "/etc/cloudflare-access-webhook-redirect/config",
+          "description": "Directory the rendered `config.toml` is mounted at, passed as `WEBHOOK_REDIRECT_CONFIG`.",
+          "required": [],
+          "title": "configDir",
+          "type": "string"
+        },
+        "rolloutOnChange": {
+          "default": false,
+          "description": "Add `checksum/*` pod annotations so a configuration change rolls the Deployment. Off by\ndefault, and deliberately so: the proxy watches the directories its configuration came from\nand rebuilds its client, path patterns, credentials and listener in place when the kubelet\nupdates the mounted ConfigMap or Secret, which is strictly better than a rollout. Turn this\non only if you want configuration changes to behave like an ordinary image bump.\n`telemetry.*` is installed once per process and needs a restart either way.",
+          "required": [],
+          "title": "rolloutOnChange",
+          "type": "boolean"
+        },
+        "secretsDir": {
+          "default": "/etc/cloudflare-access-webhook-redirect/secrets",
+          "description": "Directory the credential files are mounted at, passed as\n`WEBHOOK_REDIRECT_SECRETS_DIR`.",
+          "required": [],
+          "title": "secretsDir",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "configMount"
+    },
+    "existingSecret": {
+      "default": "",
+      "description": "Name of an existing Secret holding the Cloudflare Access credentials, which keeps them out\nof `values.yaml` and out of the Helm release object. **Its keys are the configuration paths,\nnot free-form names**: `cloudflare__client_id` and `cloudflare__client_secret`, because the\nfile name is what the loader parses. Set, the chart renders no Secret of its own and\n`cloudflare.clientId` / `cloudflare.clientSecret` are ignored.",
+      "required": [],
+      "title": "existingSecret",
+      "type": "string"
+    },
     "extraEnv": {
       "description": "Additional environment variables for the application container.",
       "items": {
@@ -1032,7 +1065,7 @@
           "type": "string"
         },
         "tag": {
-          "default": "v0.3.22@sha256:41b63717cbb575be525386d6b1c731d24e1c515b2b1d5f8421bc050a64f5375c",
+          "default": "v1.0.0@sha256:90a8c511781fa563bca7b78149975ab34dc5a6736b469b4afc7cdd8c2b4e7afd",
           "description": "The container image tag, pinned by digest (`vX.Y.Z\npull, while the tag stays on as the readable version marker. Defaults to the chart's\n`appVersion` when empty.",
           "required": [],
           "title": "tag",
@@ -1619,6 +1652,29 @@
       "required": [],
       "title": "securityContextPreset"
     },
+    "server": {
+      "additionalProperties": true,
+      "properties": {
+        "host": {
+          "default": "0.0.0.0",
+          "description": "Bind address (`server.host`). The application's own default is `127.0.0.1`, which in a\ncontainer answers nothing; `0.0.0.0` is what makes the Service reach it.",
+          "required": [],
+          "title": "host",
+          "type": "string"
+        },
+        "port": {
+          "default": 8080,
+          "description": "Bind port (`server.port`). Also the container port, the Service target and what every\nprobe and NetworkPolicy rule is written against.",
+          "maximum": 65535,
+          "minimum": 1,
+          "required": [],
+          "title": "port",
+          "type": "integer"
+        }
+      },
+      "required": [],
+      "title": "server"
+    },
     "service": {
       "additionalProperties": true,
       "properties": {
@@ -1760,6 +1816,33 @@
       "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.apps.v1.DeploymentStrategy",
       "required": []
     },
+    "telemetry": {
+      "additionalProperties": true,
+      "properties": {
+        "logLevel": {
+          "default": "info",
+          "description": "Log level (`telemetry.log_level`).",
+          "enum": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ],
+          "required": [],
+          "title": "logLevel"
+        },
+        "sentryDsn": {
+          "default": "",
+          "description": "Sentry DSN (`telemetry.sentry_dsn`). Empty disables Sentry entirely.",
+          "required": [],
+          "title": "sentryDsn",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "telemetry"
+    },
     "terminationGracePeriodSeconds": {
       "default": 30,
       "description": "Grace period for pod shutdown.",
@@ -1786,6 +1869,32 @@
       "required": [],
       "title": "topologySpreadConstraints",
       "type": "array"
+    },
+    "webhook": {
+      "additionalProperties": true,
+      "properties": {
+        "paths": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "description": "Path regex to the methods allowed on it (`webhook.paths`). Patterns are anchored, so\n`/webhook/.*` matches `/webhook/github` but not `/api/webhook/github`. Methods are `ALL`,\n`GET`, `POST`, `PUT`, `PATCH` or `DELETE`. Required — a proxy with no allowed path\nforwards nothing.\nExample:\n  \"/webhook/.*\":\n    - ALL\n  \"/api/public/.*\":\n    - GET\n    - POST",
+          "required": [],
+          "title": "paths",
+          "type": "object"
+        },
+        "targetBase": {
+          "default": "",
+          "description": "The Cloudflare Access protected service every allowed path is joined onto\n(`webhook.target_base`). Required.",
+          "required": [],
+          "title": "targetBase",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "webhook"
     }
   },
   "required": [],

--- a/charts/cloudflare-access-webhook-redirect/values.yaml
+++ b/charts/cloudflare-access-webhook-redirect/values.yaml
@@ -30,7 +30,7 @@ image:
   # -- The container image tag, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the
   # pull, while the tag stays on as the readable version marker. Defaults to the chart's
   # `appVersion` when empty.
-  tag: v0.3.22@sha256:41b63717cbb575be525386d6b1c731d24e1c515b2b1d5f8421bc050a64f5375c
+  tag: v1.0.0@sha256:90a8c511781fa563bca7b78149975ab34dc5a6736b469b4afc7cdd8c2b4e7afd
 
   # @schema
   # enum: ["", Always, IfNotPresent, Never]
@@ -154,83 +154,143 @@ securityContext: {}
 # @schema
 # additionalProperties: true
 # @schema
-application:
+server:
   # @schema
-  # enum: [debug, info, warn, error]
+  # type: string
   # @schema
-  # -- Application log level
+  # -- Bind address (`server.host`). The application's own default is `127.0.0.1`, which in a
+  # container answers nothing; `0.0.0.0` is what makes the Service reach it.
+  host: 0.0.0.0
+
+  # @schema
+  # type: integer
+  # minimum: 1
+  # maximum: 65535
+  # @schema
+  # -- Bind port (`server.port`). Also the container port, the Service target and what every
+  # probe and NetworkPolicy rule is written against.
+  port: 8080
+
+# @schema
+# additionalProperties: true
+# @schema
+webhook:
+  # @schema
+  # type: string
+  # @schema
+  # -- The Cloudflare Access protected service every allowed path is joined onto
+  # (`webhook.target_base`). Required.
+  targetBase: ""
+
+  # @schema
+  # type: object
+  # additionalProperties:
+  #   type: array
+  #   items:
+  #     type: string
+  # @schema
+  # -- Path regex to the methods allowed on it (`webhook.paths`). Patterns are anchored, so
+  # `/webhook/.*` matches `/webhook/github` but not `/api/webhook/github`. Methods are `ALL`,
+  # `GET`, `POST`, `PUT`, `PATCH` or `DELETE`. Required — a proxy with no allowed path
+  # forwards nothing.
+  # Example:
+  #   "/webhook/.*":
+  #     - ALL
+  #   "/api/public/.*":
+  #     - GET
+  #     - POST
+  paths: {}
+
+# @schema
+# additionalProperties: true
+# @schema
+telemetry:
+  # @schema
+  # enum: [trace, debug, info, warn, error]
+  # @schema
+  # -- Log level (`telemetry.log_level`).
   logLevel: info
 
   # @schema
   # type: string
   # @schema
-  # -- Sentry DSN for error tracking (empty disables)
+  # -- Sentry DSN (`telemetry.sentry_dsn`). Empty disables Sentry entirely.
   sentryDsn: ""
 
+# @schema
+# additionalProperties: true
+# @schema
+cloudflare:
   # @schema
-  # additionalProperties: true
+  # type: string
   # @schema
-  server:
-    # @schema
-    # type: integer
-    # @schema
-    # -- HTTP server port
-    port: 8080
-
-    # @schema
-    # type: string
-    # @schema
-    # -- Server bind address
-    host: 0.0.0.0
+  # -- Cloudflare Access service token client ID (`cloudflare.client_id`). Rendered into the
+  # chart's Secret and mounted as a file, so a rotation is picked up without a restart.
+  # Required unless `existingSecret` supplies it.
+  clientId: ""
 
   # @schema
-  # additionalProperties: true
+  # type: string
   # @schema
-  handler:
-    # @schema
-    # type: string
-    # @schema
-    # -- Base URL for redirect targets
-    targetBase: ""
+  # -- Cloudflare Access service token client secret (`cloudflare.client_secret`). Required
+  # unless `existingSecret` supplies it.
+  clientSecret: ""
 
-    # @schema
-    # type: object
-    # additionalProperties:
-    #   type: array
-    #   items:
-    #     type: string
-    # @schema
-    # -- Path configurations with allowed HTTP methods
-    # Example:
-    #   api/webhook:
-    #     - ALL
-    #   test:
-    #     - GET
-    #     - POST
-    paths: {}
+# @schema
+# type: string
+# @schema
+# -- Name of an existing Secret holding the Cloudflare Access credentials, which keeps them out
+# of `values.yaml` and out of the Helm release object. **Its keys are the configuration paths,
+# not free-form names**: `cloudflare__client_id` and `cloudflare__client_secret`, because the
+# file name is what the loader parses. Set, the chart renders no Secret of its own and
+# `cloudflare.clientId` / `cloudflare.clientSecret` are ignored.
+existingSecret: ""
+
+# @schema
+# type: object
+# additionalProperties: true
+# @schema
+# -- Extra configuration, expressed as the TOML tree of
+# [the service's README](https://github.com/TimSchoenle/cloudflare-access-webhook-redirect#-configuration)
+# (`server.host`, `webhook.target_base`, ...). Merged over everything the chart derives from
+# the values above, so it can both extend and override them. Rendered into the mounted
+# ConfigMap — never into the environment, which the loader refuses to combine with a file.
+config: {}
+
+# @schema
+# type: string
+# @schema
+# -- Verbatim TOML appended after the rendered configuration. The escape hatch for anything the
+# chart's TOML renderer cannot express, notably arrays of tables.
+configExtraToml: ""
+
+# @schema
+# additionalProperties: true
+# @schema
+configMount:
+  # @schema
+  # type: boolean
+  # @schema
+  # -- Add `checksum/*` pod annotations so a configuration change rolls the Deployment. Off by
+  # default, and deliberately so: the proxy watches the directories its configuration came from
+  # and rebuilds its client, path patterns, credentials and listener in place when the kubelet
+  # updates the mounted ConfigMap or Secret, which is strictly better than a rollout. Turn this
+  # on only if you want configuration changes to behave like an ordinary image bump.
+  # `telemetry.*` is installed once per process and needs a restart either way.
+  rolloutOnChange: false
 
   # @schema
-  # additionalProperties: true
+  # type: string
   # @schema
-  cloudflareAccess:
-    # @schema
-    # type: string
-    # @schema
-    # -- Existing secret name containing Cloudflare Access credentials
-    # Must contain client_id and client_secret keys
-    secretName: ""
+  # -- Directory the rendered `config.toml` is mounted at, passed as `WEBHOOK_REDIRECT_CONFIG`.
+  configDir: /etc/cloudflare-access-webhook-redirect/config
 
-    # @schema
-    # type: [string, "null"]
-    # @schema
-    # -- Optional client ID (alternative to secretName)
-    # clientId: ""
-
-    # @schema
-    # type: [string, "null"]
-    # @schema
-    # -- Optional client secret (alternative to secretName)
-    # clientSecret: ""
+  # @schema
+  # type: string
+  # @schema
+  # -- Directory the credential files are mounted at, passed as
+  # `WEBHOOK_REDIRECT_SECRETS_DIR`.
+  secretsDir: /etc/cloudflare-access-webhook-redirect/secrets
 
 # @schema
 # additionalProperties: true

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Shared template partials for the TimSchoenle Helm charts
 type: library
-version: 1.3.0
+version: 1.4.0
 home: https://github.com/TimSchoenle/helm-charts
 sources:
   - https://github.com/TimSchoenle/helm-charts

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Shared template partials for the TimSchoenle Helm charts
 
@@ -171,8 +171,15 @@ and act as the reference shape for consuming charts.
 | commonAnnotations | object | `{}` | Annotations added to every object the chart creates. Values may contain Go templates. |
 | commonLabels | object | `{}` | Labels added to every object the chart creates. Values may contain Go templates. |
 | component | string | `""` | Value for the `app.kubernetes.io/component` label. |
+| config | object | `{}` | Application configuration, expressed as the TOML tree the service documents. Rendered by `common.toml` into the ConfigMap the pod mounts, never passed as environment variables: the loader every application shares refuses a key supplied by both the environment and a file, and a value that lives in a file is one the kubelet can rotate under a running process. |
+| configExtraToml | string | `""` | Verbatim TOML appended after the rendered `config` tree. The escape hatch for anything `common.toml` cannot express, notably arrays of tables. |
+| configMount | object | `{"configDir":"","secretsDir":""}` | Where the rendered configuration and the credential files land in the container. Consumed by `common.fileConfig.*`, which also passes both directories to the application as `<PREFIX>_CONFIG` and `<PREFIX>_SECRETS_DIR`. |
+| configMount.configDir | string | `""` | Directory the rendered `config.toml` is mounted at. |
+| configMount.secretsDir | string | `""` | Directory the credential files are mounted at, one file per configuration key. |
 | dnsConfig | object | `{}` | Pod DNS configuration. |
 | dnsPolicy | string | `""` | Pod DNS policy. |
+| existingConfigMap | string | `""` | Name of an existing ConfigMap holding `config.toml`, replacing the one this chart renders. |
+| existingSecret | string | `""` | Name of an existing Secret holding the credential files, replacing the one this chart renders. Its keys must be the configuration paths the service reads, with `__` for nesting and no dots — that is the file name the loader parses. |
 | extraEnv | list | `[]` | Additional environment variables appended to the application container. |
 | extraVolumeMounts | list | `[]` | Additional volume mounts added to the application container. |
 | extraVolumes | list | `[]` | Additional volumes added to the pod. |

--- a/charts/common/templates/_fileconfig.tpl
+++ b/charts/common/templates/_fileconfig.tpl
@@ -1,0 +1,182 @@
+{{/*
+File-backed configuration: the volumes, mounts and process environment that hand a workload
+its settings as files instead of as environment variables.
+
+Every application in this repository loads configuration in layers — struct defaults, a TOML
+file, `<PREFIX>_`-prefixed environment variables, a directory of key-named secret files, and
+`<PREFIX>_<KEY>_FILE` indirection — and **the last three are mutually exclusive per key**: a
+key supplied by two of them fails the boot naming the key rather than being resolved by
+precedence. Keeping the chart's own output entirely in files therefore makes that collision
+structurally impossible, and it is also what lets the services that watch their configuration
+pick up a rotated credential without a restart. Only the two variables that decide what the
+layers *are* — `<PREFIX>_CONFIG` and `<PREFIX>_SECRETS_DIR` — are passed as environment, and
+neither can itself be file-sourced.
+
+Neither volume may ever be mounted with `subPath`: a subPath mount is resolved once at
+container start and never receives kubelet updates, which would silently turn every
+configuration change back into "restart the pod to pick it up".
+
+Value contract, documented in this chart's `values.yaml`:
+
+  configMount.configDir   directory the rendered `config.toml` is mounted at
+  configMount.secretsDir  directory the credential files are mounted at
+  existingConfigMap       an operator-supplied ConfigMap, replacing the chart's own
+  existingSecret          an operator-supplied Secret, replacing the chart's own
+*/}}
+
+{{/*
+The projected-volume sources holding one workload's credentials.
+
+Each key is a configuration path with `__` for nesting and no dots, because that is how a file
+in `<PREFIX>_SECRETS_DIR` has to be named — a `.` in the name is refused rather than treated as
+a separator.
+
+`optional: true` covers both a missing Secret and a missing key, which is what makes an
+optional credential simply absent rather than a mount failure. A genuinely missing *required*
+credential still fails loudly: the service refuses to boot and names the key.
+
+Renders empty for an empty key list, which is the single predicate the volume, its mount and
+`<PREFIX>_SECRETS_DIR` all read, so the three can never disagree.
+
+Arguments:
+  ctx   (required) root context
+  keys  list of secret file names
+*/}}
+{{- define "common.fileConfig.secretSources" -}}
+{{- $ctx := .ctx -}}
+{{- with .keys }}
+- secret:
+    name: {{ include "common.secretName" $ctx }}
+    optional: true
+    items:
+      {{- range $key := . }}
+      - key: {{ $key }}
+        path: {{ $key }}
+      {{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+The config and secrets volumes.
+
+The config volume is a plain ConfigMap volume and the secrets volume is a `projected` one, so
+the kubelet keeps both up to date in place and the applications that follow the `..data`
+symlink a projected volume uses observe the change.
+
+Arguments:
+  ctx         (required) root context
+  secretKeys  list of secret file names; empty renders no secrets volume
+*/}}
+{{- define "common.fileConfig.volumes" -}}
+{{- $ctx := .ctx -}}
+- name: config
+  configMap:
+    name: {{ include "common.configMapName" $ctx }}
+{{- with (include "common.fileConfig.secretSources" (dict "ctx" $ctx "keys" .secretKeys)) }}
+- name: secrets
+  projected:
+    defaultMode: 0400
+    sources:
+      {{- . | nindent 6 }}
+{{- end }}
+{{- end -}}
+
+{{/*
+The matching read-only mounts.
+
+Arguments:
+  ctx         (required) root context
+  secretKeys  list of secret file names; empty renders no secrets mount
+*/}}
+{{- define "common.fileConfig.volumeMounts" -}}
+{{- $ctx := .ctx -}}
+- name: config
+  mountPath: {{ $ctx.Values.configMount.configDir | quote }}
+  readOnly: true
+{{- if .secretKeys }}
+- name: secrets
+  mountPath: {{ $ctx.Values.configMount.secretsDir | quote }}
+  readOnly: true
+{{- end }}
+{{- end -}}
+
+{{/*
+The two loader variables, and nothing else.
+
+`<PREFIX>_SECRETS_DIR` is emitted only for a pod that actually mounts the secrets volume. The
+directory it names is not optional to the service: a configured secrets directory that cannot
+be read is a boot failure naming the path, not an empty layer.
+
+Arguments:
+  ctx         (required) root context
+  prefix      (required) the application's variable prefix, e.g. `WEBHOOK_REDIRECT`
+  secretKeys  list of secret file names; empty omits `<PREFIX>_SECRETS_DIR`
+*/}}
+{{- define "common.fileConfig.env" -}}
+{{- $ctx := .ctx -}}
+- name: {{ .prefix }}_CONFIG
+  value: {{ $ctx.Values.configMount.configDir | quote }}
+{{- if .secretKeys }}
+- name: {{ .prefix }}_SECRETS_DIR
+  value: {{ $ctx.Values.configMount.secretsDir | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
+The keys a chart's own Secret should carry: every entry of `data` whose value is non-empty.
+
+An unset optional credential is omitted entirely rather than written as an empty file, because
+an empty file is a *supplied* value to the loader and a supplied-but-blank credential is not
+the same thing as an absent one.
+
+Arguments:
+  data  (required) map of secret file name to value
+*/}}
+{{- define "common.fileConfig.secretData" -}}
+{{- $out := dict -}}
+{{- range $key, $value := .data -}}
+{{- if $value -}}
+{{- $_ := set $out $key ($value | toString) -}}
+{{- end -}}
+{{- end -}}
+{{- with $out -}}
+{{- toYaml . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+The secret file names a pod projects, as a YAML list: the chart's own non-empty credentials,
+or — when the operator points at their own Secret — every key the chart knows how to consume,
+since the chart cannot see inside it.
+
+Parse with `fromYamlArray` before passing the result on as `secretKeys`.
+
+Arguments:
+  ctx   (required) root context
+  data  (required) map of secret file name to value
+*/}}
+{{- define "common.fileConfig.secretKeys" -}}
+{{- $ctx := .ctx -}}
+{{- $source := .data -}}
+{{- if not $ctx.Values.existingSecret -}}
+{{- $source = include "common.fileConfig.secretData" (dict "data" .data) | fromYaml -}}
+{{- end -}}
+{{- with (keys $source | sortAlpha) -}}
+{{- toYaml . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Whether this chart renders a Secret of its own. An `existingSecret` always wins, so that a
+deployment can keep every credential out of `helm get values` entirely, and a chart with no
+credential configured renders no empty Secret at all.
+
+Arguments:
+  ctx   (required) root context
+  data  (required) map of secret file name to value
+*/}}
+{{- define "common.fileConfig.createSecret" -}}
+{{- if not .ctx.Values.existingSecret -}}
+{{- if include "common.fileConfig.secretData" (dict "data" .data) -}}true{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/common/templates/_toml.tpl
+++ b/charts/common/templates/_toml.tpl
@@ -1,0 +1,119 @@
+{{/*
+Render a values map as TOML.
+
+The applications behind these charts read a TOML configuration file, and neither Helm nor
+Sprig ships a `toToml`. This renderer covers nested tables, scalars and arrays of scalars.
+Anything outside that shape fails loudly rather than emitting a file the service would reject
+at boot; every consuming chart pairs it with a verbatim `configExtraToml` escape hatch for the
+rest.
+
+Two details carry the whole thing:
+
+  1. Scalars are emitted with `toRawJson`. A TOML basic string, integer, float, boolean and
+     array-of-scalars are all spelled exactly as their JSON equivalents, so one conversion is
+     correct for every leaf type, including escaping inside strings. `toRawJson`, not `toJson`:
+     the latter HTML-escapes `<`, `>` and `&` into `\uXXXX`, which TOML does parse back to the
+     same string, but which turns every URL carrying a query string into something no reviewer
+     can read.
+
+  2. **Every scalar in a table is emitted before any of its sub-tables.** In TOML a key
+     belongs to the most recent `[table]` header, so emitting `[database]` before a sibling
+     top-level scalar would silently reparent that scalar into `database`. Hence two passes,
+     not one.
+
+Keys outside TOML's bare-key alphabet are quoted (see `common.toml.key`), which is what makes
+a table keyed by a request path or a URL pattern — `[bucket.entries."docs/handbook"]`,
+`"/webhook/.*" = ["ALL"]` — render as valid TOML rather than as a parse error at boot.
+
+Map iteration in Go templates is sorted by key, so output is deterministic and a no-op
+`helm upgrade` produces a byte-identical ConfigMap — which matters for the services that watch
+their configuration directory, because a rewritten file is what wakes the watcher.
+
+Arguments:
+  value   (required) the map to render
+  prefix  parent table path, used by the recursion (callers pass nothing)
+
+Usage: {{ include "common.toml" (dict "value" $map) | trim }}
+*/}}
+{{- define "common.toml" -}}
+{{- $value := .value | default dict -}}
+{{- $prefix := .prefix | default "" -}}
+{{- range $k, $v := $value -}}
+{{- if and (not (kindIs "map" $v)) (not (kindIs "invalid" $v)) -}}
+{{- if kindIs "slice" $v -}}
+{{- range $item := $v -}}
+{{- if or (kindIs "map" $item) (kindIs "slice" $item) -}}
+{{- fail (printf "common.toml: config key %q is an array of tables, which this renderer cannot express. Put it in `configExtraToml` verbatim instead." (printf "%s%s" (ternary (printf "%s." $prefix) "" (ne $prefix "")) $k)) -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+{{ include "common.toml.key" $k }} = {{ toRawJson $v }}
+{{- end -}}
+{{- end -}}
+{{- range $k, $v := $value -}}
+{{- if kindIs "map" $v -}}
+{{- $key := include "common.toml.key" $k -}}
+{{- $path := ternary (printf "%s.%s" $prefix $key) $key (ne $prefix "") }}
+
+[{{ $path }}]
+{{- include "common.toml" (dict "value" $v "prefix" $path) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+One TOML key, bare where TOML allows it and quoted where it does not.
+
+TOML's bare keys are `[A-Za-z0-9_-]+`. Everything else — a request path, a regex, a dotted
+name — has to be a quoted key, and a JSON string is exactly a TOML basic string, so
+`toRawJson` both quotes and escapes it. Keys already inside the bare alphabet are emitted
+untouched, so the ordinary snake_case configuration tree renders exactly as it did before
+quoting existed.
+
+Arguments: the key, as the dot value.
+*/}}
+{{- define "common.toml.key" -}}
+{{- $key := . | toString -}}
+{{- if regexMatch "^[A-Za-z0-9_-]+$" $key -}}
+{{- $key -}}
+{{- else -}}
+{{- toRawJson $key -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Merge a list of maps into one, deeply, later entries winning, and render it as TOML.
+
+Used to fold the chart-derived wiring into the operator's own `config` tree before rendering,
+so the two never end up as competing fragments that have to be ordered against each other.
+
+Arguments:
+  maps  (required) list of maps, lowest precedence first
+
+Usage: {{ include "common.tomlMerged" (dict "maps" (list $derived $user)) }}
+*/}}
+{{- define "common.tomlMerged" -}}
+{{- $merged := dict -}}
+{{- range $m := .maps -}}
+{{- $merged = mergeOverwrite $merged (deepCopy ($m | default dict)) -}}
+{{- end -}}
+{{- include "common.toml" (dict "value" $merged) -}}
+{{- end -}}
+
+{{/*
+The complete TOML document a chart mounts: its merged configuration tree followed by the
+verbatim escape hatch.
+
+Arguments:
+  ctx   (required) root context, for `.Values.configExtraToml`
+  maps  (required) list of maps, lowest precedence first
+
+Usage: {{ include "common.configToml" (dict "ctx" $ "maps" (list $derived $.Values.config)) }}
+*/}}
+{{- define "common.configToml" -}}
+{{- include "common.tomlMerged" (dict "maps" .maps) | trim }}
+{{- with .ctx.Values.configExtraToml }}
+
+{{ . | trim }}
+{{- end }}
+{{- end -}}

--- a/charts/common/values.schema.json
+++ b/charts/common/values.schema.json
@@ -34,6 +34,42 @@
       "title": "component",
       "type": "string"
     },
+    "config": {
+      "additionalProperties": true,
+      "description": "Application configuration, expressed as the TOML tree the service documents. Rendered by\n`common.toml` into the ConfigMap the pod mounts, never passed as environment variables: the\nloader every application shares refuses a key supplied by both the environment and a file,\nand a value that lives in a file is one the kubelet can rotate under a running process.",
+      "required": [],
+      "title": "config",
+      "type": "object"
+    },
+    "configExtraToml": {
+      "default": "",
+      "description": "Verbatim TOML appended after the rendered `config` tree. The escape hatch for anything\n`common.toml` cannot express, notably arrays of tables.",
+      "required": [],
+      "title": "configExtraToml",
+      "type": "string"
+    },
+    "configMount": {
+      "additionalProperties": true,
+      "description": "Where the rendered configuration and the credential files land in the container. Consumed\nby `common.fileConfig.*`, which also passes both directories to the application as\n`\u003cPREFIX\u003e_CONFIG` and `\u003cPREFIX\u003e_SECRETS_DIR`.",
+      "properties": {
+        "configDir": {
+          "default": "",
+          "description": "Directory the rendered `config.toml` is mounted at.",
+          "required": [],
+          "title": "configDir",
+          "type": "string"
+        },
+        "secretsDir": {
+          "default": "",
+          "description": "Directory the credential files are mounted at, one file per configuration key.",
+          "required": [],
+          "title": "secretsDir",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "configMount"
+    },
     "dnsConfig": {
       "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodDNSConfig",
       "required": []
@@ -43,6 +79,20 @@
       "description": "Pod DNS policy.",
       "required": [],
       "title": "dnsPolicy",
+      "type": "string"
+    },
+    "existingConfigMap": {
+      "default": "",
+      "description": "Name of an existing ConfigMap holding `config.toml`, replacing the one this chart renders.",
+      "required": [],
+      "title": "existingConfigMap",
+      "type": "string"
+    },
+    "existingSecret": {
+      "default": "",
+      "description": "Name of an existing Secret holding the credential files, replacing the one this chart\nrenders. Its keys must be the configuration paths the service reads, with `__` for nesting\nand no dots — that is the file name the loader parses.",
+      "required": [],
+      "title": "existingSecret",
       "type": "string"
     },
     "extraEnv": {

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -46,6 +46,56 @@ commonLabels: {}
 commonAnnotations: {}
 
 # @schema
+# type: object
+# additionalProperties: true
+# @schema
+# -- Application configuration, expressed as the TOML tree the service documents. Rendered by
+# `common.toml` into the ConfigMap the pod mounts, never passed as environment variables: the
+# loader every application shares refuses a key supplied by both the environment and a file,
+# and a value that lives in a file is one the kubelet can rotate under a running process.
+config: {}
+
+# @schema
+# type: string
+# @schema
+# -- Verbatim TOML appended after the rendered `config` tree. The escape hatch for anything
+# `common.toml` cannot express, notably arrays of tables.
+configExtraToml: ""
+
+# @schema
+# additionalProperties: true
+# @schema
+# -- Where the rendered configuration and the credential files land in the container. Consumed
+# by `common.fileConfig.*`, which also passes both directories to the application as
+# `<PREFIX>_CONFIG` and `<PREFIX>_SECRETS_DIR`.
+configMount:
+  # @schema
+  # type: string
+  # @schema
+  # -- Directory the rendered `config.toml` is mounted at.
+  configDir: ""
+
+  # @schema
+  # type: string
+  # @schema
+  # -- Directory the credential files are mounted at, one file per configuration key.
+  secretsDir: ""
+
+# @schema
+# type: string
+# @schema
+# -- Name of an existing ConfigMap holding `config.toml`, replacing the one this chart renders.
+existingConfigMap: ""
+
+# @schema
+# type: string
+# @schema
+# -- Name of an existing Secret holding the credential files, replacing the one this chart
+# renders. Its keys must be the configuration paths the service reads, with `__` for nesting
+# and no dots — that is the file name the loader parses.
+existingSecret: ""
+
+# @schema
 # type: string
 # @schema
 # -- Value for the `app.kubernetes.io/component` label.

--- a/charts/mp-stats-legacy-viewer/Chart.yaml
+++ b/charts/mp-stats-legacy-viewer/Chart.yaml
@@ -1,7 +1,7 @@
 name: mp-stats-legacy-viewer
 description: MP Stats Legacy Viewer
-version: 1.0.11
-appVersion: v0.14.1
+version: 2.0.0
+appVersion: v0.15.0
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts
 sources:
@@ -11,5 +11,5 @@ maintainers:
     email: contact@tim-schoenle.de
 dependencies:
   - name: common
-    version: 1.3.0
+    version: 1.4.0
     repository: "file://../common"

--- a/charts/mp-stats-legacy-viewer/README.md
+++ b/charts/mp-stats-legacy-viewer/README.md
@@ -1,6 +1,6 @@
 # mp-stats-legacy-viewer
 
-![Version: 1.0.11](https://img.shields.io/badge/Version-1.0.11-informational?style=flat-square) ![AppVersion: v0.14.1](https://img.shields.io/badge/AppVersion-v0.14.1-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![AppVersion: v0.15.0](https://img.shields.io/badge/AppVersion-v0.15.0-informational?style=flat-square)
 
 MP Stats Legacy Viewer
 
@@ -46,6 +46,54 @@ ingress:
         - stats.example.com
 ```
 
+## Configuration
+
+The application reads its settings through a layered, file-first loader. This chart renders
+them into one `config.toml`, mounts it as a ConfigMap and points `MP_STATS_CONFIG` at it.
+Nothing is passed as an environment variable: the loader **fails the boot on a key supplied by
+both the environment and a file** rather than resolving it by precedence.
+
+**Pointing `MP_STATS_CONFIG` at the mount replaces the `/config.toml` the image ships** rather
+than layering over it, so this chart restates every key that file carried — the bind address,
+`server.distDir` and `server.dataDir`. The defaults match the image's own layout; change them
+only for an image that puts the frontend bundle or the converted data somewhere else. A
+`dist_dir` without an `index.html` is a boot failure, not a 404.
+
+`config` takes the raw TOML tree for anything the first-class values do not cover, merged over
+the derived one:
+
+```yaml
+config:
+  converter:
+    cache:
+      enabled: false
+```
+
+and `configExtraToml` is appended verbatim for what the renderer cannot express.
+
+The server does not reload its configuration, so the chart keeps the conventional
+`checksum/configmap` pod annotation: a configuration change rolls the Deployment, which is the
+only way it takes effect.
+
+## Upgrading
+
+### 1.x to 2.0
+
+Chart 2.0 tracks application 0.15.0, which replaced its environment-only configuration with the
+layered, file-first loader every chart in this repository now uses. The `application` block is
+gone; a `helm upgrade` with 1.x values fails schema validation naming the offending key rather
+than starting a pod on the defaults.
+
+| Before | After |
+|---|---|
+| `application.server.host` | `server.host` |
+| `application.server.port` | `server.port` |
+
+Both now feed `server.bind_addr` in the rendered file rather than a command-line flag. Two
+values are new and have no 1.x equivalent — `server.distDir` and `server.dataDir` — because the
+chart now supplies the paths the image's own `/config.toml` used to. Leave them alone unless
+you run a modified image.
+
 ## Health checks
 
 All three probes are enabled by default and point at the application's own endpoints —
@@ -61,12 +109,13 @@ on the startup and liveness probes, so the chart omits it there.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Explicit affinity rules. Wins over `podAntiAffinity`. |
-| application.server | object | `{"host":"0.0.0.0","port":8080}` | HTTP server configuration. Defines where the application listens for incoming connections. |
-| application.server.host | string | `"0.0.0.0"` | Host address to bind the HTTP server. Typically `0.0.0.0` to listen on all network interfaces. |
-| application.server.port | int | `8080` | Port number the server listens on. |
 | automountServiceAccountToken | bool | `false` | Mount the ServiceAccount API token into the pod. Set on the pod itself, which is what actually keeps the token out of the container: the ServiceAccount-level setting is ignored as soon as a pod names a different account. |
 | commonAnnotations | object | `{}` | Annotations added to every object this chart creates. |
 | commonLabels | object | `{}` | Labels added to every object this chart creates. |
+| config | object | `{}` | Extra configuration, expressed as the TOML tree of [the application's configuration reference](https://github.com/TimSchoenle/mp-stats-legacy-viewer/blob/main/docs/CONFIGURATION.md) (`server.bind_addr`, `converter.*`, ...). Merged over everything the chart derives from the values above, so it can both extend and override them. Rendered into the mounted ConfigMap — never into the environment, which the loader refuses to combine with a file. |
+| configExtraToml | string | `""` | Verbatim TOML appended after the rendered configuration. The escape hatch for anything the chart's TOML renderer cannot express, notably arrays of tables. |
+| configMount.configDir | string | `"/etc/mp-stats/config"` | Directory the rendered `config.toml` is mounted at, passed as `MP_STATS_CONFIG`. Pointing this at the mount **replaces** the `/config.toml` the image ships, so everything the image described — the bind address, `dist_dir`, `data_dir` — is restated by the values above. |
+| configMount.secretsDir | string | `"/etc/mp-stats/secrets"` | Directory credential files would be mounted at, passed as `MP_STATS_SECRETS_DIR`. Neither binary reads a secret today, so nothing is mounted and the variable is not set; the value is here for an operator adding one through `extraVolumes`. |
 | extraEnv | list | `[]` | Additional environment variables for the application container. |
 | extraVolumeMounts | list | `[]` | Additional volume mounts added to the application container. |
 | extraVolumes | list | `[]` | Additional volumes added to the pod. |
@@ -74,7 +123,7 @@ on the startup and liveness probes, so the chart omits it there.
 | image.pullPolicy | string | `""` | The image pull policy. Empty resolves automatically from the tag/digest. |
 | image.registry | string | `""` | Registry host. Empty means Docker Hub. |
 | image.repository | string | `"timschoenle/mp-stats-legacy-viewer"` | The container image repository. |
-| image.tag | string | `"v0.14.1@sha256:35de635c75df40c839066e23d5b1180c4a1b3e44dd8868372e717f992b7f9d18"` | The container image tag, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the pull, while the tag stays on as the readable version marker. Defaults to the chart's `appVersion` when empty. |
+| image.tag | string | `"v0.15.0@sha256:f2bd04006f3942f5b725e9f2a6fff4f88fe9c03fbb558f63edb224b45b190a7a"` | The container image tag, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the pull, while the tag stays on as the readable version marker. Defaults to the chart's `appVersion` when empty. |
 | imagePullSecrets | list | `[]` | Optional image pull secrets for private registries. |
 | ingress.annotations | object | `{}` | Custom annotations for the Ingress resource. Useful for configuring ingress controllers (e.g., cert-manager, rate limits). |
 | ingress.enabled | bool | `false` | Enable or disable Kubernetes Ingress resource creation. Set to `true` to expose the service externally via Ingress. |
@@ -148,6 +197,10 @@ on the startup and liveness probes, so the chart omits it there.
 | revisionHistoryLimit | int | `3` | Number of old ReplicaSets retained for rollback. |
 | securityContext | object | `{}` | Container security context, merged over the preset. A writable /tmp is provided automatically via an emptyDir volume. |
 | securityContextPreset | string | `"restricted"` | Container security context baseline. `restricted` drops all Linux capabilities and forbids privilege escalation, running as root and a writable root filesystem. |
+| server.dataDir | string | `"/dist/data"` | The converter's output, served under `/data` (`server.data_dir`). The default is where the image puts it. |
+| server.distDir | string | `"/dist"` | Built frontend served as the SPA (`server.dist_dir`). The server refuses to start unless it holds an `index.html`, which is both the entry point and the fallback for unknown routes. The default is where the image puts it — change it only for an image that differs. |
+| server.host | string | `"0.0.0.0"` | Host half of the bind address (`server.bind_addr`). `0.0.0.0` is what makes the Service reach the listener. |
+| server.port | int | `8080` | Port half of the bind address (`server.bind_addr`). Also the container port, the Service target and what every probe and NetworkPolicy rule is written against. |
 | service.port | int | `80` | Port that the Kubernetes Service will expose. Typically maps to `application.server.port`. |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type that exposes the application. |
 | serviceAccount.annotations | object | `{}` | Additional annotations for the service account |

--- a/charts/mp-stats-legacy-viewer/README.md.gotmpl
+++ b/charts/mp-stats-legacy-viewer/README.md.gotmpl
@@ -48,6 +48,54 @@ ingress:
         - stats.example.com
 ```
 
+## Configuration
+
+The application reads its settings through a layered, file-first loader. This chart renders
+them into one `config.toml`, mounts it as a ConfigMap and points `MP_STATS_CONFIG` at it.
+Nothing is passed as an environment variable: the loader **fails the boot on a key supplied by
+both the environment and a file** rather than resolving it by precedence.
+
+**Pointing `MP_STATS_CONFIG` at the mount replaces the `/config.toml` the image ships** rather
+than layering over it, so this chart restates every key that file carried — the bind address,
+`server.distDir` and `server.dataDir`. The defaults match the image's own layout; change them
+only for an image that puts the frontend bundle or the converted data somewhere else. A
+`dist_dir` without an `index.html` is a boot failure, not a 404.
+
+`config` takes the raw TOML tree for anything the first-class values do not cover, merged over
+the derived one:
+
+```yaml
+config:
+  converter:
+    cache:
+      enabled: false
+```
+
+and `configExtraToml` is appended verbatim for what the renderer cannot express.
+
+The server does not reload its configuration, so the chart keeps the conventional
+`checksum/configmap` pod annotation: a configuration change rolls the Deployment, which is the
+only way it takes effect.
+
+## Upgrading
+
+### 1.x to 2.0
+
+Chart 2.0 tracks application 0.15.0, which replaced its environment-only configuration with the
+layered, file-first loader every chart in this repository now uses. The `application` block is
+gone; a `helm upgrade` with 1.x values fails schema validation naming the offending key rather
+than starting a pod on the defaults.
+
+| Before | After |
+|---|---|
+| `application.server.host` | `server.host` |
+| `application.server.port` | `server.port` |
+
+Both now feed `server.bind_addr` in the rendered file rather than a command-line flag. Two
+values are new and have no 1.x equivalent — `server.distDir` and `server.dataDir` — because the
+chart now supplies the paths the image's own `/config.toml` used to. Leave them alone unless
+you run a modified image.
+
 ## Health checks
 
 All three probes are enabled by default and point at the application's own endpoints —

--- a/charts/mp-stats-legacy-viewer/templates/_helpers.tpl
+++ b/charts/mp-stats-legacy-viewer/templates/_helpers.tpl
@@ -1,0 +1,35 @@
+{{/*
+The configuration the chart derives from its own first-class values, as the TOML tree the
+server reads.
+
+`dist_dir` and `data_dir` are restated rather than inherited. The image ships a `/config.toml`
+and points `MP_STATS_CONFIG` at it; pointing that variable at this chart's mount **replaces**
+that file rather than layering over it, so every key it carried has to be carried here or the
+server falls back to the workspace-relative defaults and refuses to start on a missing
+`index.html`.
+*/}}
+{{- define "mp-stats-legacy-viewer.derivedConfig" -}}
+server:
+  bind_addr: {{ printf "%s:%v" .Values.server.host (.Values.server.port | toString) | quote }}
+  dist_dir: {{ .Values.server.distDir | quote }}
+  data_dir: {{ .Values.server.dataDir | quote }}
+{{- end -}}
+
+{{/*
+The configuration that actually reaches the server: the derived tree with the operator's own
+`config` tree merged over it, so `config` can both extend and override the values above.
+
+Not included: `configExtraToml`, which is appended verbatim and never parsed.
+*/}}
+{{- define "mp-stats-legacy-viewer.effectiveConfig" -}}
+{{- $derived := include "mp-stats-legacy-viewer.derivedConfig" . | fromYaml -}}
+{{- toYaml (mergeOverwrite $derived (deepCopy (.Values.config | default dict))) -}}
+{{- end -}}
+
+{{/*
+The complete `config.toml`: the effective tree, then the verbatim escape hatch.
+*/}}
+{{- define "mp-stats-legacy-viewer.configToml" -}}
+{{- $config := include "mp-stats-legacy-viewer.effectiveConfig" . | fromYaml -}}
+{{- include "common.configToml" (dict "ctx" . "maps" (list $config)) -}}
+{{- end -}}

--- a/charts/mp-stats-legacy-viewer/templates/configmap.yaml
+++ b/charts/mp-stats-legacy-viewer/templates/configmap.yaml
@@ -1,6 +1,5 @@
-{{- include "netcup-offer-bot.validateValues" . }}
-kind: ConfigMap
 apiVersion: v1
+kind: ConfigMap
 metadata:
   name: {{ include "common.fullname" . }}
   namespace: {{ include "common.namespace" . }}
@@ -18,4 +17,4 @@ data:
     configuration readable with `kubectl get configmap -o yaml`.
   */}}
   config.toml: |
-    {{- include "netcup-offer-bot.configToml" . | nindent 4 }}
+    {{- include "mp-stats-legacy-viewer.configToml" . | nindent 4 }}

--- a/charts/mp-stats-legacy-viewer/templates/deployment.yaml
+++ b/charts/mp-stats-legacy-viewer/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       {{- include "common.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with (include "common.podAnnotations" (dict "ctx" $ "templates" (list))) }}
+      {{- with (include "common.podAnnotations" (dict "ctx" $ "templates" (list "configmap.yaml"))) }}
       annotations:
         {{- . | nindent 8 }}
       {{- end }}
@@ -30,11 +30,20 @@ spec:
     spec:
       {{- include "common.podSpec.common" . | nindent 6 }}
       containers:
+        {{- /*
+          Configuration reaches the container as a file, never as environment variables: the
+          loader fails the boot on a key supplied by both. `MP_STATS_CONFIG` decides what the
+          file layer *is*, so it is the one thing that cannot itself be file-sourced — and
+          pointing it here replaces the `/config.toml` the image ships.
+        */}}
+        {{- $secretKeys := list }}
         {{- include "common.container" (dict
               "ctx" $
-              "ports" (list (dict "name" "http" "containerPort" (int .Values.application.server.port) "protocol" "TCP"))
+              "ports" (list (dict "name" "http" "containerPort" (int .Values.server.port) "protocol" "TCP"))
+              "env" (include "common.fileConfig.env" (dict "ctx" $ "prefix" "MP_STATS" "secretKeys" $secretKeys) | fromYamlArray)
+              "volumeMounts" (include "common.fileConfig.volumeMounts" (dict "ctx" $ "secretKeys" $secretKeys) | fromYamlArray)
             ) | nindent 8 }}
-      {{- with (include "common.volumes" (dict "ctx" $)) }}
+      {{- with (include "common.volumes" (dict "ctx" $ "volumes" (include "common.fileConfig.volumes" (dict "ctx" $ "secretKeys" $secretKeys) | fromYamlArray))) }}
       volumes:
         {{- . | nindent 8 }}
       {{- end }}

--- a/charts/mp-stats-legacy-viewer/templates/service.yaml
+++ b/charts/mp-stats-legacy-viewer/templates/service.yaml
@@ -14,6 +14,6 @@ spec:
   ports:
     - protocol: TCP
       port: {{ .Values.service.port }}
-      targetPort: {{ .Values.application.server.port }}
+      targetPort: {{ .Values.server.port }}
   selector:
     {{- include "common.selectorLabels" . | nindent 4 }}

--- a/charts/mp-stats-legacy-viewer/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/mp-stats-legacy-viewer/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1,5 +1,23 @@
 matches the committed Deployment snapshot:
   1: |
+    apiVersion: v1
+    data:
+      config.toml: |
+        [server]
+        bind_addr = "0.0.0.0:8080"
+        data_dir = "/dist/data"
+        dist_dir = "/dist"
+    kind: ConfigMap
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: mp-stats-legacy-viewer
+        app.kubernetes.io/version: 0.0.0
+        helm.sh/chart: mp-stats-legacy-viewer-0.0.0
+      name: RELEASE-NAME-mp-stats-legacy-viewer
+      namespace: NAMESPACE
+  2: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -20,6 +38,8 @@ matches the committed Deployment snapshot:
           app.kubernetes.io/name: mp-stats-legacy-viewer
       template:
         metadata:
+          annotations:
+            checksum/configmap: cefca9513426a23b31131fb777029d276ab718718f6138bbd251ea95bd74f395
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -28,7 +48,10 @@ matches the committed Deployment snapshot:
         spec:
           automountServiceAccountToken: false
           containers:
-            - image: timschoenle/mp-stats-legacy-viewer:v0.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
+            - env:
+                - name: MP_STATS_CONFIG
+                  value: /etc/mp-stats/config
+              image: timschoenle/mp-stats-legacy-viewer:v0.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3
@@ -77,6 +100,9 @@ matches the committed Deployment snapshot:
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp
+                - mountPath: /etc/mp-stats/config
+                  name: config
+                  readOnly: true
           securityContext:
             fsGroup: 1000
             fsGroupChangePolicy: OnRootMismatch
@@ -90,8 +116,29 @@ matches the committed Deployment snapshot:
           volumes:
             - emptyDir: {}
               name: tmp
+            - configMap:
+                name: RELEASE-NAME-mp-stats-legacy-viewer
+              name: config
 matches the committed Deployment snapshot with network policies and probes on:
   1: |
+    apiVersion: v1
+    data:
+      config.toml: |
+        [server]
+        bind_addr = "0.0.0.0:8080"
+        data_dir = "/dist/data"
+        dist_dir = "/dist"
+    kind: ConfigMap
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: mp-stats-legacy-viewer
+        app.kubernetes.io/version: 0.0.0
+        helm.sh/chart: mp-stats-legacy-viewer-0.0.0
+      name: RELEASE-NAME-mp-stats-legacy-viewer
+      namespace: NAMESPACE
+  2: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -112,6 +159,8 @@ matches the committed Deployment snapshot with network policies and probes on:
           app.kubernetes.io/name: mp-stats-legacy-viewer
       template:
         metadata:
+          annotations:
+            checksum/configmap: cefca9513426a23b31131fb777029d276ab718718f6138bbd251ea95bd74f395
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -130,7 +179,10 @@ matches the committed Deployment snapshot with network policies and probes on:
                   weight: 100
           automountServiceAccountToken: false
           containers:
-            - image: timschoenle/mp-stats-legacy-viewer:v0.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
+            - env:
+                - name: MP_STATS_CONFIG
+                  value: /etc/mp-stats/config
+              image: timschoenle/mp-stats-legacy-viewer:v0.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3
@@ -179,6 +231,9 @@ matches the committed Deployment snapshot with network policies and probes on:
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp
+                - mountPath: /etc/mp-stats/config
+                  name: config
+                  readOnly: true
           nodeSelector:
             kubernetes.io/os: linux
           securityContext:
@@ -194,3 +249,6 @@ matches the committed Deployment snapshot with network policies and probes on:
           volumes:
             - emptyDir: {}
               name: tmp
+            - configMap:
+                name: RELEASE-NAME-mp-stats-legacy-viewer
+              name: config

--- a/charts/mp-stats-legacy-viewer/tests/configmap_test.yaml
+++ b/charts/mp-stats-legacy-viewer/tests/configmap_test.yaml
@@ -1,0 +1,62 @@
+suite: configmap
+templates:
+  - configmap.yaml
+tests:
+  - it: renders the configuration as a single TOML file
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-mp-stats-legacy-viewer
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[server\]\nbind_addr = "0\.0\.0\.0:8080"'
+
+  # Pointing `MP_STATS_CONFIG` at this mount replaces the `/config.toml` the image ships rather
+  # than layering over it, so the paths that file carried have to be restated here. Without
+  # them the server falls back to workspace-relative defaults and refuses to start on a missing
+  # `index.html`.
+  - it: restates the paths the image's own config.toml carried
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'dist_dir = "/dist"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'data_dir = "/dist/data"'
+
+  - it: builds the bind address from host and port
+    set:
+      server.host: 127.0.0.1
+      server.port: 9090
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'bind_addr = "127\.0\.0\.1:9090"'
+
+  - it: merges the raw config tree over the derived values
+    set:
+      config:
+        server:
+          data_dir: /srv/data
+        converter:
+          cache:
+            enabled: false
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'data_dir = "/srv/data"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[converter\.cache\]\nenabled = false'
+
+  - it: appends configExtraToml verbatim
+    set:
+      configExtraToml: |
+        [converter]
+        input_dir = "/data"
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[converter\]\ninput_dir = "/data"'

--- a/charts/mp-stats-legacy-viewer/tests/deployment_test.yaml
+++ b/charts/mp-stats-legacy-viewer/tests/deployment_test.yaml
@@ -1,8 +1,14 @@
 suite: deployment
 templates:
   - deployment.yaml
+  - configmap.yaml
+# The Deployment annotates a checksum of the ConfigMap, so both templates must render; the
+# selector keeps every assertion below on the Deployment.
 tests:
   - it: creates a Deployment named after the release
+    documentSelector:
+      path: kind
+      value: Deployment
     asserts:
       - isKind:
           of: Deployment
@@ -12,8 +18,11 @@ tests:
 
   # The Service targets this port by number, and the probes address it by name.
   - it: exposes the server port as http
+    documentSelector:
+      path: kind
+      value: Deployment
     set:
-      application.server.port: 9090
+      server.port: 9090
     asserts:
       - equal:
           path: spec.template.spec.containers[0].ports
@@ -25,7 +34,72 @@ tests:
           path: spec.template.spec.containers[0].startupProbe.httpGet.port
           value: http
 
+  # The whole point of the migration: the loader refuses a key supplied by both the environment
+  # and a file. `MP_STATS_CONFIG` is the only variable left, and it is the one that cannot be
+  # file-sourced because it decides what the file layer is.
+  - it: passes configuration as a file, not as environment
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env
+          value:
+            - name: MP_STATS_CONFIG
+              value: /etc/mp-stats/config
+      - notExists:
+          path: spec.template.spec.containers[0].envFrom
+
+  - it: mounts the rendered configuration read-only
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+            configMap:
+              name: RELEASE-NAME-mp-stats-legacy-viewer
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /etc/mp-stats/config
+            readOnly: true
+
+  # Neither binary reads a secret, and a configured secrets directory that cannot be read is a
+  # boot failure naming the path, not an empty layer.
+  - it: names no secrets directory, because neither binary reads a secret
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MP_STATS_SECRETS_DIR
+            value: /etc/mp-stats/secrets
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: secrets
+            mountPath: /etc/mp-stats/secrets
+            readOnly: true
+
+  # The server does not reload, so a configuration change has to roll the pod to take effect.
+  - it: rolls the pod when the mounted configuration changes
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - exists:
+          path: spec.template.metadata.annotations["checksum/configmap"]
+
   - it: probes the three distinct health endpoints
+    documentSelector:
+      path: kind
+      value: Deployment
     asserts:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.httpGet.path
@@ -38,14 +112,10 @@ tests:
           value: /health/ready
 
   # This chart mounts no configuration, so there is nothing to checksum.
-  - it: injects no configuration or secrets
-    asserts:
-      - notExists:
-          path: spec.template.spec.containers[0].envFrom
-      - notExists:
-          path: spec.template.spec.containers[0].env
-
   - it: scales to the requested replica count
+    documentSelector:
+      path: kind
+      value: Deployment
     set:
       replicaCount: 2
     asserts:

--- a/charts/mp-stats-legacy-viewer/tests/security_test.yaml
+++ b/charts/mp-stats-legacy-viewer/tests/security_test.yaml
@@ -1,8 +1,14 @@
 suite: pod security baseline
 templates:
   - deployment.yaml
+  - configmap.yaml
+# The Deployment annotates a checksum of the ConfigMap, so both templates must render; the
+# selector keeps every assertion below on the Deployment.
 tests:
   - it: satisfies the restricted Pod Security Standard
+    documentSelector:
+      path: kind
+      value: Deployment
     asserts:
       - equal:
           path: spec.template.spec.securityContext.runAsNonRoot
@@ -32,6 +38,9 @@ tests:
   # The ServiceAccount-level setting is ignored the moment a pod names a different account,
   # so the pod-level one is what actually keeps the token off the container filesystem.
   - it: keeps the ServiceAccount token out of the pod
+    documentSelector:
+      path: kind
+      value: Deployment
     asserts:
       - equal:
           path: spec.template.spec.automountServiceAccountToken
@@ -39,6 +48,9 @@ tests:
 
   # A read-only root filesystem without a writable temp directory breaks most runtimes.
   - it: provides a writable /tmp alongside the read-only root filesystem
+    documentSelector:
+      path: kind
+      value: Deployment
     asserts:
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
@@ -52,6 +64,9 @@ tests:
             emptyDir: {}
 
   - it: drops the /tmp scaffolding when the root filesystem is writable
+    documentSelector:
+      path: kind
+      value: Deployment
     set:
       securityContext.readOnlyRootFilesystem: false
     asserts:
@@ -62,6 +77,9 @@ tests:
             mountPath: /tmp
 
   - it: lets the security baseline be switched off
+    documentSelector:
+      path: kind
+      value: Deployment
     set:
       podSecurityContextPreset: none
       securityContextPreset: none
@@ -77,6 +95,9 @@ tests:
           path: spec.template.spec.containers[0].securityContext
 
   - it: merges user overrides over the preset
+    documentSelector:
+      path: kind
+      value: Deployment
     set:
       securityContext.readOnlyRootFilesystem: false
       securityContext.capabilities.drop: [NET_RAW]
@@ -92,12 +113,18 @@ tests:
           value: false
 
   - it: pins the image by digest
+    documentSelector:
+      path: kind
+      value: Deployment
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
           pattern: "@sha256:[0-9a-f]{64}$"
 
   - it: builds the image reference from registry, repository and tag
+    documentSelector:
+      path: kind
+      value: Deployment
     set:
       image.registry: ghcr.io
       image.repository: example/app
@@ -108,6 +135,9 @@ tests:
           value: ghcr.io/example/app:v1.2.3
 
   - it: keeps the tag alongside the digest it pins
+    documentSelector:
+      path: kind
+      value: Deployment
     set:
       image.registry: ghcr.io
       image.repository: example/app
@@ -122,6 +152,9 @@ tests:
           value: IfNotPresent
 
   - it: pulls a mutable latest tag on every start
+    documentSelector:
+      path: kind
+      value: Deployment
     set:
       image.tag: latest
       image.pullPolicy: ""
@@ -131,6 +164,9 @@ tests:
           value: Always
 
   - it: keeps the chart version out of the pod labels
+    documentSelector:
+      path: kind
+      value: Deployment
     asserts:
       # helm.sh/chart embeds the chart version; carrying it on the pod template would force
       # a rollout on every chart-only version bump.
@@ -140,6 +176,9 @@ tests:
           path: metadata.labels["helm.sh/chart"]
 
   - it: keeps the selector labels stable and minimal
+    documentSelector:
+      path: kind
+      value: Deployment
     asserts:
       - equal:
           path: spec.selector.matchLabels
@@ -148,6 +187,9 @@ tests:
             app.kubernetes.io/instance: RELEASE-NAME
 
   - it: applies scheduling constraints
+    documentSelector:
+      path: kind
+      value: Deployment
     set:
       nodeSelector:
         disktype: ssd
@@ -174,6 +216,9 @@ tests:
           count: 1
 
   - it: expands the podAntiAffinity shorthand
+    documentSelector:
+      path: kind
+      value: Deployment
     set:
       podAntiAffinity: hard
     asserts:
@@ -182,6 +227,9 @@ tests:
           value: kubernetes.io/hostname
 
   - it: lets an explicit affinity win over the shorthand
+    documentSelector:
+      path: kind
+      value: Deployment
     set:
       podAntiAffinity: hard
       affinity:
@@ -199,6 +247,9 @@ tests:
           path: spec.template.spec.affinity.podAntiAffinity
 
   - it: appends extra environment variables
+    documentSelector:
+      path: kind
+      value: Deployment
     set:
       extraEnv:
         - name: EXTRA
@@ -211,6 +262,9 @@ tests:
             value: "1"
 
   - it: retains a bounded rollback history
+    documentSelector:
+      path: kind
+      value: Deployment
     asserts:
       - equal:
           path: spec.revisionHistoryLimit

--- a/charts/mp-stats-legacy-viewer/tests/snapshot_test.yaml
+++ b/charts/mp-stats-legacy-viewer/tests/snapshot_test.yaml
@@ -4,6 +4,7 @@ suite: rendered manifest snapshot
 # diff; regenerate deliberately with `helm unittest -u charts/mp-stats-legacy-viewer`.
 templates:
   - deployment.yaml
+  - configmap.yaml
 # Chart version, appVersion and the image coordinates are pinned to placeholders so a routine
 # version or image bump never invalidates the snapshot. That those fields are wired up
 # correctly is asserted in security_test.yaml; this suite guards the *shape* of the rendered

--- a/charts/mp-stats-legacy-viewer/values.schema.json
+++ b/charts/mp-stats-legacy-viewer/values.schema.json
@@ -6,35 +6,6 @@
       "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity",
       "required": []
     },
-    "application": {
-      "additionalProperties": true,
-      "properties": {
-        "server": {
-          "additionalProperties": true,
-          "description": "HTTP server configuration.\nDefines where the application listens for incoming connections.",
-          "properties": {
-            "host": {
-              "default": "0.0.0.0",
-              "description": "Host address to bind the HTTP server.\nTypically `0.0.0.0` to listen on all network interfaces.",
-              "required": [],
-              "title": "host",
-              "type": "string"
-            },
-            "port": {
-              "default": 8080,
-              "description": "Port number the server listens on.",
-              "required": [],
-              "title": "port",
-              "type": "integer"
-            }
-          },
-          "required": [],
-          "title": "server"
-        }
-      },
-      "required": [],
-      "title": "application"
-    },
     "automountServiceAccountToken": {
       "default": false,
       "description": "Mount the ServiceAccount API token into the pod.\nSet on the pod itself, which is what actually keeps the token out of the container: the\nServiceAccount-level setting is ignored as soon as a pod names a different account.",
@@ -77,6 +48,42 @@
           "title": "component",
           "type": "string"
         },
+        "config": {
+          "additionalProperties": true,
+          "description": "Application configuration, expressed as the TOML tree the service documents. Rendered by\n`common.toml` into the ConfigMap the pod mounts, never passed as environment variables: the\nloader every application shares refuses a key supplied by both the environment and a file,\nand a value that lives in a file is one the kubelet can rotate under a running process.",
+          "required": [],
+          "title": "config",
+          "type": "object"
+        },
+        "configExtraToml": {
+          "default": "",
+          "description": "Verbatim TOML appended after the rendered `config` tree. The escape hatch for anything\n`common.toml` cannot express, notably arrays of tables.",
+          "required": [],
+          "title": "configExtraToml",
+          "type": "string"
+        },
+        "configMount": {
+          "additionalProperties": true,
+          "description": "Where the rendered configuration and the credential files land in the container. Consumed\nby `common.fileConfig.*`, which also passes both directories to the application as\n`\u003cPREFIX\u003e_CONFIG` and `\u003cPREFIX\u003e_SECRETS_DIR`.",
+          "properties": {
+            "configDir": {
+              "default": "",
+              "description": "Directory the rendered `config.toml` is mounted at.",
+              "required": [],
+              "title": "configDir",
+              "type": "string"
+            },
+            "secretsDir": {
+              "default": "",
+              "description": "Directory the credential files are mounted at, one file per configuration key.",
+              "required": [],
+              "title": "secretsDir",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "configMount"
+        },
         "dnsConfig": {
           "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodDNSConfig",
           "required": []
@@ -86,6 +93,20 @@
           "description": "Pod DNS policy.",
           "required": [],
           "title": "dnsPolicy",
+          "type": "string"
+        },
+        "existingConfigMap": {
+          "default": "",
+          "description": "Name of an existing ConfigMap holding `config.toml`, replacing the one this chart renders.",
+          "required": [],
+          "title": "existingConfigMap",
+          "type": "string"
+        },
+        "existingSecret": {
+          "default": "",
+          "description": "Name of an existing Secret holding the credential files, replacing the one this chart\nrenders. Its keys must be the configuration paths the service reads, with `__` for nesting\nand no dots — that is the file name the loader parses.",
+          "required": [],
+          "title": "existingSecret",
           "type": "string"
         },
         "extraEnv": {
@@ -853,6 +874,41 @@
       "title": "commonLabels",
       "type": "object"
     },
+    "config": {
+      "additionalProperties": true,
+      "description": "Extra configuration, expressed as the TOML tree of\n[the application's configuration reference](https://github.com/TimSchoenle/mp-stats-legacy-viewer/blob/main/docs/CONFIGURATION.md)\n(`server.bind_addr`, `converter.*`, ...). Merged over everything the chart derives from the\nvalues above, so it can both extend and override them. Rendered into the mounted ConfigMap —\nnever into the environment, which the loader refuses to combine with a file.",
+      "required": [],
+      "title": "config",
+      "type": "object"
+    },
+    "configExtraToml": {
+      "default": "",
+      "description": "Verbatim TOML appended after the rendered configuration. The escape hatch for anything the\nchart's TOML renderer cannot express, notably arrays of tables.",
+      "required": [],
+      "title": "configExtraToml",
+      "type": "string"
+    },
+    "configMount": {
+      "additionalProperties": true,
+      "properties": {
+        "configDir": {
+          "default": "/etc/mp-stats/config",
+          "description": "Directory the rendered `config.toml` is mounted at, passed as `MP_STATS_CONFIG`. Pointing\nthis at the mount **replaces** the `/config.toml` the image ships, so everything the image\ndescribed — the bind address, `dist_dir`, `data_dir` — is restated by the values above.",
+          "required": [],
+          "title": "configDir",
+          "type": "string"
+        },
+        "secretsDir": {
+          "default": "/etc/mp-stats/secrets",
+          "description": "Directory credential files would be mounted at, passed as `MP_STATS_SECRETS_DIR`. Neither\nbinary reads a secret today, so nothing is mounted and the variable is not set; the value is\nhere for an operator adding one through `extraVolumes`.",
+          "required": [],
+          "title": "secretsDir",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "configMount"
+    },
     "extraEnv": {
       "description": "Additional environment variables for the application container.",
       "items": {
@@ -926,7 +982,7 @@
           "type": "string"
         },
         "tag": {
-          "default": "v0.14.1@sha256:35de635c75df40c839066e23d5b1180c4a1b3e44dd8868372e717f992b7f9d18",
+          "default": "v0.15.0@sha256:f2bd04006f3942f5b725e9f2a6fff4f88fe9c03fbb558f63edb224b45b190a7a",
           "description": "The container image tag, pinned by digest (`vX.Y.Z\npull, while the tag stays on as the readable version marker. Defaults to the chart's\n`appVersion` when empty.",
           "required": [],
           "title": "tag",
@@ -1489,6 +1545,43 @@
       ],
       "required": [],
       "title": "securityContextPreset"
+    },
+    "server": {
+      "additionalProperties": true,
+      "properties": {
+        "dataDir": {
+          "default": "/dist/data",
+          "description": "The converter's output, served under `/data` (`server.data_dir`). The default is where\nthe image puts it.",
+          "required": [],
+          "title": "dataDir",
+          "type": "string"
+        },
+        "distDir": {
+          "default": "/dist",
+          "description": "Built frontend served as the SPA (`server.dist_dir`). The server refuses to start unless\nit holds an `index.html`, which is both the entry point and the fallback for unknown routes.\nThe default is where the image puts it — change it only for an image that differs.",
+          "required": [],
+          "title": "distDir",
+          "type": "string"
+        },
+        "host": {
+          "default": "0.0.0.0",
+          "description": "Host half of the bind address (`server.bind_addr`). `0.0.0.0` is what makes the Service\nreach the listener.",
+          "required": [],
+          "title": "host",
+          "type": "string"
+        },
+        "port": {
+          "default": 8080,
+          "description": "Port half of the bind address (`server.bind_addr`). Also the container port, the Service\ntarget and what every probe and NetworkPolicy rule is written against.",
+          "maximum": 65535,
+          "minimum": 1,
+          "required": [],
+          "title": "port",
+          "type": "integer"
+        }
+      },
+      "required": [],
+      "title": "server"
     },
     "service": {
       "additionalProperties": true,

--- a/charts/mp-stats-legacy-viewer/values.yaml
+++ b/charts/mp-stats-legacy-viewer/values.yaml
@@ -23,7 +23,7 @@ image:
   # -- The container image tag, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the
   # pull, while the tag stays on as the readable version marker. Defaults to the chart's
   # `appVersion` when empty.
-  tag: v0.14.1@sha256:35de635c75df40c839066e23d5b1180c4a1b3e44dd8868372e717f992b7f9d18
+  tag: v0.15.0@sha256:f2bd04006f3942f5b725e9f2a6fff4f88fe9c03fbb558f63edb224b45b190a7a
 
   # @schema
   # enum: ["", Always, IfNotPresent, Never]
@@ -34,25 +34,75 @@ image:
 # @schema
 # additionalProperties: true
 # @schema
-application:
+server:
   # @schema
-  # additionalProperties: true
+  # type: string
   # @schema
-  # -- HTTP server configuration.
-  # Defines where the application listens for incoming connections.
-  server:
-    # @schema
-    # type: integer
-    # @schema
-    # -- Port number the server listens on.
-    port: 8080
+  # -- Host half of the bind address (`server.bind_addr`). `0.0.0.0` is what makes the Service
+  # reach the listener.
+  host: 0.0.0.0
 
-    # @schema
-    # type: string
-    # @schema
-    # -- Host address to bind the HTTP server.
-    # Typically `0.0.0.0` to listen on all network interfaces.
-    host: 0.0.0.0
+  # @schema
+  # type: integer
+  # minimum: 1
+  # maximum: 65535
+  # @schema
+  # -- Port half of the bind address (`server.bind_addr`). Also the container port, the Service
+  # target and what every probe and NetworkPolicy rule is written against.
+  port: 8080
+
+  # @schema
+  # type: string
+  # @schema
+  # -- Built frontend served as the SPA (`server.dist_dir`). The server refuses to start unless
+  # it holds an `index.html`, which is both the entry point and the fallback for unknown routes.
+  # The default is where the image puts it — change it only for an image that differs.
+  distDir: /dist
+
+  # @schema
+  # type: string
+  # @schema
+  # -- The converter's output, served under `/data` (`server.data_dir`). The default is where
+  # the image puts it.
+  dataDir: /dist/data
+
+# @schema
+# type: object
+# additionalProperties: true
+# @schema
+# -- Extra configuration, expressed as the TOML tree of
+# [the application's configuration reference](https://github.com/TimSchoenle/mp-stats-legacy-viewer/blob/main/docs/CONFIGURATION.md)
+# (`server.bind_addr`, `converter.*`, ...). Merged over everything the chart derives from the
+# values above, so it can both extend and override them. Rendered into the mounted ConfigMap —
+# never into the environment, which the loader refuses to combine with a file.
+config: {}
+
+# @schema
+# type: string
+# @schema
+# -- Verbatim TOML appended after the rendered configuration. The escape hatch for anything the
+# chart's TOML renderer cannot express, notably arrays of tables.
+configExtraToml: ""
+
+# @schema
+# additionalProperties: true
+# @schema
+configMount:
+  # @schema
+  # type: string
+  # @schema
+  # -- Directory the rendered `config.toml` is mounted at, passed as `MP_STATS_CONFIG`. Pointing
+  # this at the mount **replaces** the `/config.toml` the image ships, so everything the image
+  # described — the bind address, `dist_dir`, `data_dir` — is restated by the values above.
+  configDir: /etc/mp-stats/config
+
+  # @schema
+  # type: string
+  # @schema
+  # -- Directory credential files would be mounted at, passed as `MP_STATS_SECRETS_DIR`. Neither
+  # binary reads a secret today, so nothing is mounted and the variable is not set; the value is
+  # here for an operator adding one through `extraVolumes`.
+  secretsDir: /etc/mp-stats/secrets
 
 # @schema
 # additionalProperties: true

--- a/charts/netcup-offer-bot/Chart.yaml
+++ b/charts/netcup-offer-bot/Chart.yaml
@@ -1,7 +1,7 @@
 name: netcup-offer-bot
 description: This chart deploys the Netcup Offer Bot, which monitors https://www.netcup-sonderangebote.de/ RSS feed and sends notifications to Discord webhooks when new offers are available.
-version: 3.0.10
-appVersion: v1.5.24
+version: 4.0.0
+appVersion: v2.0.0
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts
 sources:
@@ -11,5 +11,5 @@ maintainers:
     email: contact@tim-schoenle.de
 dependencies:
   - name: common
-    version: 1.3.0
+    version: 1.4.0
     repository: "file://../common"

--- a/charts/netcup-offer-bot/README.md
+++ b/charts/netcup-offer-bot/README.md
@@ -1,6 +1,6 @@
 # netcup-offer-bot
 
-![Version: 3.0.10](https://img.shields.io/badge/Version-3.0.10-informational?style=flat-square) ![AppVersion: v1.5.24](https://img.shields.io/badge/AppVersion-v1.5.24-informational?style=flat-square)
+![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![AppVersion: v2.0.0](https://img.shields.io/badge/AppVersion-v2.0.0-informational?style=flat-square)
 
 This chart deploys the Netcup Offer Bot, which monitors https://www.netcup-sonderangebote.de/ RSS feed and sends notifications to Discord webhooks when new offers are available.
 
@@ -22,7 +22,7 @@ helm repo update
 
 helm install [RELEASE_NAME] timschoenle/netcup-offer-bot \
   --namespace [NAMESPACE] --create-namespace \
-  --set env.webHook="https://discord.com/api/webhooks/..."
+  --set discord.webhookUrl="https://discord.com/api/webhooks/..."
 ```
 
 Upgrade with `helm upgrade [RELEASE_NAME] timschoenle/netcup-offer-bot -n [NAMESPACE]`,
@@ -30,21 +30,41 @@ remove with `helm uninstall [RELEASE_NAME] -n [NAMESPACE]`.
 
 ## Keeping the webhook out of the release
 
-`env.webHook` is written into a Secret, but it still passes through `values.yaml` and stays
-readable in the Helm release object afterwards. Point `existingSecret` at a Secret you created
-yourself to avoid both:
+`discord.webhookUrl` is written into a Secret, but it still passes through `values.yaml` and
+stays readable in the Helm release object afterwards. Point `existingSecret` at a Secret you
+created yourself to avoid both:
 
 ```shell
-kubectl create secret generic netcup-webhook \
-  --namespace [NAMESPACE] \
-  --from-literal=webHook='https://discord.com/api/webhooks/...'
+kubectl create secret generic netcup-webhook   --namespace [NAMESPACE]   --from-literal=discord__webhook_url='https://discord.com/api/webhooks/...'
 ```
 
 ```yaml
 existingSecret: netcup-webhook
 ```
 
-`env.webHook` is then ignored.
+**The key name is the configuration path the bot reads, not a free-form name.** The webhook
+arrives as a file in a projected volume and the bot takes the key out of the file *name*, so
+`discord__webhook_url` is required; a Secret spelled any other way mounts cleanly, supplies
+nothing, and the bot refuses to boot naming the missing credential.
+
+`discord.webhookUrl` is then ignored.
+
+## Configuration
+
+Everything the bot reads is rendered into one `config.toml`, mounted as a ConfigMap and pointed
+at by `NETCUP_OFFER_BOT_CONFIG`; the webhook is mounted separately as a file under
+`NETCUP_OFFER_BOT_SECRETS_DIR`. Nothing is passed as an environment variable, and that is
+deliberate on two counts: the loader **fails the boot on a key supplied by both the environment
+and a file** rather than resolving it by precedence, and an environment variable is visible in
+`kubectl describe pod`, in `/proc/<pid>/environ` and in the environment of every child process
+— which for a webhook URL is exactly the exposure worth removing.
+
+The values above cover the whole documented surface. `config` takes the raw TOML tree for
+anything they do not, merged over the derived one, and `configExtraToml` is appended verbatim
+for what the renderer cannot express.
+
+The bot does not reload its configuration, so the chart keeps the conventional `checksum/*` pod
+annotations: a configuration change rolls the Deployment, which is the only way it takes effect.
 
 ## State and restarts
 
@@ -77,8 +97,38 @@ metrics:
 
 Without a matching label the PodMonitor is created and never read.
 
-`env.sentryDns` additionally routes application errors to Sentry; leave it empty to keep the
-bot's egress to Discord and the netcup feed only.
+`metrics.ip` defaults to `0.0.0.0` rather than to the bot's own `127.0.0.1`, which answers
+nothing from outside the container — a PodMonitor pointed at that would scrape a refused
+connection.
+
+`telemetry.sentryDsn` additionally routes application errors to Sentry; leave it empty to keep
+the bot's egress to Discord and the netcup feed only.
+
+## Upgrading
+
+### 3.x to 4.0
+
+Chart 4.0 tracks the bot's 2.0 release, which replaced its environment-only configuration with
+the layered, file-first loader every chart in this repository now uses. The `env` block that
+described that environment is gone; a `helm upgrade` with 3.x values fails schema validation
+naming the offending key rather than starting a pod on the defaults.
+
+| Before | After |
+|---|---|
+| `env.webHook` | `discord.webhookUrl` |
+| `env.checkInterval` | `feed.checkIntervalSecs` |
+| `env.logLevel` | `telemetry.logLevel` (now `TRACE`/`DEBUG`/`INFO`/`WARN`/`ERROR`) |
+| `env.sentryDns` | `telemetry.sentryDsn` |
+
+**An existing Secret has to be re-keyed** from `webHook` to `discord__webhook_url`:
+
+```shell
+kubectl create secret generic netcup-webhook   --namespace [NAMESPACE]   --from-literal=discord__webhook_url="$(kubectl get secret netcup-webhook -n [NAMESPACE] -o jsonpath='{.data.webHook}' | base64 -d)"   --dry-run=client -o yaml | kubectl apply -f -
+```
+
+One fix rides along: `metrics.ip` is now a real value and defaults to `0.0.0.0`. The 3.x chart
+read a `metrics.ip` that its `values.yaml` never declared, so the exporter kept the bot's
+`127.0.0.1` default and the PodMonitor scraped a refused connection.
 
 ## Values
 
@@ -88,28 +138,31 @@ bot's egress to Discord and the netcup feed only.
 | automountServiceAccountToken | bool | `false` | Mount the ServiceAccount API token into the pod. Set on the pod itself, which is what actually keeps the token out of the container: the ServiceAccount-level setting is ignored as soon as a pod names a different account. |
 | commonAnnotations | object | `{}` | Annotations added to every object this chart creates. |
 | commonLabels | object | `{}` | Labels added to every object this chart creates. |
-| env.checkInterval | int | `180` | Interval in seconds between offer checks. |
-| env.logLevel | string | `"info"` | Log level for the application. |
-| env.sentryDns | string | `""` | Sentry DSN for error tracking. Leave empty to disable. |
-| env.webHook | string | `""` | Webhook URL to send updates or notifications. Required unless `existingSecret` is set. |
-| existingSecret | string | `""` | Name of an existing Secret holding the `webHook` key. When set, the chart does not create a Secret and `env.webHook` is ignored — which keeps the webhook URL out of `values.yaml` and out of the Helm release object. |
+| config | object | `{}` | Extra configuration, expressed as the TOML tree of [the bot's README](https://github.com/TimSchoenle/netcup-offer-bot#configuration) (`feed.check_interval_secs`, `metrics.port`, ...). Merged over everything the chart derives from the values above, so it can both extend and override them. Rendered into the mounted ConfigMap — never into the environment, which the loader refuses to combine with a file. |
+| configExtraToml | string | `""` | Verbatim TOML appended after the rendered configuration. The escape hatch for anything the chart's TOML renderer cannot express, notably arrays of tables. |
+| configMount.configDir | string | `"/etc/netcup-offer-bot/config"` | Directory the rendered `config.toml` is mounted at, passed as `NETCUP_OFFER_BOT_CONFIG`. |
+| configMount.secretsDir | string | `"/etc/netcup-offer-bot/secrets"` | Directory the credential file is mounted at, passed as `NETCUP_OFFER_BOT_SECRETS_DIR`. |
+| discord.webhookUrl | string | `""` | Discord webhook the offers are posted to (`discord.webhook_url`). Rendered into the chart's Secret and mounted as a file rather than passed as an environment variable, so it never appears in `kubectl describe pod` or in the environment of a child process. Required unless `existingSecret` supplies it. |
+| existingSecret | string | `""` | Name of an existing Secret holding the Discord webhook, which keeps it out of `values.yaml` and out of the Helm release object. **Its key is the configuration path, not a free-form name**: `discord__webhook_url`, because the file name is what the loader parses. Set, the chart renders no Secret of its own and `discord.webhookUrl` is ignored. |
 | extraEnv | list | `[]` | Additional environment variables for the application container. |
 | extraVolumeMounts | list | `[]` | Additional volume mounts added to the application container. |
 | extraVolumes | list | `[]` | Additional volumes added to the pod. |
+| feed.checkIntervalSecs | int | `180` | Seconds between two RSS feed checks (`feed.check_interval_secs`). |
 | fullnameOverride | string | `""` | Override the full generated resource name. |
 | image.pullPolicy | string | `""` | The image pull policy. Empty resolves automatically from the tag/digest. |
 | image.registry | string | `""` | Registry host. Empty means Docker Hub. |
 | image.repository | string | `"timmi6790/netcup-offer-bot"` | The container image repository. |
-| image.tag | string | `"v1.5.24@sha256:358897a7b824b78d32d85cec7990b5d6a74a94deedfbe66663c4ff3b7d7d994d"` | The container image tag. Defaults to the chart's `appVersion` when empty. |
+| image.tag | string | `"v2.0.0@sha256:ca4777a39e389609910492c2668ad524295512065a41bf8ffad849004b832efb"` | The container image tag. Defaults to the chart's `appVersion` when empty. |
 | imagePullSecrets | list | `[]` | Optional image pull secrets for private registries |
 | kubeVersionOverride | string | `""` | Kubernetes version to target when branching on API availability. Lets `helm template` render for a specific cluster version without a live connection. |
 | metrics.enabled | bool | `false` | Enable Prometheus metrics endpoint. |
+| metrics.ip | string | `"0.0.0.0"` | Address the Prometheus exporter binds (`metrics.ip`). The bot's own default is `127.0.0.1`, which answers nothing from outside the container — a PodMonitor pointed at it scrapes a refused connection. |
 | metrics.podMonitor | object | `{"enabled":true,"interval":"1m","labels":{},"scrapeTimeout":"30s"}` | PodMonitor configuration for Prometheus Operator integration. Renamed from `serviceMonitor`: the chart has always rendered a PodMonitor, and there is no Service to monitor. |
 | metrics.podMonitor.enabled | bool | `true` | Create the PodMonitor. Requires the Prometheus Operator CRDs. |
 | metrics.podMonitor.interval | string | `"1m"` | Metrics scrape interval (e.g., 1m, 30s). |
 | metrics.podMonitor.labels | object | `{}` | Extra labels for the PodMonitor, e.g. the `release` label a Prometheus Operator instance selects on. |
 | metrics.podMonitor.scrapeTimeout | string | `"30s"` | Timeout for metrics scraping (e.g., 30s). |
-| metrics.port | int | `9184` | Port to expose metrics on. |
+| metrics.port | int | `9184` | Port the Prometheus exporter listens on (`metrics.port`). |
 | nameOverride | string | `""` | Override the chart name used in resource names and labels. |
 | namespaceOverride | string | `""` | Deploy into a namespace other than the release namespace. |
 | networkPolicy | object | `{"egress":{"cidr":"0.0.0.0/0","customRules":[],"dns":{"enabled":true,"namespaceSelector":{"kubernetes.io/metadata.name":"kube-system"},"podSelector":{"k8s-app":"kube-dns"}},"enabled":true,"except":["10.0.0.0/8","172.16.0.0/12","192.168.0.0/16","169.254.0.0/16"],"http":{"enabled":false},"https":{"enabled":true}},"enabled":false,"ingress":{"controller":{"enabled":true,"namespace":"traefik","selector":{"app.kubernetes.io/name":"traefik"}},"customRules":[],"enabled":true,"monitoring":{"enabled":true,"namespace":"monitoring"}}}` | Network policy configuration |
@@ -169,6 +222,8 @@ bot's egress to Discord and the netcup feed only.
 | serviceAccount.create | bool | `true` | Whether to create a dedicated service account |
 | serviceAccount.name | string | `""` | Custom service account name (auto-generated if empty) |
 | strategy | object | `{}` | Deployment update strategy. Empty uses the Kubernetes default rolling update. |
+| telemetry.logLevel | string | `"INFO"` | Log level (`telemetry.log_level`). |
+| telemetry.sentryDsn | string | `""` | Sentry DSN (`telemetry.sentry_dsn`). Empty disables Sentry entirely. |
 | terminationGracePeriodSeconds | int | `30` | Grace period for pod shutdown. |
 | tolerations | list | `[]` | Tolerations for pod assignment. |
 | topologySpreadConstraints | list | `[]` | Pod topology spread constraints for availability |

--- a/charts/netcup-offer-bot/README.md.gotmpl
+++ b/charts/netcup-offer-bot/README.md.gotmpl
@@ -24,7 +24,7 @@ helm repo update
 
 helm install [RELEASE_NAME] timschoenle/{{ template "chart.name" . }} \
   --namespace [NAMESPACE] --create-namespace \
-  --set env.webHook="https://discord.com/api/webhooks/..."
+  --set discord.webhookUrl="https://discord.com/api/webhooks/..."
 ```
 
 Upgrade with `helm upgrade [RELEASE_NAME] timschoenle/{{ template "chart.name" . }} -n [NAMESPACE]`,
@@ -32,21 +32,41 @@ remove with `helm uninstall [RELEASE_NAME] -n [NAMESPACE]`.
 
 ## Keeping the webhook out of the release
 
-`env.webHook` is written into a Secret, but it still passes through `values.yaml` and stays
-readable in the Helm release object afterwards. Point `existingSecret` at a Secret you created
-yourself to avoid both:
+`discord.webhookUrl` is written into a Secret, but it still passes through `values.yaml` and
+stays readable in the Helm release object afterwards. Point `existingSecret` at a Secret you
+created yourself to avoid both:
 
 ```shell
-kubectl create secret generic netcup-webhook \
-  --namespace [NAMESPACE] \
-  --from-literal=webHook='https://discord.com/api/webhooks/...'
+kubectl create secret generic netcup-webhook   --namespace [NAMESPACE]   --from-literal=discord__webhook_url='https://discord.com/api/webhooks/...'
 ```
 
 ```yaml
 existingSecret: netcup-webhook
 ```
 
-`env.webHook` is then ignored.
+**The key name is the configuration path the bot reads, not a free-form name.** The webhook
+arrives as a file in a projected volume and the bot takes the key out of the file *name*, so
+`discord__webhook_url` is required; a Secret spelled any other way mounts cleanly, supplies
+nothing, and the bot refuses to boot naming the missing credential.
+
+`discord.webhookUrl` is then ignored.
+
+## Configuration
+
+Everything the bot reads is rendered into one `config.toml`, mounted as a ConfigMap and pointed
+at by `NETCUP_OFFER_BOT_CONFIG`; the webhook is mounted separately as a file under
+`NETCUP_OFFER_BOT_SECRETS_DIR`. Nothing is passed as an environment variable, and that is
+deliberate on two counts: the loader **fails the boot on a key supplied by both the environment
+and a file** rather than resolving it by precedence, and an environment variable is visible in
+`kubectl describe pod`, in `/proc/<pid>/environ` and in the environment of every child process
+— which for a webhook URL is exactly the exposure worth removing.
+
+The values above cover the whole documented surface. `config` takes the raw TOML tree for
+anything they do not, merged over the derived one, and `configExtraToml` is appended verbatim
+for what the renderer cannot express.
+
+The bot does not reload its configuration, so the chart keeps the conventional `checksum/*` pod
+annotations: a configuration change rolls the Deployment, which is the only way it takes effect.
 
 ## State and restarts
 
@@ -79,8 +99,38 @@ metrics:
 
 Without a matching label the PodMonitor is created and never read.
 
-`env.sentryDns` additionally routes application errors to Sentry; leave it empty to keep the
-bot's egress to Discord and the netcup feed only.
+`metrics.ip` defaults to `0.0.0.0` rather than to the bot's own `127.0.0.1`, which answers
+nothing from outside the container — a PodMonitor pointed at that would scrape a refused
+connection.
+
+`telemetry.sentryDsn` additionally routes application errors to Sentry; leave it empty to keep
+the bot's egress to Discord and the netcup feed only.
+
+## Upgrading
+
+### 3.x to 4.0
+
+Chart 4.0 tracks the bot's 2.0 release, which replaced its environment-only configuration with
+the layered, file-first loader every chart in this repository now uses. The `env` block that
+described that environment is gone; a `helm upgrade` with 3.x values fails schema validation
+naming the offending key rather than starting a pod on the defaults.
+
+| Before | After |
+|---|---|
+| `env.webHook` | `discord.webhookUrl` |
+| `env.checkInterval` | `feed.checkIntervalSecs` |
+| `env.logLevel` | `telemetry.logLevel` (now `TRACE`/`DEBUG`/`INFO`/`WARN`/`ERROR`) |
+| `env.sentryDns` | `telemetry.sentryDsn` |
+
+**An existing Secret has to be re-keyed** from `webHook` to `discord__webhook_url`:
+
+```shell
+kubectl create secret generic netcup-webhook   --namespace [NAMESPACE]   --from-literal=discord__webhook_url="$(kubectl get secret netcup-webhook -n [NAMESPACE] -o jsonpath='{.data.webHook}' | base64 -d)"   --dry-run=client -o yaml | kubectl apply -f -
+```
+
+One fix rides along: `metrics.ip` is now a real value and defaults to `0.0.0.0`. The 3.x chart
+read a `metrics.ip` that its `values.yaml` never declared, so the exporter kept the bot's
+`127.0.0.1` default and the PodMonitor scraped a refused connection.
 
 {{ template "chart.valuesSection" . }}
 

--- a/charts/netcup-offer-bot/ci/networkpolicy-values.yaml
+++ b/charts/netcup-offer-bot/ci/networkpolicy-values.yaml
@@ -1,5 +1,5 @@
-env:
-  webHook: "https://test.google.com/webhook"
+discord:
+  webhookUrl: "https://test.google.com/webhook"
 
 networkPolicy:
   enabled: true

--- a/charts/netcup-offer-bot/ci/no-persistence-values.yaml
+++ b/charts/netcup-offer-bot/ci/no-persistence-values.yaml
@@ -1,5 +1,5 @@
-env:
-  webHook: "https://test.google.com/webhook"
+discord:
+  webhookUrl: "https://test.google.com/webhook"
 
 persistence:
   data:

--- a/charts/netcup-offer-bot/ci/test-values.yaml
+++ b/charts/netcup-offer-bot/ci/test-values.yaml
@@ -1,3 +1,3 @@
-env:
+discord:
   # Discord webhook url
-  webHook: "https://test.google.com/webhook"
+  webhookUrl: "https://test.google.com/webhook"

--- a/charts/netcup-offer-bot/templates/_helpers.tpl
+++ b/charts/netcup-offer-bot/templates/_helpers.tpl
@@ -13,3 +13,76 @@ persistentVolumeClaim:
   claimName: {{ .Values.persistence.data.existingClaim | default (include "common.fullname" .) }}
 {{- end }}
 {{- end -}}
+
+{{/*
+The configuration the chart derives from its own first-class values, as the TOML tree the bot
+reads.
+
+`metrics` is emitted only when the exporter is on: written unconditionally it would bind a
+listener no PodMonitor scrapes and no Service exposes. Optional keys are omitted rather than
+written empty — an empty `telemetry.sentry_dsn` is a *supplied* value to the loader, and
+"Sentry configured with a blank DSN" is not what an operator who left it unset meant.
+*/}}
+{{- define "netcup-offer-bot.derivedConfig" -}}
+feed:
+  check_interval_secs: {{ .Values.feed.checkIntervalSecs }}
+telemetry:
+  log_level: {{ .Values.telemetry.logLevel | quote }}
+  {{- with .Values.telemetry.sentryDsn }}
+  sentry_dsn: {{ . | quote }}
+  {{- end }}
+{{- if .Values.metrics.enabled }}
+metrics:
+  ip: {{ .Values.metrics.ip | quote }}
+  port: {{ .Values.metrics.port }}
+{{- end }}
+{{- end -}}
+
+{{/*
+The configuration that actually reaches the bot: the derived tree with the operator's own
+`config` tree merged over it, so `config` can both extend and override the values above.
+
+Not included: `configExtraToml`, which is appended verbatim and never parsed.
+*/}}
+{{- define "netcup-offer-bot.effectiveConfig" -}}
+{{- $derived := include "netcup-offer-bot.derivedConfig" . | fromYaml -}}
+{{- toYaml (mergeOverwrite $derived (deepCopy (.Values.config | default dict))) -}}
+{{- end -}}
+
+{{/*
+The complete `config.toml`: the effective tree, then the verbatim escape hatch.
+*/}}
+{{- define "netcup-offer-bot.configToml" -}}
+{{- $config := include "netcup-offer-bot.effectiveConfig" . | fromYaml -}}
+{{- include "common.configToml" (dict "ctx" . "maps" (list $config)) -}}
+{{- end -}}
+
+{{/*
+The credential this chart manages, keyed by the file name the loader reads it from: a
+configuration path with `__` for nesting and no dots, because a `.` in the name is refused
+rather than treated as a separator.
+*/}}
+{{- define "netcup-offer-bot.secretData" -}}
+discord__webhook_url: {{ .Values.discord.webhookUrl | quote }}
+{{- end -}}
+
+{{/*
+The secret file names this pod projects, as a YAML list. Parse with `fromYamlArray`.
+*/}}
+{{- define "netcup-offer-bot.secretKeys" -}}
+{{- $data := include "netcup-offer-bot.secretData" . | fromYaml -}}
+{{- include "common.fileConfig.secretKeys" (dict "ctx" . "data" $data) -}}
+{{- end -}}
+
+{{/*
+Refuse a render that could only produce a bot with nowhere to post.
+
+Checked against the projected key list rather than against `.Values.discord.webhookUrl`, so an
+`existingSecret` counts — the chart cannot see inside one, and a webhook it cannot see is not
+the same as a webhook that is missing.
+*/}}
+{{- define "netcup-offer-bot.validateValues" -}}
+{{- if not (include "netcup-offer-bot.secretKeys" .) -}}
+{{- fail (printf "\n\nVALUES VALIDATION FAILED for chart %q:\n  - discord.webhookUrl is required unless existingSecret supplies `discord__webhook_url`\n" .Chart.Name) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/netcup-offer-bot/templates/deployment.yaml
+++ b/charts/netcup-offer-bot/templates/deployment.yaml
@@ -39,12 +39,25 @@ spec:
         {{- if and .Values.metrics.enabled .Values.metrics.port }}
         {{- $ports = list (dict "name" "metrics" "containerPort" (int .Values.metrics.port) "protocol" "TCP") }}
         {{- end }}
+        {{- /*
+          Configuration reaches the container as files, never as environment variables: the
+          loader fails the boot on a key supplied by both, and the webhook stays out of
+          `kubectl describe pod` and out of every child process's environment. The two
+          variables below decide what the file layers *are*, so they are the one thing that
+          cannot itself be file-sourced.
+        */}}
+        {{- $secretKeys := include "netcup-offer-bot.secretKeys" . | fromYamlArray }}
+        {{- $mounts := concat
+              (include "common.fileConfig.volumeMounts" (dict "ctx" $ "secretKeys" $secretKeys) | fromYamlArray)
+              (list (dict "name" "data" "mountPath" "/app/data")) }}
         {{- include "common.container" (dict
               "ctx" $
               "ports" $ports
-              "envFrom" (list (dict "configMapRef" (dict "name" (include "common.fullname" .))))
-              "env" (list (dict "name" "WEB_HOOK" "valueFrom" (dict "secretKeyRef" (dict "name" (include "common.secretName" .) "key" "webHook"))))
-              "volumeMounts" (list (dict "name" "data" "mountPath" "/app/data"))
+              "env" (include "common.fileConfig.env" (dict "ctx" $ "prefix" "NETCUP_OFFER_BOT" "secretKeys" $secretKeys) | fromYamlArray)
+              "volumeMounts" $mounts
             ) | nindent 8 }}
+      {{- $volumes := concat
+            (include "common.fileConfig.volumes" (dict "ctx" $ "secretKeys" $secretKeys) | fromYamlArray)
+            (list (include "netcup-offer-bot.dataVolume" . | fromYaml)) }}
       volumes:
-        {{- include "common.volumes" (dict "ctx" $ "volumes" (list (include "netcup-offer-bot.dataVolume" . | fromYaml))) | nindent 8 }}
+        {{- include "common.volumes" (dict "ctx" $ "volumes" $volumes) | nindent 8 }}

--- a/charts/netcup-offer-bot/templates/secret.yaml
+++ b/charts/netcup-offer-bot/templates/secret.yaml
@@ -1,4 +1,5 @@
-{{- if (include "common.createSecret" .) }}
+{{- $data := include "netcup-offer-bot.secretData" . | fromYaml }}
+{{- if (include "common.fileConfig.createSecret" (dict "ctx" . "data" $data)) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,5 +13,11 @@ metadata:
   {{- end }}
 type: Opaque
 stringData:
-  webHook: {{ required "env.webHook is required unless existingSecret is set" .Values.env.webHook | quote }}
+  {{- /*
+    The key name is the configuration path with `__` for nesting and no dots, because that is
+    how a file in `NETCUP_OFFER_BOT_SECRETS_DIR` has to be named — the loader reads the key out
+    of the file *name*. Rendered as `stringData` so the value stays readable in a diff review;
+    Kubernetes stores it base64-encoded either way.
+  */}}
+  {{- include "common.fileConfig.secretData" (dict "data" $data) | nindent 2 }}
 {{- end }}

--- a/charts/netcup-offer-bot/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/netcup-offer-bot/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2,9 +2,12 @@ matches the committed Deployment snapshot:
   1: |
     apiVersion: v1
     data:
-      CHECK_INTERVAL: "180"
-      LOG_LEVEL: info
-      METRIC_PORT: "9184"
+      config.toml: |
+        [feed]
+        check_interval_secs = 180
+
+        [telemetry]
+        log_level = "INFO"
     kind: ConfigMap
     metadata:
       labels:
@@ -39,8 +42,8 @@ matches the committed Deployment snapshot:
       template:
         metadata:
           annotations:
-            checksum/configmap: f1554be1426471b88ae7097db5d823109398eae8a835b9472a3344aaa7697515
-            checksum/secret: 61d6ee818dcbf9d9fc090e9cdfc3fd832612413709f397300ab02523059e7cd7
+            checksum/configmap: 58c12855c71b1cf19d46cc3832e82816fa7cfe2d44e3628e1982c2961462e998
+            checksum/secret: 577aa58622be9fb6ea87495c17e4adfb9f66b67ff2ad792ea4a1f27446103956
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -50,14 +53,10 @@ matches the committed Deployment snapshot:
           automountServiceAccountToken: false
           containers:
             - env:
-                - name: WEB_HOOK
-                  valueFrom:
-                    secretKeyRef:
-                      key: webHook
-                      name: RELEASE-NAME-netcup-offer-bot
-              envFrom:
-                - configMapRef:
-                    name: RELEASE-NAME-netcup-offer-bot
+                - name: NETCUP_OFFER_BOT_CONFIG
+                  value: /etc/netcup-offer-bot/config
+                - name: NETCUP_OFFER_BOT_SECRETS_DIR
+                  value: /etc/netcup-offer-bot/secrets
               image: timmi6790/netcup-offer-bot:v0.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
               imagePullPolicy: IfNotPresent
               name: netcup-offer-bot
@@ -78,6 +77,12 @@ matches the committed Deployment snapshot:
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp
+                - mountPath: /etc/netcup-offer-bot/config
+                  name: config
+                  readOnly: true
+                - mountPath: /etc/netcup-offer-bot/secrets
+                  name: secrets
+                  readOnly: true
                 - mountPath: /app/data
                   name: data
           securityContext:
@@ -93,6 +98,19 @@ matches the committed Deployment snapshot:
           volumes:
             - emptyDir: {}
               name: tmp
+            - configMap:
+                name: RELEASE-NAME-netcup-offer-bot
+              name: config
+            - name: secrets
+              projected:
+                defaultMode: 256
+                sources:
+                  - secret:
+                      items:
+                        - key: discord__webhook_url
+                          path: discord__webhook_url
+                      name: RELEASE-NAME-netcup-offer-bot
+                      optional: true
             - name: data
               persistentVolumeClaim:
                 claimName: RELEASE-NAME-netcup-offer-bot
@@ -109,15 +127,18 @@ matches the committed Deployment snapshot:
       name: RELEASE-NAME-netcup-offer-bot
       namespace: NAMESPACE
     stringData:
-      webHook: https://example.invalid/hook
+      discord__webhook_url: https://example.invalid/hook
     type: Opaque
 matches the committed Deployment snapshot with network policies and probes on:
   1: |
     apiVersion: v1
     data:
-      CHECK_INTERVAL: "180"
-      LOG_LEVEL: info
-      METRIC_PORT: "9184"
+      config.toml: |
+        [feed]
+        check_interval_secs = 180
+
+        [telemetry]
+        log_level = "INFO"
     kind: ConfigMap
     metadata:
       labels:
@@ -152,8 +173,8 @@ matches the committed Deployment snapshot with network policies and probes on:
       template:
         metadata:
           annotations:
-            checksum/configmap: f1554be1426471b88ae7097db5d823109398eae8a835b9472a3344aaa7697515
-            checksum/secret: 61d6ee818dcbf9d9fc090e9cdfc3fd832612413709f397300ab02523059e7cd7
+            checksum/configmap: 58c12855c71b1cf19d46cc3832e82816fa7cfe2d44e3628e1982c2961462e998
+            checksum/secret: 577aa58622be9fb6ea87495c17e4adfb9f66b67ff2ad792ea4a1f27446103956
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -173,14 +194,10 @@ matches the committed Deployment snapshot with network policies and probes on:
           automountServiceAccountToken: false
           containers:
             - env:
-                - name: WEB_HOOK
-                  valueFrom:
-                    secretKeyRef:
-                      key: webHook
-                      name: RELEASE-NAME-netcup-offer-bot
-              envFrom:
-                - configMapRef:
-                    name: RELEASE-NAME-netcup-offer-bot
+                - name: NETCUP_OFFER_BOT_CONFIG
+                  value: /etc/netcup-offer-bot/config
+                - name: NETCUP_OFFER_BOT_SECRETS_DIR
+                  value: /etc/netcup-offer-bot/secrets
               image: timmi6790/netcup-offer-bot:v0.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
               imagePullPolicy: IfNotPresent
               name: netcup-offer-bot
@@ -201,6 +218,12 @@ matches the committed Deployment snapshot with network policies and probes on:
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp
+                - mountPath: /etc/netcup-offer-bot/config
+                  name: config
+                  readOnly: true
+                - mountPath: /etc/netcup-offer-bot/secrets
+                  name: secrets
+                  readOnly: true
                 - mountPath: /app/data
                   name: data
           nodeSelector:
@@ -218,6 +241,19 @@ matches the committed Deployment snapshot with network policies and probes on:
           volumes:
             - emptyDir: {}
               name: tmp
+            - configMap:
+                name: RELEASE-NAME-netcup-offer-bot
+              name: config
+            - name: secrets
+              projected:
+                defaultMode: 256
+                sources:
+                  - secret:
+                      items:
+                        - key: discord__webhook_url
+                          path: discord__webhook_url
+                      name: RELEASE-NAME-netcup-offer-bot
+                      optional: true
             - name: data
               persistentVolumeClaim:
                 claimName: RELEASE-NAME-netcup-offer-bot
@@ -234,5 +270,5 @@ matches the committed Deployment snapshot with network policies and probes on:
       name: RELEASE-NAME-netcup-offer-bot
       namespace: NAMESPACE
     stringData:
-      webHook: https://example.invalid/hook
+      discord__webhook_url: https://example.invalid/hook
     type: Opaque

--- a/charts/netcup-offer-bot/tests/configmap_test.yaml
+++ b/charts/netcup-offer-bot/tests/configmap_test.yaml
@@ -1,19 +1,86 @@
 suite: configmap
 templates:
   - configmap.yaml
+set:
+  discord.webhookUrl: https://example.invalid/hook
 tests:
-  - it: carries the bot configuration
+  - it: renders the configuration as a single TOML file
     asserts:
       - isKind:
           of: ConfigMap
       - equal:
           path: metadata.name
           value: RELEASE-NAME-netcup-offer-bot
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[feed\]\ncheck_interval_secs = 180'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[telemetry\]\nlog_level = "INFO"'
 
   - it: reflects a changed check interval
     set:
-      env.checkInterval: 600
+      feed.checkIntervalSecs: 600
     asserts:
-      - equal:
-          path: data.CHECK_INTERVAL
-          value: "600"
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'check_interval_secs = 600'
+
+  # Written unconditionally the exporter would bind a listener nothing scrapes.
+  - it: configures the exporter only when metrics are enabled
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: '\[metrics\]'
+
+  # The bot's own default is 127.0.0.1, which answers nothing from outside the container, so a
+  # PodMonitor pointed at it would scrape a refused connection.
+  - it: binds the exporter to every interface so the PodMonitor can reach it
+    set:
+      metrics.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[metrics\]\nip = "0\.0\.0\.0"\nport = 9184'
+
+  # An empty optional value is still a *supplied* value to the loader.
+  - it: omits an unset Sentry DSN rather than writing it empty
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'sentry_dsn'
+
+  - it: merges the raw config tree over the derived values
+    set:
+      config:
+        feed:
+          check_interval_secs: 30
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'check_interval_secs = 30'
+
+  # The webhook is a credential: it belongs in the projected Secret volume, never in a
+  # ConfigMap anyone with namespace read access can print.
+  - it: keeps the webhook out of the ConfigMap
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'webhook_url'
+
+  - it: fails loudly when no webhook is configured at all
+    set:
+      discord.webhookUrl: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "discord.webhookUrl is required unless existingSecret supplies"
+
+  # The chart cannot see inside an `existingSecret`, and a webhook it cannot see is not the
+  # same as a webhook that is missing.
+  - it: accepts an existing Secret as the webhook it cannot see
+    set:
+      discord.webhookUrl: ""
+      existingSecret: my-webhook-secret
+    asserts:
+      - isKind:
+          of: ConfigMap

--- a/charts/netcup-offer-bot/tests/deployment_test.yaml
+++ b/charts/netcup-offer-bot/tests/deployment_test.yaml
@@ -4,7 +4,7 @@ templates:
   - configmap.yaml
   - secret.yaml
 set:
-  env.webHook: https://example.invalid/hook
+  discord.webhookUrl: https://example.invalid/hook
 tests:
   - it: creates a Deployment named after the release
     documentSelector:
@@ -17,35 +17,89 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-netcup-offer-bot
 
-  - it: reads the webhook from the generated Secret
+  # The whole point of the migration: the loader refuses a key supplied by both the environment
+  # and a file, and the webhook no longer appears in `kubectl describe pod` or in the
+  # environment of a child process. The only variables left are the two that decide what the
+  # file layers are.
+  - it: passes configuration as files, not as environment
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env
+          value:
+            - name: NETCUP_OFFER_BOT_CONFIG
+              value: /etc/netcup-offer-bot/config
+            - name: NETCUP_OFFER_BOT_SECRETS_DIR
+              value: /etc/netcup-offer-bot/secrets
+      - notExists:
+          path: spec.template.spec.containers[0].envFrom
+
+  - it: mounts the rendered configuration read-only
     documentSelector:
       path: kind
       value: Deployment
     asserts:
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.volumes
           content:
-            name: WEB_HOOK
-            valueFrom:
-              secretKeyRef:
-                name: RELEASE-NAME-netcup-offer-bot
-                key: webHook
+            name: config
+            configMap:
+              name: RELEASE-NAME-netcup-offer-bot
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /etc/netcup-offer-bot/config
+            readOnly: true
 
-  - it: reads it from an existing Secret when one is given
+  - it: projects the webhook the bot reads by file name
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: secrets
+            projected:
+              defaultMode: 256
+              sources:
+                - secret:
+                    name: RELEASE-NAME-netcup-offer-bot
+                    optional: true
+                    items:
+                      - key: discord__webhook_url
+                        path: discord__webhook_url
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: secrets
+            mountPath: /etc/netcup-offer-bot/secrets
+            readOnly: true
+
+  - it: projects an existing Secret when one is given
     documentSelector:
       path: kind
       value: Deployment
     set:
+      discord.webhookUrl: null
       existingSecret: my-webhook-secret
     asserts:
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.volumes
           content:
-            name: WEB_HOOK
-            valueFrom:
-              secretKeyRef:
-                name: my-webhook-secret
-                key: webHook
+            name: secrets
+            projected:
+              defaultMode: 256
+              sources:
+                - secret:
+                    name: my-webhook-secret
+                    optional: true
+                    items:
+                      - key: discord__webhook_url
+                        path: discord__webhook_url
 
   - it: mounts the state volume the bot needs to avoid re-announcing offers
     documentSelector:

--- a/charts/netcup-offer-bot/tests/secret_test.yaml
+++ b/charts/netcup-offer-bot/tests/secret_test.yaml
@@ -2,9 +2,11 @@ suite: secret
 templates:
   - secret.yaml
 tests:
-  - it: creates a Secret from the configured webhook
+  # The key name is the configuration path: the loader reads it out of the file *name*, so
+  # `webHook` next to `discord__webhook_url` is not a cosmetic difference.
+  - it: creates a Secret keyed by configuration path
     set:
-      env.webHook: https://example.invalid/hook
+      discord.webhookUrl: https://example.invalid/hook
     asserts:
       - isKind:
           of: Secret
@@ -14,7 +16,7 @@ tests:
       # stringData, not a hand-rolled b64enc into `data`: Kubernetes does the encoding and
       # a wrongly-encoded value can no longer be committed.
       - equal:
-          path: stringData.webHook
+          path: stringData.discord__webhook_url
           value: https://example.invalid/hook
 
   - it: creates nothing when an existing Secret is supplied
@@ -23,8 +25,3 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-
-  - it: fails loudly when neither is configured
-    asserts:
-      - failedTemplate:
-          errorMessage: "env.webHook is required unless existingSecret is set"

--- a/charts/netcup-offer-bot/tests/security_test.yaml
+++ b/charts/netcup-offer-bot/tests/security_test.yaml
@@ -9,7 +9,7 @@ documentSelector:
   path: kind
   value: Deployment
 set:
-  env.webHook: https://example.invalid/hook
+  discord.webhookUrl: https://example.invalid/hook
 tests:
   - it: satisfies the restricted Pod Security Standard
     documentSelector:

--- a/charts/netcup-offer-bot/tests/snapshot_test.yaml
+++ b/charts/netcup-offer-bot/tests/snapshot_test.yaml
@@ -14,7 +14,7 @@ chart:
   version: 0.0.0
   appVersion: 0.0.0
 set:
-  env.webHook: https://example.invalid/hook
+  discord.webhookUrl: https://example.invalid/hook
   image.tag: v0.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
 tests:
   - it: matches the committed Deployment snapshot

--- a/charts/netcup-offer-bot/values.schema.json
+++ b/charts/netcup-offer-bot/values.schema.json
@@ -48,6 +48,42 @@
           "title": "component",
           "type": "string"
         },
+        "config": {
+          "additionalProperties": true,
+          "description": "Application configuration, expressed as the TOML tree the service documents. Rendered by\n`common.toml` into the ConfigMap the pod mounts, never passed as environment variables: the\nloader every application shares refuses a key supplied by both the environment and a file,\nand a value that lives in a file is one the kubelet can rotate under a running process.",
+          "required": [],
+          "title": "config",
+          "type": "object"
+        },
+        "configExtraToml": {
+          "default": "",
+          "description": "Verbatim TOML appended after the rendered `config` tree. The escape hatch for anything\n`common.toml` cannot express, notably arrays of tables.",
+          "required": [],
+          "title": "configExtraToml",
+          "type": "string"
+        },
+        "configMount": {
+          "additionalProperties": true,
+          "description": "Where the rendered configuration and the credential files land in the container. Consumed\nby `common.fileConfig.*`, which also passes both directories to the application as\n`\u003cPREFIX\u003e_CONFIG` and `\u003cPREFIX\u003e_SECRETS_DIR`.",
+          "properties": {
+            "configDir": {
+              "default": "",
+              "description": "Directory the rendered `config.toml` is mounted at.",
+              "required": [],
+              "title": "configDir",
+              "type": "string"
+            },
+            "secretsDir": {
+              "default": "",
+              "description": "Directory the credential files are mounted at, one file per configuration key.",
+              "required": [],
+              "title": "secretsDir",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "configMount"
+        },
         "dnsConfig": {
           "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodDNSConfig",
           "required": []
@@ -57,6 +93,20 @@
           "description": "Pod DNS policy.",
           "required": [],
           "title": "dnsPolicy",
+          "type": "string"
+        },
+        "existingConfigMap": {
+          "default": "",
+          "description": "Name of an existing ConfigMap holding `config.toml`, replacing the one this chart renders.",
+          "required": [],
+          "title": "existingConfigMap",
+          "type": "string"
+        },
+        "existingSecret": {
+          "default": "",
+          "description": "Name of an existing Secret holding the credential files, replacing the one this chart\nrenders. Its keys must be the configuration paths the service reads, with `__` for nesting\nand no dots — that is the file name the loader parses.",
+          "required": [],
+          "title": "existingSecret",
           "type": "string"
         },
         "extraEnv": {
@@ -824,50 +874,58 @@
       "title": "commonLabels",
       "type": "object"
     },
-    "env": {
+    "config": {
+      "additionalProperties": true,
+      "description": "Extra configuration, expressed as the TOML tree of\n[the bot's README](https://github.com/TimSchoenle/netcup-offer-bot#configuration)\n(`feed.check_interval_secs`, `metrics.port`, ...). Merged over everything the chart derives\nfrom the values above, so it can both extend and override them. Rendered into the mounted\nConfigMap — never into the environment, which the loader refuses to combine with a file.",
+      "required": [],
+      "title": "config",
+      "type": "object"
+    },
+    "configExtraToml": {
+      "default": "",
+      "description": "Verbatim TOML appended after the rendered configuration. The escape hatch for anything the\nchart's TOML renderer cannot express, notably arrays of tables.",
+      "required": [],
+      "title": "configExtraToml",
+      "type": "string"
+    },
+    "configMount": {
       "additionalProperties": true,
       "properties": {
-        "checkInterval": {
-          "default": 180,
-          "description": "Interval in seconds between offer checks.",
-          "minimum": 1,
+        "configDir": {
+          "default": "/etc/netcup-offer-bot/config",
+          "description": "Directory the rendered `config.toml` is mounted at, passed as `NETCUP_OFFER_BOT_CONFIG`.",
           "required": [],
-          "title": "checkInterval",
-          "type": "integer"
-        },
-        "logLevel": {
-          "default": "info",
-          "description": "Log level for the application.",
-          "enum": [
-            "debug",
-            "info",
-            "warn",
-            "error"
-          ],
-          "required": [],
-          "title": "logLevel"
-        },
-        "sentryDns": {
-          "default": "",
-          "description": "Sentry DSN for error tracking. Leave empty to disable.",
-          "required": [],
-          "title": "sentryDns",
+          "title": "configDir",
           "type": "string"
         },
-        "webHook": {
-          "default": "",
-          "description": "Webhook URL to send updates or notifications.\nRequired unless `existingSecret` is set.",
+        "secretsDir": {
+          "default": "/etc/netcup-offer-bot/secrets",
+          "description": "Directory the credential file is mounted at, passed as `NETCUP_OFFER_BOT_SECRETS_DIR`.",
           "required": [],
-          "title": "webHook",
+          "title": "secretsDir",
           "type": "string"
         }
       },
       "required": [],
-      "title": "env"
+      "title": "configMount"
+    },
+    "discord": {
+      "additionalProperties": true,
+      "properties": {
+        "webhookUrl": {
+          "default": "",
+          "description": "Discord webhook the offers are posted to (`discord.webhook_url`). Rendered into the\nchart's Secret and mounted as a file rather than passed as an environment variable, so it\nnever appears in `kubectl describe pod` or in the environment of a child process.\nRequired unless `existingSecret` supplies it.",
+          "required": [],
+          "title": "webhookUrl",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "discord"
     },
     "existingSecret": {
       "default": "",
-      "description": "Name of an existing Secret holding the `webHook` key.\nWhen set, the chart does not create a Secret and `env.webHook` is ignored — which keeps\nthe webhook URL out of `values.yaml` and out of the Helm release object.",
+      "description": "Name of an existing Secret holding the Discord webhook, which keeps it out of `values.yaml`\nand out of the Helm release object. **Its key is the configuration path, not a free-form\nname**: `discord__webhook_url`, because the file name is what the loader parses. Set, the\nchart renders no Secret of its own and `discord.webhookUrl` is ignored.",
       "required": [],
       "title": "existingSecret",
       "type": "string"
@@ -901,6 +959,21 @@
       "required": [],
       "title": "extraVolumes",
       "type": "array"
+    },
+    "feed": {
+      "additionalProperties": true,
+      "properties": {
+        "checkIntervalSecs": {
+          "default": 180,
+          "description": "Seconds between two RSS feed checks (`feed.check_interval_secs`).",
+          "minimum": 1,
+          "required": [],
+          "title": "checkIntervalSecs",
+          "type": "integer"
+        }
+      },
+      "required": [],
+      "title": "feed"
     },
     "fullnameOverride": {
       "default": "",
@@ -945,7 +1018,7 @@
           "type": "string"
         },
         "tag": {
-          "default": "v1.5.24@sha256:358897a7b824b78d32d85cec7990b5d6a74a94deedfbe66663c4ff3b7d7d994d",
+          "default": "v2.0.0@sha256:ca4777a39e389609910492c2668ad524295512065a41bf8ffad849004b832efb",
           "description": "The container image tag. Defaults to the chart's `appVersion` when empty.",
           "required": [],
           "title": "tag",
@@ -980,6 +1053,13 @@
           "required": [],
           "title": "enabled",
           "type": "boolean"
+        },
+        "ip": {
+          "default": "0.0.0.0",
+          "description": "Address the Prometheus exporter binds (`metrics.ip`). The bot's own default is\n`127.0.0.1`, which answers nothing from outside the container — a PodMonitor pointed at it\nscrapes a refused connection.",
+          "required": [],
+          "title": "ip",
+          "type": "string"
         },
         "podMonitor": {
           "additionalProperties": true,
@@ -1019,7 +1099,9 @@
         },
         "port": {
           "default": 9184,
-          "description": "Port to expose metrics on.",
+          "description": "Port the Prometheus exporter listens on (`metrics.port`).",
+          "maximum": 65535,
+          "minimum": 1,
           "required": [],
           "title": "port",
           "type": "integer"
@@ -1482,6 +1564,33 @@
     "strategy": {
       "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.apps.v1.DeploymentStrategy",
       "required": []
+    },
+    "telemetry": {
+      "additionalProperties": true,
+      "properties": {
+        "logLevel": {
+          "default": "INFO",
+          "description": "Log level (`telemetry.log_level`).",
+          "enum": [
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "WARN",
+            "ERROR"
+          ],
+          "required": [],
+          "title": "logLevel"
+        },
+        "sentryDsn": {
+          "default": "",
+          "description": "Sentry DSN (`telemetry.sentry_dsn`). Empty disables Sentry entirely.",
+          "required": [],
+          "title": "sentryDsn",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "telemetry"
     },
     "terminationGracePeriodSeconds": {
       "default": 30,

--- a/charts/netcup-offer-bot/values.yaml
+++ b/charts/netcup-offer-bot/values.yaml
@@ -21,7 +21,7 @@ image:
   # type: string
   # @schema
   # -- The container image tag. Defaults to the chart's `appVersion` when empty.
-  tag: v1.5.24@sha256:358897a7b824b78d32d85cec7990b5d6a74a94deedfbe66663c4ff3b7d7d994d
+  tag: v2.0.0@sha256:ca4777a39e389609910492c2668ad524295512065a41bf8ffad849004b832efb
 
   # @schema
   # enum: ["", Always, IfNotPresent, Never]
@@ -36,42 +36,87 @@ image:
 imagePullSecrets: []
 
 # @schema
-# type: string
+# additionalProperties: true
 # @schema
-# -- Name of an existing Secret holding the `webHook` key.
-# When set, the chart does not create a Secret and `env.webHook` is ignored — which keeps
-# the webhook URL out of `values.yaml` and out of the Helm release object.
-existingSecret: ""
+discord:
+  # @schema
+  # type: string
+  # @schema
+  # -- Discord webhook the offers are posted to (`discord.webhook_url`). Rendered into the
+  # chart's Secret and mounted as a file rather than passed as an environment variable, so it
+  # never appears in `kubectl describe pod` or in the environment of a child process.
+  # Required unless `existingSecret` supplies it.
+  webhookUrl: ""
 
 # @schema
 # additionalProperties: true
 # @schema
-env:
-  # @schema
-  # type: string
-  # @schema
-  # -- Sentry DSN for error tracking. Leave empty to disable.
-  sentryDns: ""
-
-  # @schema
-  # type: string
-  # @schema
-  # -- Webhook URL to send updates or notifications.
-  # Required unless `existingSecret` is set.
-  webHook: ""
-
+feed:
   # @schema
   # type: integer
   # minimum: 1
   # @schema
-  # -- Interval in seconds between offer checks.
-  checkInterval: 180
+  # -- Seconds between two RSS feed checks (`feed.check_interval_secs`).
+  checkIntervalSecs: 180
+
+# @schema
+# additionalProperties: true
+# @schema
+telemetry:
+  # @schema
+  # enum: [TRACE, DEBUG, INFO, WARN, ERROR]
+  # @schema
+  # -- Log level (`telemetry.log_level`).
+  logLevel: INFO
 
   # @schema
-  # enum: [debug, info, warn, error]
+  # type: string
   # @schema
-  # -- Log level for the application.
-  logLevel: info
+  # -- Sentry DSN (`telemetry.sentry_dsn`). Empty disables Sentry entirely.
+  sentryDsn: ""
+
+# @schema
+# type: string
+# @schema
+# -- Name of an existing Secret holding the Discord webhook, which keeps it out of `values.yaml`
+# and out of the Helm release object. **Its key is the configuration path, not a free-form
+# name**: `discord__webhook_url`, because the file name is what the loader parses. Set, the
+# chart renders no Secret of its own and `discord.webhookUrl` is ignored.
+existingSecret: ""
+
+# @schema
+# type: object
+# additionalProperties: true
+# @schema
+# -- Extra configuration, expressed as the TOML tree of
+# [the bot's README](https://github.com/TimSchoenle/netcup-offer-bot#configuration)
+# (`feed.check_interval_secs`, `metrics.port`, ...). Merged over everything the chart derives
+# from the values above, so it can both extend and override them. Rendered into the mounted
+# ConfigMap — never into the environment, which the loader refuses to combine with a file.
+config: {}
+
+# @schema
+# type: string
+# @schema
+# -- Verbatim TOML appended after the rendered configuration. The escape hatch for anything the
+# chart's TOML renderer cannot express, notably arrays of tables.
+configExtraToml: ""
+
+# @schema
+# additionalProperties: true
+# @schema
+configMount:
+  # @schema
+  # type: string
+  # @schema
+  # -- Directory the rendered `config.toml` is mounted at, passed as `NETCUP_OFFER_BOT_CONFIG`.
+  configDir: /etc/netcup-offer-bot/config
+
+  # @schema
+  # type: string
+  # @schema
+  # -- Directory the credential file is mounted at, passed as `NETCUP_OFFER_BOT_SECRETS_DIR`.
+  secretsDir: /etc/netcup-offer-bot/secrets
 
 # @schema
 # enum: [restricted, none]
@@ -223,9 +268,19 @@ metrics:
   enabled: false
 
   # @schema
-  # type: integer
+  # type: string
   # @schema
-  # -- Port to expose metrics on.
+  # -- Address the Prometheus exporter binds (`metrics.ip`). The bot's own default is
+  # `127.0.0.1`, which answers nothing from outside the container — a PodMonitor pointed at it
+  # scrapes a refused connection.
+  ip: 0.0.0.0
+
+  # @schema
+  # type: integer
+  # minimum: 1
+  # maximum: 65535
+  # @schema
+  # -- Port the Prometheus exporter listens on (`metrics.port`).
   port: 9184
 
   # @schema

--- a/charts/portfolio/Chart.yaml
+++ b/charts/portfolio/Chart.yaml
@@ -1,7 +1,7 @@
 name: portfolio
 description: Personal portfolio built with Rust (Yew frontend, Axum server).
-version: 3.0.11
-appVersion: v2.2.3
+version: 4.0.0
+appVersion: v2.3.0
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts
 sources:
@@ -11,5 +11,5 @@ maintainers:
     email: contact@tim-schoenle.de
 dependencies:
   - name: common
-    version: 1.3.0
+    version: 1.4.0
     repository: "file://../common"

--- a/charts/portfolio/README.md
+++ b/charts/portfolio/README.md
@@ -1,6 +1,6 @@
 # portfolio
 
-![Version: 3.0.11](https://img.shields.io/badge/Version-3.0.11-informational?style=flat-square) ![AppVersion: v2.2.3](https://img.shields.io/badge/AppVersion-v2.2.3-informational?style=flat-square)
+![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![AppVersion: v2.3.0](https://img.shields.io/badge/AppVersion-v2.3.0-informational?style=flat-square)
 
 Personal portfolio built with Rust (Yew frontend, Axum server).
 
@@ -82,6 +82,67 @@ livenessProbe:
 > `successThreshold` is accepted only on the readiness probe. Kubernetes rejects any value
 > other than `1` on startup and liveness probes, so the chart omits it there.
 
+## Configuration
+
+The application reads its settings through a layered, file-first loader. Everything in the
+`PORTFOLIO_` namespace — `assets.dist_dir`, `isr.*` — is rendered into one `config.toml`,
+mounted as a ConfigMap and pointed at by `PORTFOLIO_CONFIG`. The loader **fails the boot on a
+key supplied by both the environment and a file** rather than resolving it by precedence, so
+keeping the chart's output in one place makes that collision impossible.
+
+`PORT`, `IP` and `RUST_LOG` are the exception, and stay environment variables: they belong to
+the Dioxus toolchain, which reads them itself. They are `server.port`, `server.host` and
+`logLevel` in this chart's values, and cannot be supplied through `config`.
+
+One more variable is set on purpose. The published image bakes
+`PORTFOLIO_ISR__CACHE_DIR=/tmp/isr`, and the environment layer outranks the TOML one — so the
+chart restates the *effective* cache directory as an environment variable alongside the file.
+Without that, moving the cache through `isr.cacheDir` would write a value the image silently
+overrode.
+
+`config` takes the raw TOML tree for anything the first-class values do not cover, merged over
+the derived one, and `configExtraToml` is appended verbatim for what the renderer cannot
+express.
+
+The server does not reload its configuration — only the loader half of the library is used — so
+the chart keeps the conventional `checksum/config` pod annotation: a configuration change rolls
+the Deployment, which is the only way it takes effect.
+
+## Incremental static regeneration
+
+ISR is on by default and caches into `/tmp/isr`, inside the writable `emptyDir` the chart
+already mounts for the read-only root filesystem. The server creates the directory itself and
+falls back to rendering every request fresh if it turns out not to be writable.
+
+```yaml
+isr:
+  cacheDir: /tmp/isr   # empty disables ISR entirely
+  ttlSecs: 0           # 0 is a permanent cache; positive opts into time-based revalidation
+```
+
+A permanent cache is right here: every page renders from compile-time data, so the only thing
+that changes the output is a redeploy, and a redeploy starts from an empty cache. Set a
+positive TTL only when a *persistent* cache volume is shared across deploys — which needs an
+`extraVolumes` mount, since the default cache lives in an `emptyDir`.
+
+## Upgrading
+
+### 3.x to 4.0
+
+Chart 4.0 tracks application 2.3.0, which moved its settings into the layered `PORTFOLIO_`
+configuration. The `application` block is gone; a `helm upgrade` with 3.x values fails schema
+validation naming the offending key rather than starting a pod on the defaults.
+
+| Before | After |
+|---|---|
+| `application.port` | `server.port` |
+| `application.logLevel` | `logLevel` |
+
+Both are still delivered as `PORT` and `RUST_LOG` — the Dioxus toolchain reads them from the
+environment and they are not part of the layered configuration. What is new is everything
+around them: `server.host`, `assets.distDir`, `isr.*`, and the `config` / `configExtraToml`
+escape hatches, all rendered into a mounted `config.toml`.
+
 ## Security
 
 The pod satisfies the [restricted Pod Security Standard][pss] as installed: non-root (UID
@@ -115,11 +176,14 @@ curl http://localhost:8080/api/health
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Explicit affinity rules. Wins over `podAntiAffinity`. |
-| application.logLevel | string | `"info"` | Log verbosity passed to the application as `RUST_LOG`. Accepts standard tracing/env_logger directives (e.g. `info`, `debug`, `warn`). |
-| application.port | int | `8080` | Port number the application listens on (exposed to the container as `PORT`). The Axum server binds to 0.0.0.0 on this port. |
+| assets.distDir | string | `"public"` | Directory holding the bundled assets (`assets.dist_dir`), relative to the working directory. Only the readiness probe consults it; the bundle itself is served by the Dioxus asset router, which resolves `public/` relative to the binary. |
 | automountServiceAccountToken | bool | `false` | Mount the ServiceAccount API token into the pod. The application never calls the Kubernetes API. |
 | commonAnnotations | object | `{}` | Annotations added to every object this chart creates. |
 | commonLabels | object | `{}` | Labels added to every object this chart creates. |
+| config | object | `{}` | Extra configuration, expressed as the TOML tree of [the application's README](https://github.com/TimSchoenle/Portfolio#configuration) (`assets.dist_dir`, `isr.ttl_secs`, ...). Merged over everything the chart derives from the values above, so it can both extend and override them. Rendered into the mounted ConfigMap — never into the environment, which the loader refuses to combine with a file. |
+| configExtraToml | string | `""` | Verbatim TOML appended after the rendered configuration. The escape hatch for anything the chart's TOML renderer cannot express, notably arrays of tables. |
+| configMount.configDir | string | `"/etc/portfolio/config"` | Directory the rendered `config.toml` is mounted at, passed as `PORTFOLIO_CONFIG`. |
+| configMount.secretsDir | string | `"/etc/portfolio/secrets"` | Directory credential files would be mounted at, passed as `PORTFOLIO_SECRETS_DIR`. The server reads no secret today — `github.token` belongs to the build-time repository builder — so nothing is mounted and the variable is not set; the value is here for an operator adding one through `extraVolumes`. |
 | extraEnv | list | `[]` | Additional environment variables for the application container. |
 | extraVolumeMounts | list | `[]` | Additional volume mounts added to the application container. |
 | extraVolumes | list | `[]` | Additional volumes added to the pod. |
@@ -127,13 +191,16 @@ curl http://localhost:8080/api/health
 | image.pullPolicy | string | `""` | Kubernetes image pull policy. Empty resolves automatically from the tag/digest. |
 | image.registry | string | `""` | Registry host. Empty means Docker Hub. |
 | image.repository | string | `"timschoenle/portfolio"` | Container image repository where the Portfolio application image is stored. |
-| image.tag | string | `"v2.2.3@sha256:b3cbdcad9b50ba79049cfafb0f219a294106647c6cb3928057f0efbd278d40dc"` | Container image tag to deploy, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the pull, while the tag stays on as the readable version marker. Defaults to the chart's `appVersion` when empty. |
+| image.tag | string | `"v2.3.0@sha256:ae594c6c61f4f5b369803ba5e5b24294428ef8d4ebebf73e383efa57d63260ae"` | Container image tag to deploy, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the pull, while the tag stays on as the readable version marker. Defaults to the chart's `appVersion` when empty. |
 | imagePullSecrets | list | `[]` | Optional image pull secrets for private registries. |
 | ingress.annotations | object | `{}` | Custom annotations for the Ingress resource. Example: ```yaml annotations:   cert-manager.io/cluster-issuer: "letsencrypt-prod"   nginx.ingress.kubernetes.io/ssl-redirect: "true" ``` |
 | ingress.enabled | bool | `false` | Enable or disable Kubernetes Ingress resource creation. |
 | ingress.hosts | list | `[]` | List of host configurations for the Ingress. Values may contain Go templates. Example: ```yaml hosts:   - host: portfolio.example.com     paths:       - path: /         pathType: Prefix ``` |
 | ingress.ingressClassName | string | `"nginx"` | Ingress class to use (e.g., "nginx", "traefik"). |
 | ingress.tls | list | `[]` | TLS configuration for securing ingress connections. Example: ```yaml tls:   - secretName: portfolio-tls     hosts:       - portfolio.example.com ``` |
+| isr | object | `{"cacheDir":"/tmp/isr","ttlSecs":0}` | Incremental static regeneration: the server caches each rendered page and serves it again instead of re-rendering. |
+| isr.cacheDir | string | `"/tmp/isr"` | Writable directory rendered HTML is cached into (`isr.cache_dir`). Empty disables ISR and renders every request fresh. Keep it under `/tmp`, which the chart already provides as a writable emptyDir under the read-only root filesystem, and outside the bundled `public/` tree so those content-hashed assets stay immutable. The server creates the directory itself and falls back to rendering fresh if it turns out not to be writable. |
+| isr.ttlSecs | int | `0` | Revalidation interval in seconds (`isr.ttl_secs`). `0` means a permanent cache, which is right for this site: every page renders from compile-time data, so the only thing that changes the output is a redeploy — and that starts from an empty cache. Set a positive value only when a *persistent* cache volume is shared across deploys. |
 | kubeVersionOverride | string | `""` | Kubernetes version to target when branching on API availability. Lets `helm template` render for a specific cluster version without a live connection. |
 | livenessProbe | object | `{"enabled":true,"failureThreshold":3,"httpGet":{"path":"/api/health","port":"http"},"initialDelaySeconds":1,"periodSeconds":10,"timeoutSeconds":5}` | Liveness probe. Restarts the container when it stops responding. |
 | livenessProbe.enabled | bool | `true` | Enable the liveness probe. |
@@ -144,6 +211,7 @@ curl http://localhost:8080/api/health
 | livenessProbe.initialDelaySeconds | int | `1` | Delay before the first probe. |
 | livenessProbe.periodSeconds | int | `10` | Probe interval. |
 | livenessProbe.timeoutSeconds | int | `5` | Probe timeout. |
+| logLevel | string | `"info"` | Log verbosity, passed as `RUST_LOG`. Accepts standard tracing directives (`info`, `debug`, `web=debug,info`). Not part of the `PORTFOLIO_` namespace — see `server`. |
 | nameOverride | string | `""` | Override the chart name used in resource names and labels. |
 | namespaceOverride | string | `""` | Deploy into a namespace other than the release namespace. |
 | networkPolicy | object | `{"egress":{"cidr":"0.0.0.0/0","customRules":[],"dns":{"enabled":true,"namespaceSelector":{"kubernetes.io/metadata.name":"kube-system"},"podSelector":{"k8s-app":"kube-dns"}},"enabled":true,"except":["10.0.0.0/8","172.16.0.0/12","192.168.0.0/16","169.254.0.0/16"],"http":{"enabled":false},"https":{"enabled":true}},"enabled":false,"extraEgress":[],"extraIngress":[],"ingress":{"controller":{"enabled":true,"namespace":"traefik","ports":[],"selector":{"app.kubernetes.io/name":"traefik"}},"customRules":[],"enabled":true,"monitoring":{"enabled":true,"namespace":"monitoring","namespaceSelector":{},"ports":[]}}}` | Network policy configuration.  Every generated egress rule is scoped by a `to:` selector. An egress rule that lists only ports is not a restriction: the NetworkPolicy API reads a missing `to` as "any destination", which would permit traffic to every in-cluster service and to the cloud instance metadata endpoint. |
@@ -208,6 +276,9 @@ curl http://localhost:8080/api/health
 | revisionHistoryLimit | int | `3` | Number of old ReplicaSets retained for rollback. |
 | securityContext | object | `{}` | Container security context, merged over the preset. The application is a statically linked binary serving pre-built assets and needs no writable root filesystem; a writable /tmp is provided automatically via an emptyDir. |
 | securityContextPreset | string | `"restricted"` | Container security context baseline. `restricted` drops all Linux capabilities and forbids privilege escalation and a writable root filesystem. |
+| server | object | `{"host":"0.0.0.0","port":8080}` | The listener, which is the one part of the configuration the `PORTFOLIO_` namespace does not own: `PORT`, `IP` and `RUST_LOG` belong to the Dioxus toolchain, which reads them from the environment itself. They are therefore still passed as environment variables, and cannot be supplied through `config`. |
+| server.host | string | `"0.0.0.0"` | Bind address, passed as `IP`. |
+| server.port | int | `8080` | Bind port, passed as `PORT`. Also the container port, the Service target and what every probe and NetworkPolicy rule is written against. |
 | service.annotations | object | `{}` | Annotations for the Service. |
 | service.port | int | `80` | Port that the Kubernetes Service will expose. |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type that exposes the application. |

--- a/charts/portfolio/README.md.gotmpl
+++ b/charts/portfolio/README.md.gotmpl
@@ -84,6 +84,67 @@ livenessProbe:
 > `successThreshold` is accepted only on the readiness probe. Kubernetes rejects any value
 > other than `1` on startup and liveness probes, so the chart omits it there.
 
+## Configuration
+
+The application reads its settings through a layered, file-first loader. Everything in the
+`PORTFOLIO_` namespace — `assets.dist_dir`, `isr.*` — is rendered into one `config.toml`,
+mounted as a ConfigMap and pointed at by `PORTFOLIO_CONFIG`. The loader **fails the boot on a
+key supplied by both the environment and a file** rather than resolving it by precedence, so
+keeping the chart's output in one place makes that collision impossible.
+
+`PORT`, `IP` and `RUST_LOG` are the exception, and stay environment variables: they belong to
+the Dioxus toolchain, which reads them itself. They are `server.port`, `server.host` and
+`logLevel` in this chart's values, and cannot be supplied through `config`.
+
+One more variable is set on purpose. The published image bakes
+`PORTFOLIO_ISR__CACHE_DIR=/tmp/isr`, and the environment layer outranks the TOML one — so the
+chart restates the *effective* cache directory as an environment variable alongside the file.
+Without that, moving the cache through `isr.cacheDir` would write a value the image silently
+overrode.
+
+`config` takes the raw TOML tree for anything the first-class values do not cover, merged over
+the derived one, and `configExtraToml` is appended verbatim for what the renderer cannot
+express.
+
+The server does not reload its configuration — only the loader half of the library is used — so
+the chart keeps the conventional `checksum/config` pod annotation: a configuration change rolls
+the Deployment, which is the only way it takes effect.
+
+## Incremental static regeneration
+
+ISR is on by default and caches into `/tmp/isr`, inside the writable `emptyDir` the chart
+already mounts for the read-only root filesystem. The server creates the directory itself and
+falls back to rendering every request fresh if it turns out not to be writable.
+
+```yaml
+isr:
+  cacheDir: /tmp/isr   # empty disables ISR entirely
+  ttlSecs: 0           # 0 is a permanent cache; positive opts into time-based revalidation
+```
+
+A permanent cache is right here: every page renders from compile-time data, so the only thing
+that changes the output is a redeploy, and a redeploy starts from an empty cache. Set a
+positive TTL only when a *persistent* cache volume is shared across deploys — which needs an
+`extraVolumes` mount, since the default cache lives in an `emptyDir`.
+
+## Upgrading
+
+### 3.x to 4.0
+
+Chart 4.0 tracks application 2.3.0, which moved its settings into the layered `PORTFOLIO_`
+configuration. The `application` block is gone; a `helm upgrade` with 3.x values fails schema
+validation naming the offending key rather than starting a pod on the defaults.
+
+| Before | After |
+|---|---|
+| `application.port` | `server.port` |
+| `application.logLevel` | `logLevel` |
+
+Both are still delivered as `PORT` and `RUST_LOG` — the Dioxus toolchain reads them from the
+environment and they are not part of the layered configuration. What is new is everything
+around them: `server.host`, `assets.distDir`, `isr.*`, and the `config` / `configExtraToml`
+escape hatches, all rendered into a mounted `config.toml`.
+
 ## Security
 
 The pod satisfies the [restricted Pod Security Standard][pss] as installed: non-root (UID

--- a/charts/portfolio/templates/_helpers.tpl
+++ b/charts/portfolio/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+The configuration the chart derives from its own first-class values, as the TOML tree the
+server reads.
+
+`PORT`, `IP` and `RUST_LOG` are deliberately absent: they belong to the Dioxus toolchain, which
+reads them from the environment itself, not to the `PORTFOLIO_` namespace this file describes.
+*/}}
+{{- define "portfolio.derivedConfig" -}}
+assets:
+  dist_dir: {{ .Values.assets.distDir | quote }}
+isr:
+  cache_dir: {{ .Values.isr.cacheDir | quote }}
+  ttl_secs: {{ .Values.isr.ttlSecs }}
+{{- end -}}
+
+{{/*
+The configuration that actually reaches the server: the derived tree with the operator's own
+`config` tree merged over it, so `config` can both extend and override the values above.
+
+Not included: `configExtraToml`, which is appended verbatim and never parsed.
+*/}}
+{{- define "portfolio.effectiveConfig" -}}
+{{- $derived := include "portfolio.derivedConfig" . | fromYaml -}}
+{{- toYaml (mergeOverwrite $derived (deepCopy (.Values.config | default dict))) -}}
+{{- end -}}
+
+{{/*
+The complete `config.toml`: the effective tree, then the verbatim escape hatch.
+*/}}
+{{- define "portfolio.configToml" -}}
+{{- $config := include "portfolio.effectiveConfig" . | fromYaml -}}
+{{- include "common.configToml" (dict "ctx" . "maps" (list $config)) -}}
+{{- end -}}
+
+{{/*
+The container environment.
+
+Three variables the Dioxus toolchain reads for itself, one that points the layered loader at the
+mounted configuration — and one that exists only to defeat the image.
+
+`PORTFOLIO_ISR__CACHE_DIR` is baked into the published image, and the environment layer outranks
+the TOML layer. Left alone, that baked value would silently win over whatever this chart wrote
+into `config.toml`, so an operator who moved the cache would find it had not moved. Emitting the
+variable with the *effective* value — the same one the file carries — makes the two agree by
+construction. The environment and the file are not mutually exclusive layers, so supplying both
+is legal; only the environment, the secrets directory and `_FILE` collide with one another.
+*/}}
+{{- define "portfolio.env" -}}
+{{- $config := include "portfolio.effectiveConfig" . | fromYaml }}
+- name: PORT
+  value: {{ .Values.server.port | quote }}
+- name: IP
+  value: {{ .Values.server.host | quote }}
+- name: RUST_LOG
+  value: {{ .Values.logLevel | quote }}
+- name: PORTFOLIO_CONFIG
+  value: {{ .Values.configMount.configDir | quote }}
+- name: PORTFOLIO_ISR__CACHE_DIR
+  value: {{ $config | dig "isr" "cache_dir" "" | quote }}
+{{- end -}}

--- a/charts/portfolio/templates/configmap.yaml
+++ b/charts/portfolio/templates/configmap.yaml
@@ -10,5 +10,11 @@ metadata:
     {{- . | nindent 4 }}
   {{- end }}
 data:
-  PORT: {{ .Values.application.port | quote }}
-  RUST_LOG: {{ .Values.application.logLevel | quote }}
+  {{- /*
+    One file rather than a set of fragments. The loader does merge every `*.toml` in the
+    directory, but relying on that would put the precedence of one value against another inside
+    a merge this chart does not own or test. Merging in the template instead makes the effective
+    configuration readable with `kubectl get configmap -o yaml`.
+  */}}
+  config.toml: |
+    {{- include "portfolio.configToml" . | nindent 4 }}

--- a/charts/portfolio/templates/deployment.yaml
+++ b/charts/portfolio/templates/deployment.yaml
@@ -30,12 +30,21 @@ spec:
     spec:
       {{- include "common.podSpec.common" . | nindent 6 }}
       containers:
+        {{- /*
+          The `PORTFOLIO_` configuration reaches the container as a file: the loader fails the
+          boot on a key supplied by both the environment and a file, so keeping the chart's
+          output entirely in one place makes that collision impossible. The variables that
+          remain are the loader's own pointer, the ISR cache directory the image bakes in — see
+          `portfolio.env` — and the three the Dioxus toolchain reads for itself.
+        */}}
+        {{- $secretKeys := list }}
         {{- include "common.container" (dict
               "ctx" $
-              "ports" (list (dict "name" "http" "containerPort" (int .Values.application.port) "protocol" "TCP"))
-              "envFrom" (list (dict "configMapRef" (dict "name" (include "common.fullname" .))))
+              "ports" (list (dict "name" "http" "containerPort" (int .Values.server.port) "protocol" "TCP"))
+              "env" (include "portfolio.env" . | fromYamlArray)
+              "volumeMounts" (include "common.fileConfig.volumeMounts" (dict "ctx" $ "secretKeys" $secretKeys) | fromYamlArray)
             ) | nindent 8 }}
-      {{- with (include "common.volumes" (dict "ctx" $)) }}
+      {{- with (include "common.volumes" (dict "ctx" $ "volumes" (include "common.fileConfig.volumes" (dict "ctx" $ "secretKeys" $secretKeys) | fromYamlArray))) }}
       volumes:
         {{- . | nindent 8 }}
       {{- end }}

--- a/charts/portfolio/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/portfolio/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2,8 +2,13 @@ matches the committed Deployment snapshot:
   1: |
     apiVersion: v1
     data:
-      PORT: "8080"
-      RUST_LOG: info
+      config.toml: |
+        [assets]
+        dist_dir = "public"
+
+        [isr]
+        cache_dir = "/tmp/isr"
+        ttl_secs = 0
     kind: ConfigMap
     metadata:
       labels:
@@ -36,7 +41,7 @@ matches the committed Deployment snapshot:
       template:
         metadata:
           annotations:
-            checksum/configmap: e1a3b4e15a2bbe6986ebdd0a3898bcbd69372b7760e6cf1a247ba0cae2b2ba48
+            checksum/configmap: 30d787efc49cddd7af7db2b5c8c5620a2260c3ecdb57c3c4455f43f3a584b1fb
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -45,9 +50,17 @@ matches the committed Deployment snapshot:
         spec:
           automountServiceAccountToken: false
           containers:
-            - envFrom:
-                - configMapRef:
-                    name: RELEASE-NAME-portfolio
+            - env:
+                - name: PORT
+                  value: "8080"
+                - name: IP
+                  value: 0.0.0.0
+                - name: RUST_LOG
+                  value: info
+                - name: PORTFOLIO_CONFIG
+                  value: /etc/portfolio/config
+                - name: PORTFOLIO_ISR__CACHE_DIR
+                  value: /tmp/isr
               image: timschoenle/portfolio:v0.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -98,6 +111,9 @@ matches the committed Deployment snapshot:
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp
+                - mountPath: /etc/portfolio/config
+                  name: config
+                  readOnly: true
           securityContext:
             fsGroup: 1001
             fsGroupChangePolicy: OnRootMismatch
@@ -111,12 +127,20 @@ matches the committed Deployment snapshot:
           volumes:
             - emptyDir: {}
               name: tmp
+            - configMap:
+                name: RELEASE-NAME-portfolio
+              name: config
 matches the committed Deployment snapshot with network policies and probes on:
   1: |
     apiVersion: v1
     data:
-      PORT: "8080"
-      RUST_LOG: info
+      config.toml: |
+        [assets]
+        dist_dir = "public"
+
+        [isr]
+        cache_dir = "/tmp/isr"
+        ttl_secs = 0
     kind: ConfigMap
     metadata:
       labels:
@@ -149,7 +173,7 @@ matches the committed Deployment snapshot with network policies and probes on:
       template:
         metadata:
           annotations:
-            checksum/configmap: e1a3b4e15a2bbe6986ebdd0a3898bcbd69372b7760e6cf1a247ba0cae2b2ba48
+            checksum/configmap: 30d787efc49cddd7af7db2b5c8c5620a2260c3ecdb57c3c4455f43f3a584b1fb
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -168,9 +192,17 @@ matches the committed Deployment snapshot with network policies and probes on:
                   weight: 100
           automountServiceAccountToken: false
           containers:
-            - envFrom:
-                - configMapRef:
-                    name: RELEASE-NAME-portfolio
+            - env:
+                - name: PORT
+                  value: "8080"
+                - name: IP
+                  value: 0.0.0.0
+                - name: RUST_LOG
+                  value: info
+                - name: PORTFOLIO_CONFIG
+                  value: /etc/portfolio/config
+                - name: PORTFOLIO_ISR__CACHE_DIR
+                  value: /tmp/isr
               image: timschoenle/portfolio:v0.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -221,6 +253,9 @@ matches the committed Deployment snapshot with network policies and probes on:
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp
+                - mountPath: /etc/portfolio/config
+                  name: config
+                  readOnly: true
           nodeSelector:
             kubernetes.io/os: linux
           securityContext:
@@ -236,3 +271,6 @@ matches the committed Deployment snapshot with network policies and probes on:
           volumes:
             - emptyDir: {}
               name: tmp
+            - configMap:
+                name: RELEASE-NAME-portfolio
+              name: config

--- a/charts/portfolio/tests/configmap_test.yaml
+++ b/charts/portfolio/tests/configmap_test.yaml
@@ -2,30 +2,47 @@ suite: test configmap
 templates:
   - configmap.yaml
 tests:
-  - it: should create a ConfigMap
+  - it: renders the configuration as a single TOML file
     asserts:
       - isKind:
           of: ConfigMap
       - equal:
           path: metadata.name
           value: RELEASE-NAME-portfolio
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[assets\]\ndist_dir = "public"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[isr\]\ncache_dir = "/tmp/isr"\nttl_secs = 0'
 
-  - it: should set PORT correctly
-    asserts:
-      - equal:
-          path: data.PORT
-          value: "8080"
-
-  - it: should set RUST_LOG from logLevel
-    asserts:
-      - equal:
-          path: data.RUST_LOG
-          value: info
-
-  - it: should override RUST_LOG when logLevel is set
+  - it: reflects a changed ISR cache directory and TTL
     set:
-      application.logLevel: debug
+      isr.cacheDir: /cache/isr
+      isr.ttlSecs: 300
     asserts:
-      - equal:
-          path: data.RUST_LOG
-          value: debug
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'cache_dir = "/cache/isr"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'ttl_secs = 300'
+
+  - it: merges the raw config tree over the derived values
+    set:
+      config:
+        assets:
+          dist_dir: /srv/public
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'dist_dir = "/srv/public"'
+
+  # `PORT`, `IP` and `RUST_LOG` belong to the Dioxus toolchain, which reads them from the
+  # environment itself. Writing them into the `PORTFOLIO_` configuration file would be writing
+  # keys nothing reads.
+  - it: keeps the Dioxus variables out of the configuration file
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: '(?i)(rust_log|\bport\b)'

--- a/charts/portfolio/tests/deployment_test.yaml
+++ b/charts/portfolio/tests/deployment_test.yaml
@@ -21,7 +21,7 @@ tests:
       path: kind
       value: Deployment
     set:
-      application.port: 9090
+      server.port: 9090
     asserts:
       - equal:
           path: spec.template.spec.containers[0].ports
@@ -29,6 +29,100 @@ tests:
             - containerPort: 9090
               name: http
               protocol: TCP
+
+  # The `PORTFOLIO_` configuration arrives as a file; what is left in the environment is the
+  # loader's pointer, the ISR cache directory, and the three variables the Dioxus toolchain
+  # reads for itself.
+  # The exhaustive list is the assertion: every entry is a plain value, so no credential is
+  # injected at runtime and nothing is read from a Secret.
+  - it: passes the PORTFOLIO configuration as a file and the Dioxus knobs as environment
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env
+          value:
+            - name: PORT
+              value: "8080"
+            - name: IP
+              value: 0.0.0.0
+            - name: RUST_LOG
+              value: info
+            - name: PORTFOLIO_CONFIG
+              value: /etc/portfolio/config
+            - name: PORTFOLIO_ISR__CACHE_DIR
+              value: /tmp/isr
+      - notExists:
+          path: spec.template.spec.containers[0].envFrom
+
+  # The published image bakes `PORTFOLIO_ISR__CACHE_DIR=/tmp/isr`, and the environment layer
+  # outranks the TOML one. Without the chart restating it, a moved cache directory would be
+  # written into `config.toml` and then silently ignored.
+  - it: restates the ISR cache directory so the image cannot shadow the file
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      isr.cacheDir: /cache/isr
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PORTFOLIO_ISR__CACHE_DIR
+            value: /cache/isr
+
+  - it: follows the cache directory set through the raw config tree
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      config:
+        isr:
+          cache_dir: /cache/from-config
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PORTFOLIO_ISR__CACHE_DIR
+            value: /cache/from-config
+
+  - it: mounts the rendered configuration read-only
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+            configMap:
+              name: RELEASE-NAME-portfolio
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /etc/portfolio/config
+            readOnly: true
+
+  # The server reads no secret, so pointing it at a directory no volume provides would be a
+  # boot failure naming the path.
+  - it: names no secrets directory, because the server reads no secret
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PORTFOLIO_SECRETS_DIR
+            value: /etc/portfolio/secrets
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: secrets
+            mountPath: /etc/portfolio/secrets
+            readOnly: true
 
   - it: probes the health endpoint on all three probes
     documentSelector:
@@ -76,25 +170,6 @@ tests:
           path: spec.template.spec.containers[0].startupProbe
       - exists:
           path: spec.template.spec.containers[0].livenessProbe
-
-  - it: loads configuration from the ConfigMap
-    documentSelector:
-      path: kind
-      value: Deployment
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].envFrom
-          content:
-            configMapRef:
-              name: RELEASE-NAME-portfolio
-
-  - it: injects no secrets at runtime
-    documentSelector:
-      path: kind
-      value: Deployment
-    asserts:
-      - notExists:
-          path: spec.template.spec.containers[0].env
 
   # Without this the pod keeps running the old configuration after a values change.
   - it: rolls the pod when the ConfigMap changes

--- a/charts/portfolio/values.schema.json
+++ b/charts/portfolio/values.schema.json
@@ -6,26 +6,19 @@
       "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity",
       "required": []
     },
-    "application": {
+    "assets": {
       "additionalProperties": true,
       "properties": {
-        "logLevel": {
-          "default": "info",
-          "description": "Log verbosity passed to the application as `RUST_LOG`.\nAccepts standard tracing/env_logger directives (e.g. `info`, `debug`, `warn`).",
+        "distDir": {
+          "default": "public",
+          "description": "Directory holding the bundled assets (`assets.dist_dir`), relative to the working\ndirectory. Only the readiness probe consults it; the bundle itself is served by the Dioxus\nasset router, which resolves `public/` relative to the binary.",
           "required": [],
-          "title": "logLevel",
+          "title": "distDir",
           "type": "string"
-        },
-        "port": {
-          "default": 8080,
-          "description": "Port number the application listens on (exposed to the container as `PORT`).\nThe Axum server binds to 0.0.0.0 on this port.",
-          "required": [],
-          "title": "port",
-          "type": "integer"
         }
       },
       "required": [],
-      "title": "application"
+      "title": "assets"
     },
     "automountServiceAccountToken": {
       "default": false,
@@ -69,6 +62,42 @@
           "title": "component",
           "type": "string"
         },
+        "config": {
+          "additionalProperties": true,
+          "description": "Application configuration, expressed as the TOML tree the service documents. Rendered by\n`common.toml` into the ConfigMap the pod mounts, never passed as environment variables: the\nloader every application shares refuses a key supplied by both the environment and a file,\nand a value that lives in a file is one the kubelet can rotate under a running process.",
+          "required": [],
+          "title": "config",
+          "type": "object"
+        },
+        "configExtraToml": {
+          "default": "",
+          "description": "Verbatim TOML appended after the rendered `config` tree. The escape hatch for anything\n`common.toml` cannot express, notably arrays of tables.",
+          "required": [],
+          "title": "configExtraToml",
+          "type": "string"
+        },
+        "configMount": {
+          "additionalProperties": true,
+          "description": "Where the rendered configuration and the credential files land in the container. Consumed\nby `common.fileConfig.*`, which also passes both directories to the application as\n`\u003cPREFIX\u003e_CONFIG` and `\u003cPREFIX\u003e_SECRETS_DIR`.",
+          "properties": {
+            "configDir": {
+              "default": "",
+              "description": "Directory the rendered `config.toml` is mounted at.",
+              "required": [],
+              "title": "configDir",
+              "type": "string"
+            },
+            "secretsDir": {
+              "default": "",
+              "description": "Directory the credential files are mounted at, one file per configuration key.",
+              "required": [],
+              "title": "secretsDir",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "configMount"
+        },
         "dnsConfig": {
           "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodDNSConfig",
           "required": []
@@ -78,6 +107,20 @@
           "description": "Pod DNS policy.",
           "required": [],
           "title": "dnsPolicy",
+          "type": "string"
+        },
+        "existingConfigMap": {
+          "default": "",
+          "description": "Name of an existing ConfigMap holding `config.toml`, replacing the one this chart renders.",
+          "required": [],
+          "title": "existingConfigMap",
+          "type": "string"
+        },
+        "existingSecret": {
+          "default": "",
+          "description": "Name of an existing Secret holding the credential files, replacing the one this chart\nrenders. Its keys must be the configuration paths the service reads, with `__` for nesting\nand no dots — that is the file name the loader parses.",
+          "required": [],
+          "title": "existingSecret",
           "type": "string"
         },
         "extraEnv": {
@@ -845,6 +888,41 @@
       "title": "commonLabels",
       "type": "object"
     },
+    "config": {
+      "additionalProperties": true,
+      "description": "Extra configuration, expressed as the TOML tree of\n[the application's README](https://github.com/TimSchoenle/Portfolio#configuration)\n(`assets.dist_dir`, `isr.ttl_secs`, ...). Merged over everything the chart derives from the\nvalues above, so it can both extend and override them. Rendered into the mounted ConfigMap —\nnever into the environment, which the loader refuses to combine with a file.",
+      "required": [],
+      "title": "config",
+      "type": "object"
+    },
+    "configExtraToml": {
+      "default": "",
+      "description": "Verbatim TOML appended after the rendered configuration. The escape hatch for anything the\nchart's TOML renderer cannot express, notably arrays of tables.",
+      "required": [],
+      "title": "configExtraToml",
+      "type": "string"
+    },
+    "configMount": {
+      "additionalProperties": true,
+      "properties": {
+        "configDir": {
+          "default": "/etc/portfolio/config",
+          "description": "Directory the rendered `config.toml` is mounted at, passed as `PORTFOLIO_CONFIG`.",
+          "required": [],
+          "title": "configDir",
+          "type": "string"
+        },
+        "secretsDir": {
+          "default": "/etc/portfolio/secrets",
+          "description": "Directory credential files would be mounted at, passed as `PORTFOLIO_SECRETS_DIR`. The\nserver reads no secret today — `github.token` belongs to the build-time repository\nbuilder — so nothing is mounted and the variable is not set; the value is here for an\noperator adding one through `extraVolumes`.",
+          "required": [],
+          "title": "secretsDir",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "configMount"
+    },
     "extraEnv": {
       "description": "Additional environment variables for the application container.",
       "items": {
@@ -918,7 +996,7 @@
           "type": "string"
         },
         "tag": {
-          "default": "v2.2.3@sha256:b3cbdcad9b50ba79049cfafb0f219a294106647c6cb3928057f0efbd278d40dc",
+          "default": "v2.3.0@sha256:ae594c6c61f4f5b369803ba5e5b24294428ef8d4ebebf73e383efa57d63260ae",
           "description": "Container image tag to deploy, pinned by digest (`vX.Y.Z\nthe pull, while the tag stays on as the readable version marker. Defaults to the chart's\n`appVersion` when empty.",
           "required": [],
           "title": "tag",
@@ -982,6 +1060,29 @@
       },
       "required": [],
       "title": "ingress"
+    },
+    "isr": {
+      "additionalProperties": true,
+      "description": "Incremental static regeneration: the server caches each rendered page and serves it again\ninstead of re-rendering.",
+      "properties": {
+        "cacheDir": {
+          "default": "/tmp/isr",
+          "description": "Writable directory rendered HTML is cached into (`isr.cache_dir`). Empty disables ISR and\nrenders every request fresh. Keep it under `/tmp`, which the chart already provides as a\nwritable emptyDir under the read-only root filesystem, and outside the bundled `public/`\ntree so those content-hashed assets stay immutable. The server creates the directory itself\nand falls back to rendering fresh if it turns out not to be writable.",
+          "required": [],
+          "title": "cacheDir",
+          "type": "string"
+        },
+        "ttlSecs": {
+          "default": 0,
+          "description": "Revalidation interval in seconds (`isr.ttl_secs`). `0` means a permanent cache, which is\nright for this site: every page renders from compile-time data, so the only thing that\nchanges the output is a redeploy — and that starts from an empty cache. Set a positive value\nonly when a *persistent* cache volume is shared across deploys.",
+          "minimum": 0,
+          "required": [],
+          "title": "ttlSecs",
+          "type": "integer"
+        }
+      },
+      "required": [],
+      "title": "isr"
     },
     "kubeVersionOverride": {
       "default": "",
@@ -1054,6 +1155,13 @@
       },
       "required": [],
       "title": "livenessProbe"
+    },
+    "logLevel": {
+      "default": "info",
+      "description": "Log verbosity, passed as `RUST_LOG`. Accepts standard tracing directives (`info`, `debug`,\n`web=debug,info`). Not part of the `PORTFOLIO_` namespace — see `server`.",
+      "required": [],
+      "title": "logLevel",
+      "type": "string"
     },
     "nameOverride": {
       "default": "",
@@ -1528,6 +1636,30 @@
       ],
       "required": [],
       "title": "securityContextPreset"
+    },
+    "server": {
+      "additionalProperties": true,
+      "description": "The listener, which is the one part of the configuration the `PORTFOLIO_` namespace does\nnot own: `PORT`, `IP` and `RUST_LOG` belong to the Dioxus toolchain, which reads them from the\nenvironment itself. They are therefore still passed as environment variables, and cannot be\nsupplied through `config`.",
+      "properties": {
+        "host": {
+          "default": "0.0.0.0",
+          "description": "Bind address, passed as `IP`.",
+          "required": [],
+          "title": "host",
+          "type": "string"
+        },
+        "port": {
+          "default": 8080,
+          "description": "Bind port, passed as `PORT`. Also the container port, the Service target and what every\nprobe and NetworkPolicy rule is written against.",
+          "maximum": 65535,
+          "minimum": 1,
+          "required": [],
+          "title": "port",
+          "type": "integer"
+        }
+      },
+      "required": [],
+      "title": "server"
     },
     "service": {
       "additionalProperties": true,

--- a/charts/portfolio/values.yaml
+++ b/charts/portfolio/values.yaml
@@ -23,7 +23,7 @@ image:
   # -- Container image tag to deploy, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins
   # the pull, while the tag stays on as the readable version marker. Defaults to the chart's
   # `appVersion` when empty.
-  tag: v2.2.3@sha256:b3cbdcad9b50ba79049cfafb0f219a294106647c6cb3928057f0efbd278d40dc
+  tag: v2.3.0@sha256:ae594c6c61f4f5b369803ba5e5b24294428ef8d4ebebf73e383efa57d63260ae
 
   # @schema
   # enum: ["", Always, IfNotPresent, Never]
@@ -65,20 +65,107 @@ terminationGracePeriodSeconds: 30
 # @schema
 # additionalProperties: true
 # @schema
-application:
+# -- The listener, which is the one part of the configuration the `PORTFOLIO_` namespace does
+# not own: `PORT`, `IP` and `RUST_LOG` belong to the Dioxus toolchain, which reads them from the
+# environment itself. They are therefore still passed as environment variables, and cannot be
+# supplied through `config`.
+server:
+  # @schema
+  # type: string
+  # @schema
+  # -- Bind address, passed as `IP`.
+  host: 0.0.0.0
+
   # @schema
   # type: integer
+  # minimum: 1
+  # maximum: 65535
   # @schema
-  # -- Port number the application listens on (exposed to the container as `PORT`).
-  # The Axum server binds to 0.0.0.0 on this port.
+  # -- Bind port, passed as `PORT`. Also the container port, the Service target and what every
+  # probe and NetworkPolicy rule is written against.
   port: 8080
+
+# @schema
+# type: string
+# @schema
+# -- Log verbosity, passed as `RUST_LOG`. Accepts standard tracing directives (`info`, `debug`,
+# `web=debug,info`). Not part of the `PORTFOLIO_` namespace — see `server`.
+logLevel: info
+
+# @schema
+# additionalProperties: true
+# @schema
+assets:
+  # @schema
+  # type: string
+  # @schema
+  # -- Directory holding the bundled assets (`assets.dist_dir`), relative to the working
+  # directory. Only the readiness probe consults it; the bundle itself is served by the Dioxus
+  # asset router, which resolves `public/` relative to the binary.
+  distDir: public
+
+# @schema
+# additionalProperties: true
+# @schema
+# -- Incremental static regeneration: the server caches each rendered page and serves it again
+# instead of re-rendering.
+isr:
+  # @schema
+  # type: string
+  # @schema
+  # -- Writable directory rendered HTML is cached into (`isr.cache_dir`). Empty disables ISR and
+  # renders every request fresh. Keep it under `/tmp`, which the chart already provides as a
+  # writable emptyDir under the read-only root filesystem, and outside the bundled `public/`
+  # tree so those content-hashed assets stay immutable. The server creates the directory itself
+  # and falls back to rendering fresh if it turns out not to be writable.
+  cacheDir: /tmp/isr
+
+  # @schema
+  # type: integer
+  # minimum: 0
+  # @schema
+  # -- Revalidation interval in seconds (`isr.ttl_secs`). `0` means a permanent cache, which is
+  # right for this site: every page renders from compile-time data, so the only thing that
+  # changes the output is a redeploy — and that starts from an empty cache. Set a positive value
+  # only when a *persistent* cache volume is shared across deploys.
+  ttlSecs: 0
+
+# @schema
+# type: object
+# additionalProperties: true
+# @schema
+# -- Extra configuration, expressed as the TOML tree of
+# [the application's README](https://github.com/TimSchoenle/Portfolio#configuration)
+# (`assets.dist_dir`, `isr.ttl_secs`, ...). Merged over everything the chart derives from the
+# values above, so it can both extend and override them. Rendered into the mounted ConfigMap —
+# never into the environment, which the loader refuses to combine with a file.
+config: {}
+
+# @schema
+# type: string
+# @schema
+# -- Verbatim TOML appended after the rendered configuration. The escape hatch for anything the
+# chart's TOML renderer cannot express, notably arrays of tables.
+configExtraToml: ""
+
+# @schema
+# additionalProperties: true
+# @schema
+configMount:
+  # @schema
+  # type: string
+  # @schema
+  # -- Directory the rendered `config.toml` is mounted at, passed as `PORTFOLIO_CONFIG`.
+  configDir: /etc/portfolio/config
 
   # @schema
   # type: string
   # @schema
-  # -- Log verbosity passed to the application as `RUST_LOG`.
-  # Accepts standard tracing/env_logger directives (e.g. `info`, `debug`, `warn`).
-  logLevel: info
+  # -- Directory credential files would be mounted at, passed as `PORTFOLIO_SECRETS_DIR`. The
+  # server reads no secret today — `github.token` belongs to the build-time repository
+  # builder — so nothing is mounted and the variable is not set; the value is here for an
+  # operator adding one through `extraVolumes`.
+  secretsDir: /etc/portfolio/secrets
 
 # @schema
 # additionalProperties: true

--- a/charts/s3-bucket-perma-link/Chart.yaml
+++ b/charts/s3-bucket-perma-link/Chart.yaml
@@ -1,7 +1,7 @@
 name: s3-bucket-perma-link
 description: This chart deploys a simple web server that provides permanent links to specific S3 bucket resources. It allows you to define static URL paths that always point to specific files in your S3 buckets.
-version: 2.0.10
-appVersion: v0.3.24
+version: 3.0.0
+appVersion: v1.0.0
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts
 sources:
@@ -11,5 +11,5 @@ maintainers:
     email: contact@tim-schoenle.de
 dependencies:
   - name: common
-    version: 1.3.0
+    version: 1.4.0
     repository: "file://../common"

--- a/charts/s3-bucket-perma-link/README.md
+++ b/charts/s3-bucket-perma-link/README.md
@@ -1,6 +1,6 @@
 # s3-bucket-perma-link
 
-![Version: 2.0.10](https://img.shields.io/badge/Version-2.0.10-informational?style=flat-square) ![AppVersion: v0.3.24](https://img.shields.io/badge/AppVersion-v0.3.24-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 This chart deploys a simple web server that provides permanent links to specific S3 bucket resources. It allows you to define static URL paths that always point to specific files in your S3 buckets.
 
@@ -21,22 +21,19 @@ bucket has to be made public.
 Create the credential Secret first — the chart never takes the keys as values:
 
 ```shell
-kubectl create secret generic s3-credentials \
-  --namespace [NAMESPACE] \
-  --from-literal=access_key='...' \
-  --from-literal=secret_key='...'
+kubectl create secret generic s3-credentials   --namespace [NAMESPACE]   --from-literal=s3__access_key='...'   --from-literal=s3__secret_key='...'
 ```
 
-The key names matter: the chart reads `access_key` and `secret_key`, and a Secret with any
-other spelling produces a pod that starts and then fails every request.
+**The key names are the configuration paths the service reads, not free-form names.** The
+credential arrives as a file and the service takes the key out of the file *name*, so
+`s3__access_key` is required; a Secret spelled any other way mounts cleanly, supplies nothing,
+and the service refuses to boot naming the missing credential.
 
 ```shell
 helm repo add timschoenle https://timschoenle.github.io/helm-charts
 helm repo update
 
-helm install [RELEASE_NAME] timschoenle/s3-bucket-perma-link \
-  --namespace [NAMESPACE] --create-namespace \
-  --values values.yaml
+helm install [RELEASE_NAME] timschoenle/s3-bucket-perma-link   --namespace [NAMESPACE] --create-namespace   --values values.yaml
 ```
 
 Upgrade with `helm upgrade [RELEASE_NAME] timschoenle/s3-bucket-perma-link -n [NAMESPACE]`,
@@ -44,42 +41,116 @@ remove with `helm uninstall [RELEASE_NAME] -n [NAMESPACE]`.
 
 ## Mapping paths to objects
 
-`application.handler.entries` is the whole configuration: one key per URL path, whose value is
-a list of `"bucket,key"` pairs.
+`bucket.entries` is the whole configuration: one entry per URL path, naming the bucket and the
+object key it resolves to.
 
 ```yaml
-application:
-  handler:
-    entries:
-      latest-report:
-        - "company-reports,2024/q4-report.pdf"
-      user-guide:
-        - "documentation,guides/user-guide.pdf"
+bucket:
+  entries:
+    latest-report:
+      bucket: company-reports
+      object: 2024/q4-report.pdf
+    "guides/user-guide":
+      bucket: documentation
+      object: guides/user-guide.pdf
 
-  s3:
-    secretName: s3-credentials
-    host: s3.eu-central-1.amazonaws.com
-    region: eu-central-1
+s3:
+  host: s3.eu-central-1.amazonaws.com
+  region: eu-central-1
+
+existingSecret: s3-credentials
 ```
 
 `GET /latest-report` then serves `2024/q4-report.pdf` out of `company-reports`. Paths are
 declared, not derived — a request for anything not listed here is not proxied, so the bucket
 cannot be walked through this service.
 
-Changing an entry is a values change and a rollout; the URL is unaffected.
+Changing an entry is a values change and no rollout: the service watches its configuration
+directory and rebuilds its bucket clients in place. The URL is unaffected either way.
+
+## Configuration
+
+Everything the service reads is rendered into one `config.toml`, mounted as a ConfigMap and
+pointed at by `S3_PERMA_LINK_CONFIG`. Nothing is passed as an environment variable, and that is
+deliberate: the loader **fails the boot on a key supplied by both the environment and a file**
+rather than resolving it by precedence, and a value that lives in a file is one the kubelet can
+rotate under a running process — which is what lets a rotated S3 credential take effect without
+a restart.
+
+The values above cover the whole documented surface. `config` takes the raw TOML tree for
+anything they do not, merged over the derived one, and `configExtraToml` is appended verbatim
+for what the renderer cannot express, notably arrays of tables.
+
+Because the service rebuilds itself when a mount changes, this chart publishes **no
+`checksum/*` pod annotations by default** — a configuration change reloads rather than rolls.
+Set `configMount.rolloutOnChange: true` to make it behave like an ordinary image bump instead.
+`telemetry.*` is installed once per process and needs a restart either way.
+
+`s3.accessKey` / `s3.secretKey` are accepted as an alternative to `existingSecret` and make the
+chart render the Secret itself. That puts the credentials into `values.yaml` and into the Helm
+release object, where anyone who can run `helm get values` can read them — use it for a
+throwaway cluster, not for anything real. `existingSecret` wins if both are set.
 
 ## Non-AWS endpoints
 
-`application.s3.host` takes any S3-compatible API endpoint, including a port. `region` is still
-required — most implementations only use it to build the request signature, but the signature
-is rejected if it disagrees with what the server expects.
+`s3.host` takes any S3-compatible API endpoint, including a port. `region` is still required —
+most implementations only use it to build the request signature, but the signature is rejected
+if it disagrees with what the server expects.
 
 ```yaml
+s3:
+  host: minio.example.com:9000
+  region: us-east-1
+
+existingSecret: s3-credentials
+```
+
+## Upgrading
+
+### 2.x to 3.0
+
+Chart 3.0 tracks the service's 1.0 release, which replaced its environment-only configuration
+with the layered, file-first loader every chart in this repository now uses. The values that
+described that environment are gone; a `helm upgrade` with 2.x values fails schema validation
+naming the offending key rather than starting a pod on the defaults.
+
+| Before | After |
+|---|---|
+| `application.server.host` | `server.host` |
+| `application.server.port` | `server.port` |
+| `application.s3.host` | `s3.host` |
+| `application.s3.region` | `s3.region` |
+| `application.s3.accessKey` | `s3.accessKey` |
+| `application.s3.secretKey` | `s3.secretKey` |
+| `application.s3.secretName` | `existingSecret` |
+| `application.handler.entries` | `bucket.entries` |
+| `application.logLevel` | `telemetry.logLevel` |
+| `application.sentryDsn` | `telemetry.sentryDsn` |
+
+Two changes need work beyond a rename:
+
+**Entries are mappings, not `"bucket,object"` strings.**
+
+```yaml
+# before
 application:
-  s3:
-    secretName: s3-credentials
-    host: minio.example.com:9000
-    region: us-east-1
+  handler:
+    entries:
+      latest-report:
+        - "company-reports,2024/q4-report.pdf"
+
+# after
+bucket:
+  entries:
+    latest-report:
+      bucket: company-reports
+      object: 2024/q4-report.pdf
+```
+
+**An existing Secret has to be re-keyed** to `s3__access_key` and `s3__secret_key`:
+
+```shell
+kubectl create secret generic s3-credentials   --namespace [NAMESPACE]   --from-literal=s3__access_key="$(kubectl get secret s3-credentials -n [NAMESPACE] -o jsonpath='{.data.access_key}' | base64 -d)"   --from-literal=s3__secret_key="$(kubectl get secret s3-credentials -n [NAMESPACE] -o jsonpath='{.data.secret_key}' | base64 -d)"   --dry-run=client -o yaml | kubectl apply -f -
 ```
 
 ## Publishing it
@@ -130,19 +201,16 @@ networkPolicy:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Explicit affinity rules. Wins over `podAntiAffinity`. |
-| application.handler.entries | object | `{}` | Handler configuration defining static routes and their S3 mappings. Each key represents a URL path, and the value is a list of "bucket,file" pairs. Example: ```yaml entries:   myfile: ["bucket1,file.txt"]   mydir: ["bucket2,dir/index.html"] ``` |
-| application.logLevel | string | `"info"` | Log level for application output. |
-| application.s3 | object | `{"host":"s3.amazon.com","region":"eu-central-1","secretName":""}` | Configuration for connecting to an S3-compatible service. |
-| application.s3.host | string | `"s3.amazon.com"` | S3-compatible API endpoint. Example: "https://s3.amazonaws.com" or "https://minio.yourdomain.com" |
-| application.s3.region | string | `"eu-central-1"` | AWS region or S3 region identifier. Used for authenticating with region-specific endpoints. |
-| application.s3.secretName | string | `""` | Name of an existing Kubernetes Secret containing S3 credentials. The secret must include `access_key` and `secret_key` fields. |
-| application.sentryDsn | string | `""` | Sentry DSN for error tracking and reporting. Leave empty to disable Sentry integration. |
-| application.server | object | `{"host":"0.0.0.0","port":8080}` | HTTP server configuration. Defines where the application listens for incoming connections. |
-| application.server.host | string | `"0.0.0.0"` | Host address to bind the HTTP server. Typically `0.0.0.0` to listen on all network interfaces. |
-| application.server.port | int | `8080` | Port number the server listens on. |
 | automountServiceAccountToken | bool | `false` | Mount the ServiceAccount API token into the pod. Set on the pod itself, which is what actually keeps the token out of the container: the ServiceAccount-level setting is ignored as soon as a pod names a different account. |
+| bucket.entries | object | `{}` | One entry per permanent link (`bucket.entries`), keyed by the request path it is served at and valued by the bucket and object key it resolves to. Required — a server with no entry serves nothing. Example: ```yaml entries:   "docs/handbook":     bucket: media     object: handbook.pdf   changelog:     bucket: media     object: releases/CHANGELOG.md ``` |
 | commonAnnotations | object | `{}` | Annotations added to every object this chart creates. |
 | commonLabels | object | `{}` | Labels added to every object this chart creates. |
+| config | object | `{}` | Extra configuration, expressed as the TOML tree of [the service's README](https://github.com/TimSchoenle/s3-bucket-perma-link#configuration) (`server.host`, `bucket.entries`, ...). Merged over everything the chart derives from the values above, so it can both extend and override them. Rendered into the mounted ConfigMap — never into the environment, which the loader refuses to combine with a file. |
+| configExtraToml | string | `""` | Verbatim TOML appended after the rendered configuration. The escape hatch for anything the chart's TOML renderer cannot express, notably arrays of tables. |
+| configMount.configDir | string | `"/etc/s3-bucket-perma-link/config"` | Directory the rendered `config.toml` is mounted at, passed as `S3_PERMA_LINK_CONFIG`. |
+| configMount.rolloutOnChange | bool | `false` | Add `checksum/*` pod annotations so a configuration change rolls the Deployment. Off by default, and deliberately so: the service watches the directories its configuration came from and rebuilds its bucket clients and listener in place when the kubelet updates the mounted ConfigMap or Secret, which is strictly better than a rollout. Turn this on only if you want configuration changes to behave like an ordinary image bump. `telemetry.*` is installed once per process and needs a restart either way. |
+| configMount.secretsDir | string | `"/etc/s3-bucket-perma-link/secrets"` | Directory the credential files are mounted at, passed as `S3_PERMA_LINK_SECRETS_DIR`. |
+| existingSecret | string | `""` | Name of an existing Secret holding the S3 credentials, which keeps them out of `values.yaml` and out of the Helm release object. **Its keys are the configuration paths, not free-form names**: `s3__access_key` and `s3__secret_key`, because the file name is what the loader parses. Set, the chart renders no Secret of its own and `s3.accessKey` / `s3.secretKey` are ignored. |
 | extraEnv | list | `[]` | Additional environment variables for the application container. |
 | extraVolumeMounts | list | `[]` | Additional volume mounts added to the application container. |
 | extraVolumes | list | `[]` | Additional volumes added to the pod. |
@@ -150,7 +218,7 @@ networkPolicy:
 | image.pullPolicy | string | `""` | The image pull policy. Empty resolves automatically from the tag/digest. |
 | image.registry | string | `""` | Registry host. Empty means Docker Hub. |
 | image.repository | string | `"timmi6790/s3-bucket-perma-link"` | The container image repository. |
-| image.tag | string | `"v0.3.24@sha256:f3e960670fccf8e46d268ca091fcc12950b469f82de9d08d939eb19a53fb88bf"` | The container image tag, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the pull, while the tag stays on as the readable version marker. Defaults to the chart's `appVersion` when empty. |
+| image.tag | string | `"v1.0.0@sha256:eb402090337f7123a489e0a5f386d6e5e89f587e6d48d1df403b8d3c827bbdbb"` | The container image tag, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the pull, while the tag stays on as the readable version marker. Defaults to the chart's `appVersion` when empty. |
 | imagePullSecrets | list | `[]` | Optional image pull secrets for private registries. |
 | ingress.annotations | object | `{}` | Custom annotations for the Ingress resource. Useful for configuring ingress controllers (e.g., cert-manager, rate limits). |
 | ingress.enabled | bool | `false` | Enable or disable Kubernetes Ingress resource creation. Set to `true` to expose the service externally via Ingress. |
@@ -222,8 +290,14 @@ networkPolicy:
 | resources.requests.memory | string | `"15Mi"` | Minimum memory requested by the container. |
 | resourcesPreset | string | `""` | Named resource sizing. Ignored when `resources` is set. |
 | revisionHistoryLimit | int | `3` | Number of old ReplicaSets retained for rollback. |
+| s3.accessKey | string | `""` | S3 access key (`s3.access_key`). Rendered into the chart's Secret and mounted as a file, so a rotation is picked up without a restart. Required unless `existingSecret` supplies it. |
+| s3.host | string | `"s3.amazon.com"` | S3-compatible API endpoint (`s3.host`), e.g. `s3.eu-central-1.amazonaws.com` or `minio.example.com`. |
+| s3.region | string | `"eu-central-1"` | Region identifier used when signing requests (`s3.region`). |
+| s3.secretKey | string | `""` | S3 secret key (`s3.secret_key`). Required unless `existingSecret` supplies it. |
 | securityContext | object | `{}` | Container security context, merged over the preset. A writable /tmp is provided automatically via an emptyDir volume. |
 | securityContextPreset | string | `"restricted"` | Container security context baseline. `restricted` drops all Linux capabilities and forbids privilege escalation, running as root and a writable root filesystem. |
+| server.host | string | `"0.0.0.0"` | Bind address (`server.host`). `0.0.0.0` is what makes the Service reach the listener. |
+| server.port | int | `8080` | Bind port (`server.port`). Also the container port, the Service target and what every probe and NetworkPolicy rule is written against. |
 | service.port | int | `80` | Port that the Kubernetes Service will expose. Typically maps to `application.server.port`. |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type that exposes the application. |
 | serviceAccount.annotations | object | `{}` | Additional annotations for the service account |
@@ -240,6 +314,8 @@ networkPolicy:
 | startupProbe.periodSeconds | int | `5` | Probe interval. |
 | startupProbe.timeoutSeconds | int | `3` | Probe timeout. |
 | strategy | object | `{}` | Deployment update strategy. Empty uses the Kubernetes default rolling update. |
+| telemetry.logLevel | string | `"info"` | Log level (`telemetry.log_level`). |
+| telemetry.sentryDsn | string | `""` | Sentry DSN (`telemetry.sentry_dsn`). Empty disables Sentry entirely. |
 | terminationGracePeriodSeconds | int | `30` | Grace period for pod shutdown. |
 | tolerations | list | `[]` | Tolerations for pod assignment. |
 | topologySpreadConstraints | list | `[]` | Pod topology spread constraints for availability. |

--- a/charts/s3-bucket-perma-link/README.md.gotmpl
+++ b/charts/s3-bucket-perma-link/README.md.gotmpl
@@ -23,22 +23,19 @@ bucket has to be made public.
 Create the credential Secret first — the chart never takes the keys as values:
 
 ```shell
-kubectl create secret generic s3-credentials \
-  --namespace [NAMESPACE] \
-  --from-literal=access_key='...' \
-  --from-literal=secret_key='...'
+kubectl create secret generic s3-credentials   --namespace [NAMESPACE]   --from-literal=s3__access_key='...'   --from-literal=s3__secret_key='...'
 ```
 
-The key names matter: the chart reads `access_key` and `secret_key`, and a Secret with any
-other spelling produces a pod that starts and then fails every request.
+**The key names are the configuration paths the service reads, not free-form names.** The
+credential arrives as a file and the service takes the key out of the file *name*, so
+`s3__access_key` is required; a Secret spelled any other way mounts cleanly, supplies nothing,
+and the service refuses to boot naming the missing credential.
 
 ```shell
 helm repo add timschoenle https://timschoenle.github.io/helm-charts
 helm repo update
 
-helm install [RELEASE_NAME] timschoenle/{{ template "chart.name" . }} \
-  --namespace [NAMESPACE] --create-namespace \
-  --values values.yaml
+helm install [RELEASE_NAME] timschoenle/{{ template "chart.name" . }}   --namespace [NAMESPACE] --create-namespace   --values values.yaml
 ```
 
 Upgrade with `helm upgrade [RELEASE_NAME] timschoenle/{{ template "chart.name" . }} -n [NAMESPACE]`,
@@ -46,42 +43,116 @@ remove with `helm uninstall [RELEASE_NAME] -n [NAMESPACE]`.
 
 ## Mapping paths to objects
 
-`application.handler.entries` is the whole configuration: one key per URL path, whose value is
-a list of `"bucket,key"` pairs.
+`bucket.entries` is the whole configuration: one entry per URL path, naming the bucket and the
+object key it resolves to.
 
 ```yaml
-application:
-  handler:
-    entries:
-      latest-report:
-        - "company-reports,2024/q4-report.pdf"
-      user-guide:
-        - "documentation,guides/user-guide.pdf"
+bucket:
+  entries:
+    latest-report:
+      bucket: company-reports
+      object: 2024/q4-report.pdf
+    "guides/user-guide":
+      bucket: documentation
+      object: guides/user-guide.pdf
 
-  s3:
-    secretName: s3-credentials
-    host: s3.eu-central-1.amazonaws.com
-    region: eu-central-1
+s3:
+  host: s3.eu-central-1.amazonaws.com
+  region: eu-central-1
+
+existingSecret: s3-credentials
 ```
 
 `GET /latest-report` then serves `2024/q4-report.pdf` out of `company-reports`. Paths are
 declared, not derived — a request for anything not listed here is not proxied, so the bucket
 cannot be walked through this service.
 
-Changing an entry is a values change and a rollout; the URL is unaffected.
+Changing an entry is a values change and no rollout: the service watches its configuration
+directory and rebuilds its bucket clients in place. The URL is unaffected either way.
+
+## Configuration
+
+Everything the service reads is rendered into one `config.toml`, mounted as a ConfigMap and
+pointed at by `S3_PERMA_LINK_CONFIG`. Nothing is passed as an environment variable, and that is
+deliberate: the loader **fails the boot on a key supplied by both the environment and a file**
+rather than resolving it by precedence, and a value that lives in a file is one the kubelet can
+rotate under a running process — which is what lets a rotated S3 credential take effect without
+a restart.
+
+The values above cover the whole documented surface. `config` takes the raw TOML tree for
+anything they do not, merged over the derived one, and `configExtraToml` is appended verbatim
+for what the renderer cannot express, notably arrays of tables.
+
+Because the service rebuilds itself when a mount changes, this chart publishes **no
+`checksum/*` pod annotations by default** — a configuration change reloads rather than rolls.
+Set `configMount.rolloutOnChange: true` to make it behave like an ordinary image bump instead.
+`telemetry.*` is installed once per process and needs a restart either way.
+
+`s3.accessKey` / `s3.secretKey` are accepted as an alternative to `existingSecret` and make the
+chart render the Secret itself. That puts the credentials into `values.yaml` and into the Helm
+release object, where anyone who can run `helm get values` can read them — use it for a
+throwaway cluster, not for anything real. `existingSecret` wins if both are set.
 
 ## Non-AWS endpoints
 
-`application.s3.host` takes any S3-compatible API endpoint, including a port. `region` is still
-required — most implementations only use it to build the request signature, but the signature
-is rejected if it disagrees with what the server expects.
+`s3.host` takes any S3-compatible API endpoint, including a port. `region` is still required —
+most implementations only use it to build the request signature, but the signature is rejected
+if it disagrees with what the server expects.
 
 ```yaml
+s3:
+  host: minio.example.com:9000
+  region: us-east-1
+
+existingSecret: s3-credentials
+```
+
+## Upgrading
+
+### 2.x to 3.0
+
+Chart 3.0 tracks the service's 1.0 release, which replaced its environment-only configuration
+with the layered, file-first loader every chart in this repository now uses. The values that
+described that environment are gone; a `helm upgrade` with 2.x values fails schema validation
+naming the offending key rather than starting a pod on the defaults.
+
+| Before | After |
+|---|---|
+| `application.server.host` | `server.host` |
+| `application.server.port` | `server.port` |
+| `application.s3.host` | `s3.host` |
+| `application.s3.region` | `s3.region` |
+| `application.s3.accessKey` | `s3.accessKey` |
+| `application.s3.secretKey` | `s3.secretKey` |
+| `application.s3.secretName` | `existingSecret` |
+| `application.handler.entries` | `bucket.entries` |
+| `application.logLevel` | `telemetry.logLevel` |
+| `application.sentryDsn` | `telemetry.sentryDsn` |
+
+Two changes need work beyond a rename:
+
+**Entries are mappings, not `"bucket,object"` strings.**
+
+```yaml
+# before
 application:
-  s3:
-    secretName: s3-credentials
-    host: minio.example.com:9000
-    region: us-east-1
+  handler:
+    entries:
+      latest-report:
+        - "company-reports,2024/q4-report.pdf"
+
+# after
+bucket:
+  entries:
+    latest-report:
+      bucket: company-reports
+      object: 2024/q4-report.pdf
+```
+
+**An existing Secret has to be re-keyed** to `s3__access_key` and `s3__secret_key`:
+
+```shell
+kubectl create secret generic s3-credentials   --namespace [NAMESPACE]   --from-literal=s3__access_key="$(kubectl get secret s3-credentials -n [NAMESPACE] -o jsonpath='{.data.access_key}' | base64 -d)"   --from-literal=s3__secret_key="$(kubectl get secret s3-credentials -n [NAMESPACE] -o jsonpath='{.data.secret_key}' | base64 -d)"   --dry-run=client -o yaml | kubectl apply -f -
 ```
 
 ## Publishing it

--- a/charts/s3-bucket-perma-link/ci/networkpolicy-values.yaml
+++ b/charts/s3-bucket-perma-link/ci/networkpolicy-values.yaml
@@ -1,13 +1,14 @@
-application:
-  handler:
-    entries:
-      4tv#Sjfpj&:
-        - bucket,file.txt
-  s3:
-    accessKey: "fe47359d4fe04df0a8689fba2358c8d2.access"
-    secretKey: "7ae0f15050f34f29b394495331ca28a2"
-    host: "s3.amazon.com"
-    region: "eu-central-1"
+s3:
+  accessKey: "fe47359d4fe04df0a8689fba2358c8d2.access"
+  secretKey: "7ae0f15050f34f29b394495331ca28a2"
+  host: "s3.amazon.com"
+  region: "eu-central-1"
+
+bucket:
+  entries:
+    "4tv#Sjfpj&":
+      bucket: bucket
+      object: file.txt
 
 networkPolicy:
   enabled: true

--- a/charts/s3-bucket-perma-link/ci/no-ingress-values.yaml
+++ b/charts/s3-bucket-perma-link/ci/no-ingress-values.yaml
@@ -1,13 +1,14 @@
-application:
-  handler:
-    entries:
-      4tv#Sjfpj&:
-        - bucket,file.txt
-  s3:
-    accessKey: "fe47359d4fe04df0a8689fba2358c8d2.access"
-    secretKey: "7ae0f15050f34f29b394495331ca28a2"
-    host: "s3.amazon.com"
-    region: "eu-central-1"
+s3:
+  accessKey: "fe47359d4fe04df0a8689fba2358c8d2.access"
+  secretKey: "7ae0f15050f34f29b394495331ca28a2"
+  host: "s3.amazon.com"
+  region: "eu-central-1"
+
+bucket:
+  entries:
+    "4tv#Sjfpj&":
+      bucket: bucket
+      object: file.txt
 
 ingress:
   enabled: false

--- a/charts/s3-bucket-perma-link/ci/test-values.yaml
+++ b/charts/s3-bucket-perma-link/ci/test-values.yaml
@@ -1,16 +1,17 @@
-application:
-  handler:
-    entries:
-      4tv#Sjfpj&:
-        - bucket,file.txt
-      hGEvxxML5*:
-        - bucket2,dir/file.txt
+s3:
+  accessKey: "fe47359d4fe04df0a8689fba2358c8d2.access"
+  secretKey: "7ae0f15050f34f29b394495331ca28a2"
+  host: "s3.amazon.com"
+  region: "eu-central-1"
 
-  s3:
-    accessKey: "fe47359d4fe04df0a8689fba2358c8d2.access"
-    secretKey: "7ae0f15050f34f29b394495331ca28a2"
-    host: "s3.amazon.com"
-    region: "eu-central-1"
+bucket:
+  entries:
+    "4tv#Sjfpj&":
+      bucket: bucket
+      object: file.txt
+    "hGEvxxML5*":
+      bucket: bucket2
+      object: dir/file.txt
 
 ingress:
   enabled: true

--- a/charts/s3-bucket-perma-link/templates/_helpers.tpl
+++ b/charts/s3-bucket-perma-link/templates/_helpers.tpl
@@ -1,10 +1,112 @@
 {{/*
-Create the name of the secret to use
+The configuration the chart derives from its own first-class values, as the TOML tree the
+service reads.
+
+Optional keys are omitted rather than written empty: an empty `telemetry.sentry_dsn` is a
+*supplied* value to the loader, and "Sentry configured with a blank DSN" is not what an
+operator who left it unset meant.
 */}}
-{{- define "s3-bucket-perma-link.s3-secretName" -}}
-{{- if .Values.application.s3.secretName }}
-{{- .Values.application.s3.secretName }}
-{{- else }}
-{{- include "common.fullname" . }}
+{{- define "s3-bucket-perma-link.derivedConfig" -}}
+server:
+  host: {{ .Values.server.host | quote }}
+  port: {{ .Values.server.port }}
+s3:
+  host: {{ .Values.s3.host | quote }}
+  region: {{ .Values.s3.region | quote }}
+telemetry:
+  log_level: {{ .Values.telemetry.logLevel | quote }}
+  {{- with .Values.telemetry.sentryDsn }}
+  sentry_dsn: {{ . | quote }}
+  {{- end }}
+{{- with .Values.bucket.entries }}
+bucket:
+  entries:
+    {{- toYaml . | nindent 4 }}
 {{- end }}
-{{- end }}
+{{- end -}}
+
+{{/*
+The configuration that actually reaches the service: the derived tree with the operator's own
+`config` tree merged over it, so `config` can both extend and override the values above.
+
+Not included: `configExtraToml`, which is appended verbatim and never parsed.
+*/}}
+{{- define "s3-bucket-perma-link.effectiveConfig" -}}
+{{- $derived := include "s3-bucket-perma-link.derivedConfig" . | fromYaml -}}
+{{- toYaml (mergeOverwrite $derived (deepCopy (.Values.config | default dict))) -}}
+{{- end -}}
+
+{{/*
+The complete `config.toml`: the effective tree, then the verbatim escape hatch.
+*/}}
+{{- define "s3-bucket-perma-link.configToml" -}}
+{{- $config := include "s3-bucket-perma-link.effectiveConfig" . | fromYaml -}}
+{{- include "common.configToml" (dict "ctx" . "maps" (list $config)) -}}
+{{- end -}}
+
+{{/*
+Refuse a render that could only produce a server with nothing to serve, and one that would
+resolve an entry to a bucket or an object the operator never named.
+
+Checked against the *effective* tree rather than against `.Values.bucket`, so supplying entries
+through `config` is as valid as supplying them through the first-class value. `configExtraToml`
+is appended verbatim and never parsed, so a chart that has one steps out of the way rather than
+rejecting a configuration it cannot see.
+*/}}
+{{- define "s3-bucket-perma-link.validateValues" -}}
+{{- if not .Values.configExtraToml -}}
+{{- $config := include "s3-bucket-perma-link.effectiveConfig" . | fromYaml -}}
+{{- $entries := $config | dig "bucket" "entries" dict -}}
+{{- $messages := list -}}
+{{- if not $entries -}}
+{{- $messages = append $messages "  - bucket.entries is required but was not set: a server with no entry serves nothing" -}}
+{{- end -}}
+{{- range $path, $entry := $entries -}}
+{{- if not (kindIs "map" $entry) -}}
+{{- $messages = append $messages (printf "  - bucket.entries[%q] must be a mapping of `bucket` and `object`" $path) -}}
+{{- else -}}
+{{- if not (get $entry "bucket") -}}
+{{- $messages = append $messages (printf "  - bucket.entries[%q].bucket is required but was not set" $path) -}}
+{{- end -}}
+{{- if not (get $entry "object") -}}
+{{- $messages = append $messages (printf "  - bucket.entries[%q].object is required but was not set" $path) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if $messages -}}
+{{- fail (printf "\n\nVALUES VALIDATION FAILED for chart %q:\n%s\n" .Chart.Name (join "\n" $messages)) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+The credentials this chart manages, keyed by the file name the loader reads them from: a
+configuration path with `__` for nesting and no dots, because a `.` in the name is refused
+rather than treated as a separator.
+*/}}
+{{- define "s3-bucket-perma-link.secretData" -}}
+s3__access_key: {{ .Values.s3.accessKey | quote }}
+s3__secret_key: {{ .Values.s3.secretKey | quote }}
+{{- end -}}
+
+{{/*
+The secret file names this pod projects, as a YAML list. Parse with `fromYamlArray`.
+*/}}
+{{- define "s3-bucket-perma-link.secretKeys" -}}
+{{- $data := include "s3-bucket-perma-link.secretData" . | fromYaml -}}
+{{- include "common.fileConfig.secretKeys" (dict "ctx" . "data" $data) -}}
+{{- end -}}
+
+{{/*
+The pod template annotations.
+
+Deliberately without the `checksum/*` annotations the other charts in this repository use by
+default: the service watches its configuration and secrets directories and rebuilds its bucket
+clients and listener when the kubelet refreshes either mount, so rolling the Deployment on a
+configuration change would throw that property away. `configMount.rolloutOnChange` restores the
+conventional behaviour.
+*/}}
+{{- define "s3-bucket-perma-link.podAnnotations" -}}
+{{- $templates := ternary (list "configmap.yaml" "secret.yaml") (list) .Values.configMount.rolloutOnChange -}}
+{{- include "common.podAnnotations" (dict "ctx" . "templates" $templates) -}}
+{{- end -}}

--- a/charts/s3-bucket-perma-link/templates/configmap.yaml
+++ b/charts/s3-bucket-perma-link/templates/configmap.yaml
@@ -1,9 +1,4 @@
-{{- include "common.validateValues" (dict "ctx" $ "required" (list
-     "application.server.host"
-     "application.server.port"
-     "application.s3.host"
-     "application.s3.region"
-   )) }}
+{{- include "s3-bucket-perma-link.validateValues" . }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -16,25 +11,12 @@ metadata:
     {{- . | nindent 4 }}
   {{- end }}
 data:
-  SERVER.HOST: {{ .Values.application.server.host | quote }}
-  SERVER.PORT: {{ .Values.application.server.port | quote }}
-  S3.HOST: {{ .Values.application.s3.host | quote }}
-  S3.REGION: {{ .Values.application.s3.region | quote }}
-  BUCKET.ENTRIES: {{ include "config.entries" . }}
-  LOG_LEVEL: {{ .Values.application.logLevel | quote }}
-  {{- with .Values.application.sentryDsn}}
-  SENTRY_DSN: {{ . | quote }}
-  {{- end}}
-
-
-{{/*
-Convert entriy values to the correct format
-Example: key:bucket,file.txt; key2:bucket2,config.yaml
-*/}}
-{{- define "config.entries" -}}
-{{- $list := list -}}
-{{- range $k, $v := .Values.application.handler.entries -}}
-{{- $list = append $list (printf "%s:%s" $k (join "," $v)) -}}
-{{- end -}}
-{{ join "; " $list }}
-{{- end -}}
+  {{- /*
+    One file rather than a set of fragments. The loader does merge every `*.toml` in the
+    directory, but relying on that would put the precedence of one value against another inside
+    a merge this chart does not own or test. Merging in the template instead makes the effective
+    configuration readable with `kubectl get configmap -o yaml`, which is what an operator wants
+    to look at when a reload did not do what they expected.
+  */}}
+  config.toml: |
+    {{- include "s3-bucket-perma-link.configToml" . | nindent 4 }}

--- a/charts/s3-bucket-perma-link/templates/deployment.yaml
+++ b/charts/s3-bucket-perma-link/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       {{- include "common.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with (include "common.podAnnotations" (dict "ctx" $ "templates" (list "configmap.yaml" "secret.yaml"))) }}
+      {{- with (include "s3-bucket-perma-link.podAnnotations" .) }}
       annotations:
         {{- . | nindent 8 }}
       {{- end }}
@@ -30,17 +30,20 @@ spec:
     spec:
       {{- include "common.podSpec.common" . | nindent 6 }}
       containers:
-        {{- $secret := include "s3-bucket-perma-link.s3-secretName" . }}
+        {{- /*
+          Configuration reaches the container as files, never as environment variables: the
+          loader fails the boot on a key supplied by both, and only a file can be rotated under
+          a running process. The two variables below decide what the file layers *are*, so they
+          are the one thing that cannot itself be file-sourced.
+        */}}
+        {{- $secretKeys := include "s3-bucket-perma-link.secretKeys" . | fromYamlArray }}
         {{- include "common.container" (dict
               "ctx" $
-              "ports" (list (dict "name" "http" "containerPort" (int .Values.application.server.port) "protocol" "TCP"))
-              "envFrom" (list (dict "configMapRef" (dict "name" (include "common.fullname" .))))
-              "env" (list
-                (dict "name" "S3.ACCESS_KEY" "valueFrom" (dict "secretKeyRef" (dict "name" $secret "key" "access_key")))
-                (dict "name" "S3.SECRET_KEY" "valueFrom" (dict "secretKeyRef" (dict "name" $secret "key" "secret_key")))
-              )
+              "ports" (list (dict "name" "http" "containerPort" (int .Values.server.port) "protocol" "TCP"))
+              "env" (include "common.fileConfig.env" (dict "ctx" $ "prefix" "S3_PERMA_LINK" "secretKeys" $secretKeys) | fromYamlArray)
+              "volumeMounts" (include "common.fileConfig.volumeMounts" (dict "ctx" $ "secretKeys" $secretKeys) | fromYamlArray)
             ) | nindent 8 }}
-      {{- with (include "common.volumes" (dict "ctx" $)) }}
+      {{- with (include "common.volumes" (dict "ctx" $ "volumes" (include "common.fileConfig.volumes" (dict "ctx" $ "secretKeys" $secretKeys) | fromYamlArray))) }}
       volumes:
         {{- . | nindent 8 }}
       {{- end }}

--- a/charts/s3-bucket-perma-link/templates/secret.yaml
+++ b/charts/s3-bucket-perma-link/templates/secret.yaml
@@ -1,4 +1,5 @@
-{{- if and (not .Values.application.s3.secretName) .Values.application.s3.accessKey .Values.application.s3.secretKey }}
+{{- $data := include "s3-bucket-perma-link.secretData" . | fromYaml }}
+{{- if (include "common.fileConfig.createSecret" (dict "ctx" . "data" $data)) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,6 +13,11 @@ metadata:
   {{- end }}
 type: Opaque
 stringData:
-  access_key: {{ .Values.application.s3.accessKey | quote }}
-  secret_key: {{ .Values.application.s3.secretKey | quote }}
+  {{- /*
+    Key names are configuration paths with `__` for nesting and no dots, because that is how a
+    file in `S3_PERMA_LINK_SECRETS_DIR` has to be named — the loader reads the key out of the
+    file *name*. Rendered as `stringData` so the values stay readable in a diff review;
+    Kubernetes stores them base64-encoded either way.
+  */}}
+  {{- include "common.fileConfig.secretData" (dict "data" $data) | nindent 2 }}
 {{- end }}

--- a/charts/s3-bucket-perma-link/templates/service.yaml
+++ b/charts/s3-bucket-perma-link/templates/service.yaml
@@ -14,6 +14,6 @@ spec:
   ports:
     - protocol: TCP
       port: {{ .Values.service.port }}
-      targetPort: {{ .Values.application.server.port }}
+      targetPort: {{ .Values.server.port }}
   selector:
     {{- include "common.selectorLabels" . | nindent 4 }}

--- a/charts/s3-bucket-perma-link/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/s3-bucket-perma-link/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2,12 +2,25 @@ matches the committed Deployment snapshot:
   1: |
     apiVersion: v1
     data:
-      BUCKET.ENTRIES: null
-      LOG_LEVEL: info
-      S3.HOST: s3.amazon.com
-      S3.REGION: eu-central-1
-      SERVER.HOST: 0.0.0.0
-      SERVER.PORT: "8080"
+      config.toml: |
+        [bucket]
+
+        [bucket.entries]
+
+        [bucket.entries.logo]
+        bucket = "my-bucket"
+        object = "logo.png"
+
+        [s3]
+        host = "s3.amazon.com"
+        region = "eu-central-1"
+
+        [server]
+        host = "0.0.0.0"
+        port = 8080
+
+        [telemetry]
+        log_level = "info"
     kind: ConfigMap
     metadata:
       labels:
@@ -39,8 +52,6 @@ matches the committed Deployment snapshot:
           app.kubernetes.io/name: s3-bucket-perma-link
       template:
         metadata:
-          annotations:
-            checksum/configmap: 5255a453c195bcd7a09ad1b27660a198473dfab65c58b3bab218e0f917790018
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -50,19 +61,8 @@ matches the committed Deployment snapshot:
           automountServiceAccountToken: false
           containers:
             - env:
-                - name: S3.ACCESS_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      key: access_key
-                      name: RELEASE-NAME-s3-bucket-perma-link
-                - name: S3.SECRET_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      key: secret_key
-                      name: RELEASE-NAME-s3-bucket-perma-link
-              envFrom:
-                - configMapRef:
-                    name: RELEASE-NAME-s3-bucket-perma-link
+                - name: S3_PERMA_LINK_CONFIG
+                  value: /etc/s3-bucket-perma-link/config
               image: timmi6790/s3-bucket-perma-link:v0.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -112,6 +112,9 @@ matches the committed Deployment snapshot:
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp
+                - mountPath: /etc/s3-bucket-perma-link/config
+                  name: config
+                  readOnly: true
           securityContext:
             fsGroup: 1000
             fsGroupChangePolicy: OnRootMismatch
@@ -125,16 +128,32 @@ matches the committed Deployment snapshot:
           volumes:
             - emptyDir: {}
               name: tmp
+            - configMap:
+                name: RELEASE-NAME-s3-bucket-perma-link
+              name: config
 matches the committed Deployment snapshot with network policies and probes on:
   1: |
     apiVersion: v1
     data:
-      BUCKET.ENTRIES: null
-      LOG_LEVEL: info
-      S3.HOST: s3.amazon.com
-      S3.REGION: eu-central-1
-      SERVER.HOST: 0.0.0.0
-      SERVER.PORT: "8080"
+      config.toml: |
+        [bucket]
+
+        [bucket.entries]
+
+        [bucket.entries.logo]
+        bucket = "my-bucket"
+        object = "logo.png"
+
+        [s3]
+        host = "s3.amazon.com"
+        region = "eu-central-1"
+
+        [server]
+        host = "0.0.0.0"
+        port = 8080
+
+        [telemetry]
+        log_level = "info"
     kind: ConfigMap
     metadata:
       labels:
@@ -166,8 +185,6 @@ matches the committed Deployment snapshot with network policies and probes on:
           app.kubernetes.io/name: s3-bucket-perma-link
       template:
         metadata:
-          annotations:
-            checksum/configmap: 5255a453c195bcd7a09ad1b27660a198473dfab65c58b3bab218e0f917790018
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -187,19 +204,8 @@ matches the committed Deployment snapshot with network policies and probes on:
           automountServiceAccountToken: false
           containers:
             - env:
-                - name: S3.ACCESS_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      key: access_key
-                      name: RELEASE-NAME-s3-bucket-perma-link
-                - name: S3.SECRET_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      key: secret_key
-                      name: RELEASE-NAME-s3-bucket-perma-link
-              envFrom:
-                - configMapRef:
-                    name: RELEASE-NAME-s3-bucket-perma-link
+                - name: S3_PERMA_LINK_CONFIG
+                  value: /etc/s3-bucket-perma-link/config
               image: timmi6790/s3-bucket-perma-link:v0.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -249,6 +255,9 @@ matches the committed Deployment snapshot with network policies and probes on:
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp
+                - mountPath: /etc/s3-bucket-perma-link/config
+                  name: config
+                  readOnly: true
           nodeSelector:
             kubernetes.io/os: linux
           securityContext:
@@ -264,3 +273,6 @@ matches the committed Deployment snapshot with network policies and probes on:
           volumes:
             - emptyDir: {}
               name: tmp
+            - configMap:
+                name: RELEASE-NAME-s3-bucket-perma-link
+              name: config

--- a/charts/s3-bucket-perma-link/tests/configmap_test.yaml
+++ b/charts/s3-bucket-perma-link/tests/configmap_test.yaml
@@ -1,44 +1,108 @@
 suite: configmap
 templates:
   - configmap.yaml
+set:
+  bucket.entries:
+    logo:
+      bucket: my-bucket
+      object: logo.png
 tests:
-  - it: carries the server and S3 configuration
+  - it: renders the configuration as a single TOML file
     asserts:
       - isKind:
           of: ConfigMap
-      - equal:
-          path: data["SERVER.PORT"]
-          value: "8080"
-      - equal:
-          path: data["S3.REGION"]
-          value: eu-central-1
-      - equal:
-          path: data.LOG_LEVEL
-          value: info
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[server\]\nhost = "0\.0\.0\.0"\nport = 8080'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[s3\]\nhost = "s3\.amazon\.com"\nregion = "eu-central-1"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[telemetry\]\nlog_level = "info"'
 
-  - it: flattens bucket entries into the expected wire format
+  - it: renders one table per permanent link
     set:
-      application.handler.entries:
+      bucket.entries:
         logo:
-          - my-bucket
-          - logo.png
+          bucket: my-bucket
+          object: logo.png
         readme:
-          - other-bucket
-          - README.md
+          bucket: other-bucket
+          object: docs/README.md
     asserts:
-      - equal:
-          path: data["BUCKET.ENTRIES"]
-          value: "logo:my-bucket,logo.png; readme:other-bucket,README.md"
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[bucket\.entries\.logo\]\nbucket = "my-bucket"\nobject = "logo\.png"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[bucket\.entries\.readme\]\nbucket = "other-bucket"\nobject = "docs/README\.md"'
 
-  - it: omits the Sentry DSN unless configured
-    asserts:
-      - notExists:
-          path: data.SENTRY_DSN
-
-  - it: includes the Sentry DSN when configured
+  # A request path is not a TOML bare key. Emitted unquoted it would not parse, and the service
+  # would fail the boot on a file the chart wrote.
+  - it: quotes a request path that is not a bare TOML key
     set:
-      application.sentryDsn: https://key@sentry.example.com/1
+      bucket.entries:
+        "docs/handbook":
+          bucket: media
+          object: handbook.pdf
     asserts:
-      - equal:
-          path: data.SENTRY_DSN
-          value: https://key@sentry.example.com/1
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[bucket\.entries\."docs/handbook"\]'
+
+  # An empty optional value is still a *supplied* value to the loader, and "Sentry configured
+  # with a blank DSN" is not what leaving it unset meant.
+  - it: omits an unset Sentry DSN rather than writing it empty
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'sentry_dsn'
+
+  - it: writes the Sentry DSN once it is set
+    set:
+      telemetry.sentryDsn: https://key@sentry.example.invalid/1
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'sentry_dsn = "https://key@sentry\.example\.invalid/1"'
+
+  - it: merges the raw config tree over the derived values
+    set:
+      config:
+        s3:
+          region: us-east-1
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'region = "us-east-1"'
+
+  - it: refuses a render with nothing to serve
+    set:
+      bucket.entries: null
+    asserts:
+      - failedTemplate:
+          errorPattern: "bucket.entries is required but was not set"
+
+  # The old value shape was a list of `bucket,object` strings. `bucket.entries` is typed, so
+  # the schema rejects that outright; the raw `config` tree is not, and rendering it as-is
+  # would emit a TOML array where the service expects a table — a failure that would otherwise
+  # surface at boot.
+  - it: names an entry that is not a bucket and object mapping
+    set:
+      config:
+        bucket:
+          entries:
+            legacy:
+              - my-bucket
+              - logo.png
+    asserts:
+      - failedTemplate:
+          errorPattern: 'bucket.entries\["legacy"\] must be a mapping of `bucket` and `object`'
+
+  - it: names an entry missing its object key
+    set:
+      bucket.entries.logo.object: null
+    asserts:
+      - failedTemplate:
+          errorPattern: 'bucket.entries\["logo"\].object is required but was not set'

--- a/charts/s3-bucket-perma-link/tests/deployment_test.yaml
+++ b/charts/s3-bucket-perma-link/tests/deployment_test.yaml
@@ -3,6 +3,11 @@ templates:
   - deployment.yaml
   - configmap.yaml
   - secret.yaml
+set:
+  bucket.entries:
+    logo:
+      bucket: my-bucket
+      object: logo.png
 tests:
   - it: creates a Deployment named after the release
     documentSelector:
@@ -21,7 +26,7 @@ tests:
       path: kind
       value: Deployment
     set:
-      application.server.port: 9090
+      server.port: 9090
     asserts:
       - equal:
           path: spec.template.spec.containers[0].ports
@@ -33,53 +38,135 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.port
           value: http
 
-  - it: reads S3 credentials from the generated Secret
-    documentSelector:
-      path: kind
-      value: Deployment
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: S3.ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: RELEASE-NAME-s3-bucket-perma-link
-                key: access_key
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: S3.SECRET_KEY
-            valueFrom:
-              secretKeyRef:
-                name: RELEASE-NAME-s3-bucket-perma-link
-                key: secret_key
-
-  - it: reads them from an existing Secret when one is given
+  # The whole point of the migration: the loader refuses a key supplied by both the environment
+  # and a file, and only a file can be rotated under a running process. The only variables left
+  # are the two that decide what the file layers are.
+  - it: passes configuration as files, not as environment
     documentSelector:
       path: kind
       value: Deployment
     set:
-      application.s3.secretName: my-s3-secret
+      s3.accessKey: test-access
+      s3.secretKey: test-secret
     asserts:
-      - contains:
+      - equal:
           path: spec.template.spec.containers[0].env
-          content:
-            name: S3.ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: my-s3-secret
-                key: access_key
+          value:
+            - name: S3_PERMA_LINK_CONFIG
+              value: /etc/s3-bucket-perma-link/config
+            - name: S3_PERMA_LINK_SECRETS_DIR
+              value: /etc/s3-bucket-perma-link/secrets
+      - notExists:
+          path: spec.template.spec.containers[0].envFrom
 
-  - it: loads configuration from the ConfigMap and rolls on change
+  - it: mounts the rendered configuration read-only
     documentSelector:
       path: kind
       value: Deployment
     asserts:
       - contains:
-          path: spec.template.spec.containers[0].envFrom
+          path: spec.template.spec.volumes
           content:
-            configMapRef:
+            name: config
+            configMap:
               name: RELEASE-NAME-s3-bucket-perma-link
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /etc/s3-bucket-perma-link/config
+            readOnly: true
+
+  # A projected volume, so the kubelet keeps it up to date in place and the service — which
+  # follows the `..data` symlink — rebuilds its bucket clients without a restart.
+  - it: projects the credentials the service reads by file name
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      s3.accessKey: test-access
+      s3.secretKey: test-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: secrets
+            projected:
+              defaultMode: 256
+              sources:
+                - secret:
+                    name: RELEASE-NAME-s3-bucket-perma-link
+                    optional: true
+                    items:
+                      - key: s3__access_key
+                        path: s3__access_key
+                      - key: s3__secret_key
+                        path: s3__secret_key
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: secrets
+            mountPath: /etc/s3-bucket-perma-link/secrets
+            readOnly: true
+
+  - it: projects an existing Secret when one is given
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      existingSecret: my-s3-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: secrets
+            projected:
+              defaultMode: 256
+              sources:
+                - secret:
+                    name: my-s3-secret
+                    optional: true
+                    items:
+                      - key: s3__access_key
+                        path: s3__access_key
+                      - key: s3__secret_key
+                        path: s3__secret_key
+
+  # A configured secrets directory that cannot be read is a boot failure naming the path, not
+  # an empty layer — so the variable and the mount have to appear and disappear together.
+  - it: names no secrets directory when no credential is configured
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: S3_PERMA_LINK_SECRETS_DIR
+            value: /etc/s3-bucket-perma-link/secrets
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: secrets
+            mountPath: /etc/s3-bucket-perma-link/secrets
+            readOnly: true
+
+  # The service rebuilds itself when a mount changes, so a configuration change must not roll
+  # the Deployment unless the operator asks for it.
+  - it: publishes no checksum by default and one on request
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations["checksum/configmap"]
+
+  - it: publishes the checksum when rolloutOnChange is set
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      configMount.rolloutOnChange: true
+    asserts:
       - exists:
           path: spec.template.metadata.annotations["checksum/configmap"]

--- a/charts/s3-bucket-perma-link/tests/secret_test.yaml
+++ b/charts/s3-bucket-perma-link/tests/secret_test.yaml
@@ -7,10 +7,12 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: creates a Secret from inline credentials
+  # The key names are the configuration paths: the loader reads the key out of the file *name*,
+  # so `access_key` next to `s3__access_key` is not a cosmetic difference.
+  - it: creates a Secret keyed by configuration path
     set:
-      application.s3.accessKey: test-access
-      application.s3.secretKey: test-secret
+      s3.accessKey: test-access
+      s3.secretKey: test-secret
     asserts:
       - isKind:
           of: Secret
@@ -18,17 +20,27 @@ tests:
           path: type
           value: Opaque
       - equal:
-          path: stringData.access_key
+          path: stringData.s3__access_key
           value: test-access
       - equal:
-          path: stringData.secret_key
+          path: stringData.s3__secret_key
           value: test-secret
+
+  - it: omits a credential that was left unset rather than writing an empty file
+    set:
+      s3.accessKey: test-access
+    asserts:
+      - equal:
+          path: stringData.s3__access_key
+          value: test-access
+      - notExists:
+          path: stringData.s3__secret_key
 
   - it: creates nothing when an existing Secret is supplied
     set:
-      application.s3.secretName: my-s3-secret
-      application.s3.accessKey: test-access
-      application.s3.secretKey: test-secret
+      existingSecret: my-s3-secret
+      s3.accessKey: test-access
+      s3.secretKey: test-secret
     asserts:
       - hasDocuments:
           count: 0

--- a/charts/s3-bucket-perma-link/tests/security_test.yaml
+++ b/charts/s3-bucket-perma-link/tests/security_test.yaml
@@ -8,6 +8,11 @@ templates:
 documentSelector:
   path: kind
   value: Deployment
+set:
+  bucket.entries:
+    logo:
+      bucket: my-bucket
+      object: logo.png
 tests:
   - it: satisfies the restricted Pod Security Standard
     documentSelector:

--- a/charts/s3-bucket-perma-link/tests/snapshot_test.yaml
+++ b/charts/s3-bucket-perma-link/tests/snapshot_test.yaml
@@ -14,6 +14,10 @@ chart:
   version: 0.0.0
   appVersion: 0.0.0
 set:
+  bucket.entries:
+    logo:
+      bucket: my-bucket
+      object: logo.png
   image.tag: v0.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
 tests:
   - it: matches the committed Deployment snapshot

--- a/charts/s3-bucket-perma-link/values.schema.json
+++ b/charts/s3-bucket-perma-link/values.schema.json
@@ -6,109 +6,29 @@
       "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity",
       "required": []
     },
-    "application": {
-      "additionalProperties": true,
-      "properties": {
-        "handler": {
-          "additionalProperties": true,
-          "properties": {
-            "entries": {
-              "additionalProperties": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "description": "Handler configuration defining static routes and their S3 mappings.\nEach key represents a URL path, and the value is a list of \"bucket,file\" pairs.\nExample:\n```yaml\nentries:\n  myfile: [\"bucket1,file.txt\"]\n  mydir: [\"bucket2,dir/index.html\"]\n```",
-              "required": [],
-              "title": "entries",
-              "type": "object"
-            }
-          },
-          "required": [],
-          "title": "handler",
-          "type": "object"
-        },
-        "logLevel": {
-          "default": "info",
-          "description": "Log level for application output.",
-          "enum": [
-            "debug",
-            "info",
-            "warn",
-            "error"
-          ],
-          "required": [],
-          "title": "logLevel"
-        },
-        "s3": {
-          "additionalProperties": true,
-          "description": "Configuration for connecting to an S3-compatible service.",
-          "properties": {
-            "host": {
-              "default": "s3.amazon.com",
-              "description": "S3-compatible API endpoint.\nExample: \"https://s3.amazonaws.com\" or \"https://minio.yourdomain.com\"",
-              "required": [],
-              "title": "host",
-              "type": "string"
-            },
-            "region": {
-              "default": "eu-central-1",
-              "description": "AWS region or S3 region identifier.\nUsed for authenticating with region-specific endpoints.",
-              "required": [],
-              "title": "region",
-              "type": "string"
-            },
-            "secretName": {
-              "default": "",
-              "description": "Name of an existing Kubernetes Secret containing S3 credentials.\nThe secret must include `access_key` and `secret_key` fields.",
-              "required": [],
-              "title": "secretName",
-              "type": "string"
-            }
-          },
-          "required": [],
-          "title": "s3"
-        },
-        "sentryDsn": {
-          "default": "",
-          "description": "Sentry DSN for error tracking and reporting.\nLeave empty to disable Sentry integration.",
-          "required": [],
-          "title": "sentryDsn",
-          "type": "string"
-        },
-        "server": {
-          "additionalProperties": true,
-          "description": "HTTP server configuration.\nDefines where the application listens for incoming connections.",
-          "properties": {
-            "host": {
-              "default": "0.0.0.0",
-              "description": "Host address to bind the HTTP server.\nTypically `0.0.0.0` to listen on all network interfaces.",
-              "required": [],
-              "title": "host",
-              "type": "string"
-            },
-            "port": {
-              "default": 8080,
-              "description": "Port number the server listens on.",
-              "required": [],
-              "title": "port",
-              "type": "integer"
-            }
-          },
-          "required": [],
-          "title": "server"
-        }
-      },
-      "required": [],
-      "title": "application"
-    },
     "automountServiceAccountToken": {
       "default": false,
       "description": "Mount the ServiceAccount API token into the pod.\nSet on the pod itself, which is what actually keeps the token out of the container: the\nServiceAccount-level setting is ignored as soon as a pod names a different account.",
       "required": [],
       "title": "automountServiceAccountToken",
       "type": "boolean"
+    },
+    "bucket": {
+      "additionalProperties": true,
+      "properties": {
+        "entries": {
+          "additionalProperties": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "description": "One entry per permanent link (`bucket.entries`), keyed by the request path it is served\nat and valued by the bucket and object key it resolves to. Required — a server with no\nentry serves nothing.\nExample:\n```yaml\nentries:\n  \"docs/handbook\":\n    bucket: media\n    object: handbook.pdf\n  changelog:\n    bucket: media\n    object: releases/CHANGELOG.md\n```",
+          "required": [],
+          "title": "entries",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "bucket"
     },
     "common": {
       "description": "Shared template partials for the TimSchoenle Helm charts",
@@ -145,6 +65,42 @@
           "title": "component",
           "type": "string"
         },
+        "config": {
+          "additionalProperties": true,
+          "description": "Application configuration, expressed as the TOML tree the service documents. Rendered by\n`common.toml` into the ConfigMap the pod mounts, never passed as environment variables: the\nloader every application shares refuses a key supplied by both the environment and a file,\nand a value that lives in a file is one the kubelet can rotate under a running process.",
+          "required": [],
+          "title": "config",
+          "type": "object"
+        },
+        "configExtraToml": {
+          "default": "",
+          "description": "Verbatim TOML appended after the rendered `config` tree. The escape hatch for anything\n`common.toml` cannot express, notably arrays of tables.",
+          "required": [],
+          "title": "configExtraToml",
+          "type": "string"
+        },
+        "configMount": {
+          "additionalProperties": true,
+          "description": "Where the rendered configuration and the credential files land in the container. Consumed\nby `common.fileConfig.*`, which also passes both directories to the application as\n`\u003cPREFIX\u003e_CONFIG` and `\u003cPREFIX\u003e_SECRETS_DIR`.",
+          "properties": {
+            "configDir": {
+              "default": "",
+              "description": "Directory the rendered `config.toml` is mounted at.",
+              "required": [],
+              "title": "configDir",
+              "type": "string"
+            },
+            "secretsDir": {
+              "default": "",
+              "description": "Directory the credential files are mounted at, one file per configuration key.",
+              "required": [],
+              "title": "secretsDir",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "configMount"
+        },
         "dnsConfig": {
           "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodDNSConfig",
           "required": []
@@ -154,6 +110,20 @@
           "description": "Pod DNS policy.",
           "required": [],
           "title": "dnsPolicy",
+          "type": "string"
+        },
+        "existingConfigMap": {
+          "default": "",
+          "description": "Name of an existing ConfigMap holding `config.toml`, replacing the one this chart renders.",
+          "required": [],
+          "title": "existingConfigMap",
+          "type": "string"
+        },
+        "existingSecret": {
+          "default": "",
+          "description": "Name of an existing Secret holding the credential files, replacing the one this chart\nrenders. Its keys must be the configuration paths the service reads, with `__` for nesting\nand no dots — that is the file name the loader parses.",
+          "required": [],
+          "title": "existingSecret",
           "type": "string"
         },
         "extraEnv": {
@@ -921,6 +891,55 @@
       "title": "commonLabels",
       "type": "object"
     },
+    "config": {
+      "additionalProperties": true,
+      "description": "Extra configuration, expressed as the TOML tree of\n[the service's README](https://github.com/TimSchoenle/s3-bucket-perma-link#configuration)\n(`server.host`, `bucket.entries`, ...). Merged over everything the chart derives from the\nvalues above, so it can both extend and override them. Rendered into the mounted ConfigMap —\nnever into the environment, which the loader refuses to combine with a file.",
+      "required": [],
+      "title": "config",
+      "type": "object"
+    },
+    "configExtraToml": {
+      "default": "",
+      "description": "Verbatim TOML appended after the rendered configuration. The escape hatch for anything the\nchart's TOML renderer cannot express, notably arrays of tables.",
+      "required": [],
+      "title": "configExtraToml",
+      "type": "string"
+    },
+    "configMount": {
+      "additionalProperties": true,
+      "properties": {
+        "configDir": {
+          "default": "/etc/s3-bucket-perma-link/config",
+          "description": "Directory the rendered `config.toml` is mounted at, passed as `S3_PERMA_LINK_CONFIG`.",
+          "required": [],
+          "title": "configDir",
+          "type": "string"
+        },
+        "rolloutOnChange": {
+          "default": false,
+          "description": "Add `checksum/*` pod annotations so a configuration change rolls the Deployment. Off by\ndefault, and deliberately so: the service watches the directories its configuration came\nfrom and rebuilds its bucket clients and listener in place when the kubelet updates the\nmounted ConfigMap or Secret, which is strictly better than a rollout. Turn this on only if\nyou want configuration changes to behave like an ordinary image bump. `telemetry.*` is\ninstalled once per process and needs a restart either way.",
+          "required": [],
+          "title": "rolloutOnChange",
+          "type": "boolean"
+        },
+        "secretsDir": {
+          "default": "/etc/s3-bucket-perma-link/secrets",
+          "description": "Directory the credential files are mounted at, passed as `S3_PERMA_LINK_SECRETS_DIR`.",
+          "required": [],
+          "title": "secretsDir",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "configMount"
+    },
+    "existingSecret": {
+      "default": "",
+      "description": "Name of an existing Secret holding the S3 credentials, which keeps them out of\n`values.yaml` and out of the Helm release object. **Its keys are the configuration paths, not\nfree-form names**: `s3__access_key` and `s3__secret_key`, because the file name is what the\nloader parses. Set, the chart renders no Secret of its own and `s3.accessKey` / `s3.secretKey`\nare ignored.",
+      "required": [],
+      "title": "existingSecret",
+      "type": "string"
+    },
     "extraEnv": {
       "description": "Additional environment variables for the application container.",
       "items": {
@@ -994,7 +1013,7 @@
           "type": "string"
         },
         "tag": {
-          "default": "v0.3.24@sha256:f3e960670fccf8e46d268ca091fcc12950b469f82de9d08d939eb19a53fb88bf",
+          "default": "v1.0.0@sha256:eb402090337f7123a489e0a5f386d6e5e89f587e6d48d1df403b8d3c827bbdbb",
           "description": "The container image tag, pinned by digest (`vX.Y.Z\npull, while the tag stays on as the readable version marker. Defaults to the chart's\n`appVersion` when empty.",
           "required": [],
           "title": "tag",
@@ -1544,6 +1563,41 @@
       "title": "revisionHistoryLimit",
       "type": "integer"
     },
+    "s3": {
+      "additionalProperties": true,
+      "properties": {
+        "accessKey": {
+          "default": "",
+          "description": "S3 access key (`s3.access_key`). Rendered into the chart's Secret and mounted as a file,\nso a rotation is picked up without a restart. Required unless `existingSecret` supplies it.",
+          "required": [],
+          "title": "accessKey",
+          "type": "string"
+        },
+        "host": {
+          "default": "s3.amazon.com",
+          "description": "S3-compatible API endpoint (`s3.host`), e.g. `s3.eu-central-1.amazonaws.com` or\n`minio.example.com`.",
+          "required": [],
+          "title": "host",
+          "type": "string"
+        },
+        "region": {
+          "default": "eu-central-1",
+          "description": "Region identifier used when signing requests (`s3.region`).",
+          "required": [],
+          "title": "region",
+          "type": "string"
+        },
+        "secretKey": {
+          "default": "",
+          "description": "S3 secret key (`s3.secret_key`). Required unless `existingSecret` supplies it.",
+          "required": [],
+          "title": "secretKey",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "s3"
+    },
     "securityContext": {
       "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
       "required": []
@@ -1557,6 +1611,29 @@
       ],
       "required": [],
       "title": "securityContextPreset"
+    },
+    "server": {
+      "additionalProperties": true,
+      "properties": {
+        "host": {
+          "default": "0.0.0.0",
+          "description": "Bind address (`server.host`). `0.0.0.0` is what makes the Service reach the listener.",
+          "required": [],
+          "title": "host",
+          "type": "string"
+        },
+        "port": {
+          "default": 8080,
+          "description": "Bind port (`server.port`). Also the container port, the Service target and what every\nprobe and NetworkPolicy rule is written against.",
+          "maximum": 65535,
+          "minimum": 1,
+          "required": [],
+          "title": "port",
+          "type": "integer"
+        }
+      },
+      "required": [],
+      "title": "server"
     },
     "service": {
       "additionalProperties": true,
@@ -1686,6 +1763,33 @@
     "strategy": {
       "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.apps.v1.DeploymentStrategy",
       "required": []
+    },
+    "telemetry": {
+      "additionalProperties": true,
+      "properties": {
+        "logLevel": {
+          "default": "info",
+          "description": "Log level (`telemetry.log_level`).",
+          "enum": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ],
+          "required": [],
+          "title": "logLevel"
+        },
+        "sentryDsn": {
+          "default": "",
+          "description": "Sentry DSN (`telemetry.sentry_dsn`). Empty disables Sentry entirely.",
+          "required": [],
+          "title": "sentryDsn",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "telemetry"
     },
     "terminationGracePeriodSeconds": {
       "default": 30,

--- a/charts/s3-bucket-perma-link/values.yaml
+++ b/charts/s3-bucket-perma-link/values.yaml
@@ -23,7 +23,7 @@ image:
   # -- The container image tag, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the
   # pull, while the tag stays on as the readable version marker. Defaults to the chart's
   # `appVersion` when empty.
-  tag: v0.3.24@sha256:f3e960670fccf8e46d268ca091fcc12950b469f82de9d08d939eb19a53fb88bf
+  tag: v1.0.0@sha256:eb402090337f7123a489e0a5f386d6e5e89f587e6d48d1df403b8d3c827bbdbb
 
   # @schema
   # enum: ["", Always, IfNotPresent, Never]
@@ -34,98 +34,147 @@ image:
 # @schema
 # additionalProperties: true
 # @schema
-application:
+server:
   # @schema
-  # enum: [debug, info, warn, error]
+  # type: string
   # @schema
-  # -- Log level for application output.
+  # -- Bind address (`server.host`). `0.0.0.0` is what makes the Service reach the listener.
+  host: 0.0.0.0
+
+  # @schema
+  # type: integer
+  # minimum: 1
+  # maximum: 65535
+  # @schema
+  # -- Bind port (`server.port`). Also the container port, the Service target and what every
+  # probe and NetworkPolicy rule is written against.
+  port: 8080
+
+# @schema
+# additionalProperties: true
+# @schema
+s3:
+  # @schema
+  # type: string
+  # @schema
+  # -- S3-compatible API endpoint (`s3.host`), e.g. `s3.eu-central-1.amazonaws.com` or
+  # `minio.example.com`.
+  host: "s3.amazon.com"
+
+  # @schema
+  # type: string
+  # @schema
+  # -- Region identifier used when signing requests (`s3.region`).
+  region: "eu-central-1"
+
+  # @schema
+  # type: string
+  # @schema
+  # -- S3 access key (`s3.access_key`). Rendered into the chart's Secret and mounted as a file,
+  # so a rotation is picked up without a restart. Required unless `existingSecret` supplies it.
+  accessKey: ""
+
+  # @schema
+  # type: string
+  # @schema
+  # -- S3 secret key (`s3.secret_key`). Required unless `existingSecret` supplies it.
+  secretKey: ""
+
+# @schema
+# additionalProperties: true
+# @schema
+bucket:
+  # @schema
+  # type: object
+  # additionalProperties:
+  #   type: object
+  #   additionalProperties: true
+  # @schema
+  # -- One entry per permanent link (`bucket.entries`), keyed by the request path it is served
+  # at and valued by the bucket and object key it resolves to. Required — a server with no
+  # entry serves nothing.
+  # Example:
+  # ```yaml
+  # entries:
+  #   "docs/handbook":
+  #     bucket: media
+  #     object: handbook.pdf
+  #   changelog:
+  #     bucket: media
+  #     object: releases/CHANGELOG.md
+  # ```
+  entries: {}
+
+# @schema
+# additionalProperties: true
+# @schema
+telemetry:
+  # @schema
+  # enum: [trace, debug, info, warn, error]
+  # @schema
+  # -- Log level (`telemetry.log_level`).
   logLevel: info
 
   # @schema
   # type: string
   # @schema
-  # -- Sentry DSN for error tracking and reporting.
-  # Leave empty to disable Sentry integration.
+  # -- Sentry DSN (`telemetry.sentry_dsn`). Empty disables Sentry entirely.
   sentryDsn: ""
 
+# @schema
+# type: string
+# @schema
+# -- Name of an existing Secret holding the S3 credentials, which keeps them out of
+# `values.yaml` and out of the Helm release object. **Its keys are the configuration paths, not
+# free-form names**: `s3__access_key` and `s3__secret_key`, because the file name is what the
+# loader parses. Set, the chart renders no Secret of its own and `s3.accessKey` / `s3.secretKey`
+# are ignored.
+existingSecret: ""
+
+# @schema
+# type: object
+# additionalProperties: true
+# @schema
+# -- Extra configuration, expressed as the TOML tree of
+# [the service's README](https://github.com/TimSchoenle/s3-bucket-perma-link#configuration)
+# (`server.host`, `bucket.entries`, ...). Merged over everything the chart derives from the
+# values above, so it can both extend and override them. Rendered into the mounted ConfigMap —
+# never into the environment, which the loader refuses to combine with a file.
+config: {}
+
+# @schema
+# type: string
+# @schema
+# -- Verbatim TOML appended after the rendered configuration. The escape hatch for anything the
+# chart's TOML renderer cannot express, notably arrays of tables.
+configExtraToml: ""
+
+# @schema
+# additionalProperties: true
+# @schema
+configMount:
   # @schema
-  # additionalProperties: true
+  # type: boolean
   # @schema
-  # -- HTTP server configuration.
-  # Defines where the application listens for incoming connections.
-  server:
-    # @schema
-    # type: integer
-    # @schema
-    # -- Port number the server listens on.
-    port: 8080
-
-    # @schema
-    # type: string
-    # @schema
-    # -- Host address to bind the HTTP server.
-    # Typically `0.0.0.0` to listen on all network interfaces.
-    host: 0.0.0.0
+  # -- Add `checksum/*` pod annotations so a configuration change rolls the Deployment. Off by
+  # default, and deliberately so: the service watches the directories its configuration came
+  # from and rebuilds its bucket clients and listener in place when the kubelet updates the
+  # mounted ConfigMap or Secret, which is strictly better than a rollout. Turn this on only if
+  # you want configuration changes to behave like an ordinary image bump. `telemetry.*` is
+  # installed once per process and needs a restart either way.
+  rolloutOnChange: false
 
   # @schema
-  # type: object
-  # additionalProperties: true
+  # type: string
   # @schema
-  handler:
-    # @schema
-    # type: object
-    # additionalProperties:
-    #   type: array
-    #   items:
-    #     type: string
-    # @schema
-    # -- Handler configuration defining static routes and their S3 mappings.
-    # Each key represents a URL path, and the value is a list of "bucket,file" pairs.
-    # Example:
-    # ```yaml
-    # entries:
-    #   myfile: ["bucket1,file.txt"]
-    #   mydir: ["bucket2,dir/index.html"]
-    # ```
-    entries: {}
+  # -- Directory the rendered `config.toml` is mounted at, passed as `S3_PERMA_LINK_CONFIG`.
+  configDir: /etc/s3-bucket-perma-link/config
 
   # @schema
-  # additionalProperties: true
+  # type: string
   # @schema
-  # -- Configuration for connecting to an S3-compatible service.
-  s3:
-    # @schema
-    # type: string
-    # @schema
-    # -- Name of an existing Kubernetes Secret containing S3 credentials.
-    # The secret must include `access_key` and `secret_key` fields.
-    secretName: ""
-
-    # @schema
-    # type: [string, "null"]
-    # @schema
-    # -- Optional access key (alternative to secretName)
-    # accessKey: ""
-
-    # @schema
-    # type: [string, "null"]
-    # @schema
-    # -- Optional secret key (alternative to secretName)
-    # secretKey: ""
-
-    # @schema
-    # type: string
-    # @schema
-    # -- S3-compatible API endpoint.
-    # Example: "https://s3.amazonaws.com" or "https://minio.yourdomain.com"
-    host: "s3.amazon.com"
-
-    # @schema
-    # type: string
-    # @schema
-    # -- AWS region or S3 region identifier.
-    # Used for authenticating with region-specific endpoints.
-    region: "eu-central-1"
+  # -- Directory the credential files are mounted at, passed as `S3_PERMA_LINK_SECRETS_DIR`.
+  secretsDir: /etc/s3-bucket-perma-link/secrets
 
 # @schema
 # additionalProperties: true

--- a/charts/tankovault/Chart.yaml
+++ b/charts/tankovault/Chart.yaml
@@ -1,6 +1,6 @@
 name: tankovault
 description: This chart deploys the full TankoVault manga aggregator stack — frontend, api, control-plane, worker, notifier, sync, challenge-solver and render — hardened to the restricted Pod Security Standard, with file-backed configuration that reloads in place instead of restarting pods, optional bundled PostgreSQL, Valkey, NATS JetStream and TRAWL, and optional Prometheus metrics, alerting rules and Grafana dashboards.
-version: 3.3.4
+version: 3.3.5
 appVersion: 3.6.0
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts
@@ -11,5 +11,5 @@ maintainers:
     email: contact@tim-schoenle.de
 dependencies:
   - name: common
-    version: 1.3.0
+    version: 1.4.0
     repository: "file://../common"

--- a/charts/tankovault/README.md
+++ b/charts/tankovault/README.md
@@ -1,6 +1,6 @@
 # tankovault
 
-![Version: 3.3.4](https://img.shields.io/badge/Version-3.3.4-informational?style=flat-square) ![AppVersion: 3.6.0](https://img.shields.io/badge/AppVersion-3.6.0-informational?style=flat-square)
+![Version: 3.3.5](https://img.shields.io/badge/Version-3.3.5-informational?style=flat-square) ![AppVersion: 3.6.0](https://img.shields.io/badge/AppVersion-3.6.0-informational?style=flat-square)
 
 This chart deploys the full TankoVault manga aggregator stack — frontend, api, control-plane, worker, notifier, sync, challenge-solver and render — hardened to the restricted Pod Security Standard, with file-backed configuration that reloads in place instead of restarting pods, optional bundled PostgreSQL, Valkey, NATS JetStream and TRAWL, and optional Prometheus metrics, alerting rules and Grafana dashboards.
 

--- a/charts/tankovault/templates/_toml.tpl
+++ b/charts/tankovault/templates/_toml.tpl
@@ -1,65 +1,19 @@
 {{/*
-Render a values map as TOML.
+TankoVault's TOML rendering, which is the `common` library's.
 
-TankoVault's configuration file layer is TOML only, and neither Helm nor Sprig ships a
-`toToml`. This renderer covers exactly the shape `docs/CONFIGURATION.md` describes: nested
-tables, scalars, and arrays of scalars. Anything outside that shape fails loudly rather than
-emitting a file the service would reject at boot — `configExtraToml` is the escape hatch.
+The renderer used to live here; it now backs every chart in this repository that mounts a
+configuration file, so it belongs in the library the charts share. These two names stay as the
+chart's own vocabulary — `tankovault.configToml` and the tests call them — and forward
+unchanged, so the rendered ConfigMap is byte-identical to what the local implementation
+produced.
 
-Two details carry the whole thing:
-
-  1. Scalars are emitted with `toJson`. A TOML basic string, integer, float, boolean and
-     array-of-scalars are all spelled exactly as their JSON equivalents, so one conversion is
-     correct for every leaf type, including escaping inside strings.
-
-  2. **Every scalar in a table is emitted before any of its sub-tables.** In TOML a key
-     belongs to the most recent `[table]` header, so emitting `[database]` before a sibling
-     top-level scalar would silently reparent that scalar into `database`. Hence two passes,
-     not one.
-
-Map iteration in Go templates is sorted by key, so output is deterministic and a no-op
-`helm upgrade` produces a byte-identical ConfigMap — which matters here, because a changed
-ConfigMap is what wakes every service's config watcher.
-
-Usage: {{ include "tankovault.toml" (dict "value" $map) | trim }}
+See `common.toml` for the shape it accepts and why scalars are emitted before sub-tables.
+`configExtraToml` remains the escape hatch for anything outside it, notably arrays of tables.
 */}}
 {{- define "tankovault.toml" -}}
-{{- $value := .value | default dict -}}
-{{- $prefix := .prefix | default "" -}}
-{{- range $k, $v := $value -}}
-{{- if and (not (kindIs "map" $v)) (not (kindIs "invalid" $v)) -}}
-{{- if kindIs "slice" $v -}}
-{{- range $item := $v -}}
-{{- if or (kindIs "map" $item) (kindIs "slice" $item) -}}
-{{- fail (printf "tankovault: config key %q is an array of tables, which this chart cannot render as TOML. Put it in `configExtraToml` verbatim instead." (printf "%s%s" (ternary (printf "%s." $prefix) "" (ne $prefix "")) $k)) -}}
-{{- end -}}
-{{- end -}}
-{{- end }}
-{{ $k }} = {{ toJson $v }}
-{{- end -}}
-{{- end -}}
-{{- range $k, $v := $value -}}
-{{- if kindIs "map" $v -}}
-{{- $path := ternary (printf "%s.%s" $prefix $k) $k (ne $prefix "") }}
-
-[{{ $path }}]
-{{- include "tankovault.toml" (dict "value" $v "prefix" $path) -}}
-{{- end -}}
-{{- end -}}
+{{- include "common.toml" . -}}
 {{- end -}}
 
-{{/*
-Merge a list of maps into one, deeply, later entries winning, and render it as TOML.
-
-Used to fold the chart-derived wiring into the operator's own `config` tree before rendering,
-so the two never end up as competing fragments that have to be ordered against each other.
-
-Usage: {{ include "tankovault.tomlMerged" (dict "maps" (list $derived $user)) }}
-*/}}
 {{- define "tankovault.tomlMerged" -}}
-{{- $merged := dict -}}
-{{- range $m := .maps -}}
-{{- $merged = mergeOverwrite $merged (deepCopy ($m | default dict)) -}}
-{{- end -}}
-{{- include "tankovault.toml" (dict "value" $merged) -}}
+{{- include "common.tomlMerged" . -}}
 {{- end -}}

--- a/charts/tankovault/values.schema.json
+++ b/charts/tankovault/values.schema.json
@@ -297,6 +297,42 @@
           "title": "component",
           "type": "string"
         },
+        "config": {
+          "additionalProperties": true,
+          "description": "Application configuration, expressed as the TOML tree the service documents. Rendered by\n`common.toml` into the ConfigMap the pod mounts, never passed as environment variables: the\nloader every application shares refuses a key supplied by both the environment and a file,\nand a value that lives in a file is one the kubelet can rotate under a running process.",
+          "required": [],
+          "title": "config",
+          "type": "object"
+        },
+        "configExtraToml": {
+          "default": "",
+          "description": "Verbatim TOML appended after the rendered `config` tree. The escape hatch for anything\n`common.toml` cannot express, notably arrays of tables.",
+          "required": [],
+          "title": "configExtraToml",
+          "type": "string"
+        },
+        "configMount": {
+          "additionalProperties": true,
+          "description": "Where the rendered configuration and the credential files land in the container. Consumed\nby `common.fileConfig.*`, which also passes both directories to the application as\n`\u003cPREFIX\u003e_CONFIG` and `\u003cPREFIX\u003e_SECRETS_DIR`.",
+          "properties": {
+            "configDir": {
+              "default": "",
+              "description": "Directory the rendered `config.toml` is mounted at.",
+              "required": [],
+              "title": "configDir",
+              "type": "string"
+            },
+            "secretsDir": {
+              "default": "",
+              "description": "Directory the credential files are mounted at, one file per configuration key.",
+              "required": [],
+              "title": "secretsDir",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "configMount"
+        },
         "dnsConfig": {
           "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodDNSConfig",
           "required": []
@@ -306,6 +342,20 @@
           "description": "Pod DNS policy.",
           "required": [],
           "title": "dnsPolicy",
+          "type": "string"
+        },
+        "existingConfigMap": {
+          "default": "",
+          "description": "Name of an existing ConfigMap holding `config.toml`, replacing the one this chart renders.",
+          "required": [],
+          "title": "existingConfigMap",
+          "type": "string"
+        },
+        "existingSecret": {
+          "default": "",
+          "description": "Name of an existing Secret holding the credential files, replacing the one this chart\nrenders. Its keys must be the configuration paths the service reads, with `__` for nesting\nand no dots — that is the file name the loader parses.",
+          "required": [],
+          "title": "existingSecret",
           "type": "string"
         },
         "extraEnv": {

--- a/charts/teamspeak/Chart.yaml
+++ b/charts/teamspeak/Chart.yaml
@@ -1,6 +1,6 @@
 name: teamspeak
 description: This chart deploys a TeamSpeak 3 server hardened to the restricted Pod Security Standard, with optional persistence, an optional Prometheus metrics exporter sidecar, Grafana dashboards and Prometheus alerting rules.
-version: 1.0.6
+version: 1.0.7
 appVersion: 3.13.8
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts
@@ -12,5 +12,5 @@ maintainers:
     email: contact@tim-schoenle.de
 dependencies:
   - name: common
-    version: 1.3.0
+    version: 1.4.0
     repository: "file://../common"

--- a/charts/teamspeak/README.md
+++ b/charts/teamspeak/README.md
@@ -1,6 +1,6 @@
 # teamspeak
 
-![Version: 1.0.6](https://img.shields.io/badge/Version-1.0.6-informational?style=flat-square) ![AppVersion: 3.13.8](https://img.shields.io/badge/AppVersion-3.13.8-informational?style=flat-square)
+![Version: 1.0.7](https://img.shields.io/badge/Version-1.0.7-informational?style=flat-square) ![AppVersion: 3.13.8](https://img.shields.io/badge/AppVersion-3.13.8-informational?style=flat-square)
 
 This chart deploys a TeamSpeak 3 server hardened to the restricted Pod Security Standard, with optional persistence, an optional Prometheus metrics exporter sidecar, Grafana dashboards and Prometheus alerting rules.
 

--- a/charts/teamspeak/values.schema.json
+++ b/charts/teamspeak/values.schema.json
@@ -48,6 +48,42 @@
           "title": "component",
           "type": "string"
         },
+        "config": {
+          "additionalProperties": true,
+          "description": "Application configuration, expressed as the TOML tree the service documents. Rendered by\n`common.toml` into the ConfigMap the pod mounts, never passed as environment variables: the\nloader every application shares refuses a key supplied by both the environment and a file,\nand a value that lives in a file is one the kubelet can rotate under a running process.",
+          "required": [],
+          "title": "config",
+          "type": "object"
+        },
+        "configExtraToml": {
+          "default": "",
+          "description": "Verbatim TOML appended after the rendered `config` tree. The escape hatch for anything\n`common.toml` cannot express, notably arrays of tables.",
+          "required": [],
+          "title": "configExtraToml",
+          "type": "string"
+        },
+        "configMount": {
+          "additionalProperties": true,
+          "description": "Where the rendered configuration and the credential files land in the container. Consumed\nby `common.fileConfig.*`, which also passes both directories to the application as\n`\u003cPREFIX\u003e_CONFIG` and `\u003cPREFIX\u003e_SECRETS_DIR`.",
+          "properties": {
+            "configDir": {
+              "default": "",
+              "description": "Directory the rendered `config.toml` is mounted at.",
+              "required": [],
+              "title": "configDir",
+              "type": "string"
+            },
+            "secretsDir": {
+              "default": "",
+              "description": "Directory the credential files are mounted at, one file per configuration key.",
+              "required": [],
+              "title": "secretsDir",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "configMount"
+        },
         "dnsConfig": {
           "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodDNSConfig",
           "required": []
@@ -57,6 +93,20 @@
           "description": "Pod DNS policy.",
           "required": [],
           "title": "dnsPolicy",
+          "type": "string"
+        },
+        "existingConfigMap": {
+          "default": "",
+          "description": "Name of an existing ConfigMap holding `config.toml`, replacing the one this chart renders.",
+          "required": [],
+          "title": "existingConfigMap",
+          "type": "string"
+        },
+        "existingSecret": {
+          "default": "",
+          "description": "Name of an existing Secret holding the credential files, replacing the one this chart\nrenders. Its keys must be the configuration paths the service reads, with `__` for nesting\nand no dots — that is the file name the loader parses.",
+          "required": [],
+          "title": "existingSecret",
           "type": "string"
         },
         "extraEnv": {


### PR DESCRIPTION
Every application behind these charts has now released the layered, file-first configuration
loader TankoVault already used, so all five charts move onto it at once.

Configuration is rendered into a `config.toml` ConfigMap and credentials into a projected
Secret volume named by configuration path. Nothing reaches a container as an environment
variable any more except the two variables that decide what the file layers *are*.

That is the point of the change rather than a side effect of it. The loader these releases
share **fails the boot on a key supplied by both the environment and a file** instead of
resolving it by precedence, so keeping the chart's output entirely in files makes that
collision structurally impossible — and a value that lives in a file is one the kubelet can
rotate under a running process, which is what lets `cloudflare-access-webhook-redirect` and
`s3-bucket-perma-link` pick up a rotated credential with no rollout at all.

## Charts

Every one takes a major version, because every one's values contract changed. Migration
tables are in each chart's README under `Upgrading`.

| Chart | Chart version | appVersion | Upstream |
|---|---|---|---|
| `cloudflare-access-webhook-redirect` | 3.0.9 → **4.0.0** | v0.3.22 → v1.0.0 | supersedes #387 |
| `s3-bucket-perma-link` | 2.0.10 → **3.0.0** | v0.3.24 → v1.0.0 | supersedes #385 |
| `netcup-offer-bot` | 3.0.10 → **4.0.0** | v1.5.24 → v2.0.0 | supersedes #386 |
| `portfolio` | 3.0.11 → **4.0.0** | v2.2.3 → v2.3.0 | supersedes #388 |
| `mp-stats-legacy-viewer` | 1.0.11 → **2.0.0** | v0.14.1 → v0.15.0 | supersedes #389 |
| `common` | 1.3.0 → **1.4.0** | — | library |
| `tankovault` | 3.3.3 → 3.3.4 | unchanged | dependency + renderer moved out |
| `teamspeak` | 1.0.6 → 1.0.7 | unchanged | dependency only |

The five automated image-bump PRs carry the same digests this branch pins, so they can be
closed once this merges.

## `common` 1.4.0

The shared machinery, so no chart carries its own copy:

- `common.toml` / `common.tomlMerged` / `common.configToml` — moved out of `tankovault`,
  which now forwards to them. One renderer instead of one per chart.
- `common.fileConfig.*` — the config and secrets volumes, their mounts, the two loader
  variables, and the Secret bookkeeping (which keys exist, whether to render a Secret at all).

Two renderer fixes came out of the new call sites:

- **Keys outside TOML's bare-key alphabet are quoted.** `webhook.paths` is keyed by a path
  regex and `bucket.entries` by a request path; emitted bare, neither parses.
- **Scalars use `toRawJson`, not `toJson`.** The latter HTML-escapes `<`, `>` and `&` into
  `\uXXXX`. TOML parses those back to the same string, so it was never wrong — but it turned
  every URL with a query string into something unreadable in review.

## Three things worth a close look

**`existingSecret` has to be re-keyed.** The loader reads each credential out of the *file
name*, so the keys are now `cloudflare__client_id`, `s3__access_key`,
`discord__webhook_url`. A Secret still holding the old spelling mounts cleanly, supplies
nothing, and the service refuses to boot naming the missing credential. Each README has the
`kubectl create secret ... --dry-run=client -o yaml | kubectl apply -f -` one-liner.

**portfolio keeps three environment variables, and adds a fourth on purpose.** `PORT`, `IP`
and `RUST_LOG` belong to the Dioxus toolchain, which reads them itself — they are not in the
`PORTFOLIO_` namespace. Separately, the published image bakes
`PORTFOLIO_ISR__CACHE_DIR=/tmp/isr`, and the environment layer outranks the TOML one, so the
chart restates the *effective* cache directory as an environment variable alongside the file.
Without that, moving the cache through `isr.cacheDir` would write a value the image silently
overrode.

**mp-stats-legacy-viewer now supplies `server.dist_dir` and `server.data_dir`.** Pointing
`MP_STATS_CONFIG` at the chart's mount **replaces** the `/config.toml` the image ships rather
than layering over it, so every key that file carried has to be carried here. The defaults
match the image's layout; a `dist_dir` without an `index.html` is a boot failure, not a 404.

## One bug fixed in passing

`netcup-offer-bot`'s ConfigMap rendered `METRIC_IP` from `.Values.metrics.ip`, a key its
`values.yaml` never declared — so it never rendered, the exporter kept the bot's `127.0.0.1`
default, and a PodMonitor pointed at it scraped a refused connection. `metrics.ip` is a real
value now and defaults to `0.0.0.0`.

## Rollout behaviour

`cloudflare-access-webhook-redirect` and `s3-bucket-perma-link` watch their mounts and rebuild
in place, so both publish **no `checksum/*` pod annotations by default** — a configuration
change reloads rather than rolls. `configMount.rolloutOnChange: true` restores the
conventional behaviour. The other three do not reload, and keep the checksum annotations
unconditionally, which is the only way a change takes effect there.

## Verification

- `helm unittest` green on all eight charts: 589 tests, 43 snapshots. New suites cover the
  rendered TOML, the projected volumes, the exact environment, and the validation messages.
- `helm lint` clean on all five migrated charts.
- Every chart rendered against every one of its `ci/` values files, and **all 77 resulting
  `config.toml` documents parsed with a real TOML parser** (Python `tomllib`) — including
  tankovault's, which confirms the renderer move changed nothing.
- `values.schema.json` regenerated for every chart.
