### PR TITLE
feat(portfolio,mp-stats-legacy-viewer): expose the Cloudflare CSP flags

### DIFF
--- a/charts/mp-stats-legacy-viewer/Chart.yaml
+++ b/charts/mp-stats-legacy-viewer/Chart.yaml
@@ -1,7 +1,7 @@
 name: mp-stats-legacy-viewer
 description: MP Stats Legacy Viewer
-version: 2.0.0
-appVersion: v0.15.0
+version: 2.1.0
+appVersion: v0.16.0
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts
 sources:

--- a/charts/mp-stats-legacy-viewer/README.md
+++ b/charts/mp-stats-legacy-viewer/README.md
@@ -1,6 +1,6 @@
 # mp-stats-legacy-viewer
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![AppVersion: v0.15.0](https://img.shields.io/badge/AppVersion-v0.15.0-informational?style=flat-square)
+![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![AppVersion: v0.16.0](https://img.shields.io/badge/AppVersion-v0.16.0-informational?style=flat-square)
 
 MP Stats Legacy Viewer
 
@@ -75,6 +75,39 @@ The server does not reload its configuration, so the chart keeps the conventiona
 `checksum/configmap` pod annotation: a configuration change rolls the Deployment, which is the
 only way it takes effect.
 
+## Content-Security-Policy
+
+The header is derived, not configured: at startup the server reads the `index.html` in
+`server.distDir` and hashes every inline `<script>` in it, so the policy cannot drift from the
+frontend build. An unreadable or unscannable shell fails the boot before the listener binds.
+
+What the values decide is which Cloudflare products this deployment runs. All are off, because
+each one widens the policy:
+
+```yaml
+server:
+  csp:
+    enabled: true
+    cloudflare:
+      scriptNonce: false   # for the script Cloudflare's bot products inject at the edge
+      turnstile: false     # admits challenges.cloudflare.com in script-src and frame-src
+      webAnalytics: false  # admits the beacon and the endpoint it reports to
+```
+
+Turn `scriptNonce` on when Bot Fight Mode, JavaScript Detections or the challenge platform sit
+in front of this origin: they inject an inline script at the edge, after the shell was hashed,
+so no hash can cover it and `script-src` refuses it — bot management looks enabled and does
+nothing. The nonce also makes every document `Cache-Control: no-cache`, which comes with one
+condition the chart cannot enforce:
+
+> [!IMPORTANT]
+> No Cloudflare Cache Rule may cache the shell. A "Cache Everything" rule overrides the origin's
+> `Cache-Control`, satisfying the obligation at the origin and violating it at the edge — one
+> nonce shared by every reader of that cache entry.
+
+`enabled: false` drops the header entirely, and is only right when something in front of this
+server already sets one.
+
 ## Upgrading
 
 ### 1.x to 2.0
@@ -123,7 +156,7 @@ on the startup and liveness probes, so the chart omits it there.
 | image.pullPolicy | string | `""` | The image pull policy. Empty resolves automatically from the tag/digest. |
 | image.registry | string | `""` | Registry host. Empty means Docker Hub. |
 | image.repository | string | `"timschoenle/mp-stats-legacy-viewer"` | The container image repository. |
-| image.tag | string | `"v0.15.0@sha256:f2bd04006f3942f5b725e9f2a6fff4f88fe9c03fbb558f63edb224b45b190a7a"` | The container image tag, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the pull, while the tag stays on as the readable version marker. Defaults to the chart's `appVersion` when empty. |
+| image.tag | string | `"v0.16.0@sha256:3bd63be239ea5a290c59bdc9527d0869e25b7a6adb6f6c3ab1b360e3a7ec74a4"` | The container image tag, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the pull, while the tag stays on as the readable version marker. Defaults to the chart's `appVersion` when empty. |
 | imagePullSecrets | list | `[]` | Optional image pull secrets for private registries. |
 | ingress.annotations | object | `{}` | Custom annotations for the Ingress resource. Useful for configuring ingress controllers (e.g., cert-manager, rate limits). |
 | ingress.enabled | bool | `false` | Enable or disable Kubernetes Ingress resource creation. Set to `true` to expose the service externally via Ingress. |
@@ -197,6 +230,12 @@ on the startup and liveness probes, so the chart omits it there.
 | revisionHistoryLimit | int | `3` | Number of old ReplicaSets retained for rollback. |
 | securityContext | object | `{}` | Container security context, merged over the preset. A writable /tmp is provided automatically via an emptyDir volume. |
 | securityContextPreset | string | `"restricted"` | Container security context baseline. `restricted` drops all Linux capabilities and forbids privilege escalation, running as root and a writable root filesystem. |
+| server.csp | object | `{"cloudflare":{"scriptNonce":false,"turnstile":false,"webAnalytics":false},"enabled":true}` | The `Content-Security-Policy` the server attaches to every document. The policy itself is not configurable — it is derived at startup from the `index.html` in `distDir`, hashing every inline `<script>` in it, so it cannot drift from the frontend build. An unreadable shell fails the boot before the listener binds. |
+| server.csp.cloudflare | object | `{"scriptNonce":false,"turnstile":false,"webAnalytics":false}` | Concessions to the Cloudflare products running in front of this deployment. All off: each one widens the policy, and only for a product that is actually switched on. |
+| server.csp.cloudflare.scriptNonce | bool | `false` | Reserve a per-response nonce in `script-src` and serve documents `Cache-Control: no-cache` (`server.csp.cloudflare.script_nonce`). Needed by the products that inject an inline script at the edge — Bot Fight Mode, JavaScript Detections, the challenge platform — which no hash can cover, because they run after the shell was hashed. It carries one obligation the chart cannot enforce: **no Cloudflare Cache Rule may cache the shell**, or a single nonce is shared by every reader of that cache entry. |
+| server.csp.cloudflare.turnstile | bool | `false` | Admit `https://challenges.cloudflare.com` in `script-src` and `frame-src` (`server.csp.cloudflare.turnstile`), for a Turnstile widget rendered in a page this server serves. |
+| server.csp.cloudflare.webAnalytics | bool | `false` | Admit the Web Analytics beacon and the endpoint it reports to (`server.csp.cloudflare.web_analytics`). For the manually embedded snippet only — the automatic edge injection needs `scriptNonce` instead. |
+| server.csp.enabled | bool | `true` | Attach the header at all (`server.csp.enabled`). Turn it off only when something in front of this server already sets one. |
 | server.dataDir | string | `"/dist/data"` | The converter's output, served under `/data` (`server.data_dir`). The default is where the image puts it. |
 | server.distDir | string | `"/dist"` | Built frontend served as the SPA (`server.dist_dir`). The server refuses to start unless it holds an `index.html`, which is both the entry point and the fallback for unknown routes. The default is where the image puts it — change it only for an image that differs. |
 | server.host | string | `"0.0.0.0"` | Host half of the bind address (`server.bind_addr`). `0.0.0.0` is what makes the Service reach the listener. |

--- a/charts/mp-stats-legacy-viewer/README.md.gotmpl
+++ b/charts/mp-stats-legacy-viewer/README.md.gotmpl
@@ -77,6 +77,39 @@ The server does not reload its configuration, so the chart keeps the conventiona
 `checksum/configmap` pod annotation: a configuration change rolls the Deployment, which is the
 only way it takes effect.
 
+## Content-Security-Policy
+
+The header is derived, not configured: at startup the server reads the `index.html` in
+`server.distDir` and hashes every inline `<script>` in it, so the policy cannot drift from the
+frontend build. An unreadable or unscannable shell fails the boot before the listener binds.
+
+What the values decide is which Cloudflare products this deployment runs. All are off, because
+each one widens the policy:
+
+```yaml
+server:
+  csp:
+    enabled: true
+    cloudflare:
+      scriptNonce: false   # for the script Cloudflare's bot products inject at the edge
+      turnstile: false     # admits challenges.cloudflare.com in script-src and frame-src
+      webAnalytics: false  # admits the beacon and the endpoint it reports to
+```
+
+Turn `scriptNonce` on when Bot Fight Mode, JavaScript Detections or the challenge platform sit
+in front of this origin: they inject an inline script at the edge, after the shell was hashed,
+so no hash can cover it and `script-src` refuses it — bot management looks enabled and does
+nothing. The nonce also makes every document `Cache-Control: no-cache`, which comes with one
+condition the chart cannot enforce:
+
+> [!IMPORTANT]
+> No Cloudflare Cache Rule may cache the shell. A "Cache Everything" rule overrides the origin's
+> `Cache-Control`, satisfying the obligation at the origin and violating it at the edge — one
+> nonce shared by every reader of that cache entry.
+
+`enabled: false` drops the header entirely, and is only right when something in front of this
+server already sets one.
+
 ## Upgrading
 
 ### 1.x to 2.0

--- a/charts/mp-stats-legacy-viewer/templates/_helpers.tpl
+++ b/charts/mp-stats-legacy-viewer/templates/_helpers.tpl
@@ -13,6 +13,12 @@ server:
   bind_addr: {{ printf "%s:%v" .Values.server.host (.Values.server.port | toString) | quote }}
   dist_dir: {{ .Values.server.distDir | quote }}
   data_dir: {{ .Values.server.dataDir | quote }}
+  csp:
+    enabled: {{ .Values.server.csp.enabled }}
+    cloudflare:
+      script_nonce: {{ .Values.server.csp.cloudflare.scriptNonce }}
+      turnstile: {{ .Values.server.csp.cloudflare.turnstile }}
+      web_analytics: {{ .Values.server.csp.cloudflare.webAnalytics }}
 {{- end -}}
 
 {{/*

--- a/charts/mp-stats-legacy-viewer/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/mp-stats-legacy-viewer/tests/__snapshot__/snapshot_test.yaml.snap
@@ -7,6 +7,14 @@ matches the committed Deployment snapshot:
         bind_addr = "0.0.0.0:8080"
         data_dir = "/dist/data"
         dist_dir = "/dist"
+
+        [server.csp]
+        enabled = true
+
+        [server.csp.cloudflare]
+        script_nonce = false
+        turnstile = false
+        web_analytics = false
     kind: ConfigMap
     metadata:
       labels:
@@ -39,7 +47,7 @@ matches the committed Deployment snapshot:
       template:
         metadata:
           annotations:
-            checksum/configmap: cefca9513426a23b31131fb777029d276ab718718f6138bbd251ea95bd74f395
+            checksum/configmap: d5ad6f28f9ad5a9d8a06f3c339f6f01d1ee32f95af810dde63349cbe893409cf
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -128,6 +136,14 @@ matches the committed Deployment snapshot with network policies and probes on:
         bind_addr = "0.0.0.0:8080"
         data_dir = "/dist/data"
         dist_dir = "/dist"
+
+        [server.csp]
+        enabled = true
+
+        [server.csp.cloudflare]
+        script_nonce = false
+        turnstile = false
+        web_analytics = false
     kind: ConfigMap
     metadata:
       labels:
@@ -160,7 +176,7 @@ matches the committed Deployment snapshot with network policies and probes on:
       template:
         metadata:
           annotations:
-            checksum/configmap: cefca9513426a23b31131fb777029d276ab718718f6138bbd251ea95bd74f395
+            checksum/configmap: d5ad6f28f9ad5a9d8a06f3c339f6f01d1ee32f95af810dde63349cbe893409cf
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm

--- a/charts/mp-stats-legacy-viewer/tests/configmap_test.yaml
+++ b/charts/mp-stats-legacy-viewer/tests/configmap_test.yaml
@@ -51,6 +51,36 @@ tests:
           path: data["config.toml"]
           pattern: '\[converter\.cache\]\nenabled = false'
 
+  # The policy itself is derived from the shell at startup and is not configurable; what the
+  # chart writes is only which Cloudflare products it has to make room for. All off by default,
+  # because each one widens the policy.
+  - it: renders the Content-Security-Policy defaults
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[server\.csp\]\nenabled = true'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[server\.csp\.cloudflare\]\nscript_nonce = false\nturnstile = false\nweb_analytics = false'
+
+  - it: admits the Cloudflare products that are switched on
+    set:
+      server.csp.cloudflare.scriptNonce: true
+      server.csp.cloudflare.turnstile: true
+      server.csp.cloudflare.webAnalytics: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'script_nonce = true\nturnstile = true\nweb_analytics = true'
+
+  - it: allows the header to be turned off for a proxy that sets its own
+    set:
+      server.csp.enabled: false
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[server\.csp\]\nenabled = false'
+
   - it: appends configExtraToml verbatim
     set:
       configExtraToml: |

--- a/charts/mp-stats-legacy-viewer/values.schema.json
+++ b/charts/mp-stats-legacy-viewer/values.schema.json
@@ -982,7 +982,7 @@
           "type": "string"
         },
         "tag": {
-          "default": "v0.15.0@sha256:f2bd04006f3942f5b725e9f2a6fff4f88fe9c03fbb558f63edb224b45b190a7a",
+          "default": "v0.16.0@sha256:3bd63be239ea5a290c59bdc9527d0869e25b7a6adb6f6c3ab1b360e3a7ec74a4",
           "description": "The container image tag, pinned by digest (`vX.Y.Z\npull, while the tag stays on as the readable version marker. Defaults to the chart's\n`appVersion` when empty.",
           "required": [],
           "title": "tag",
@@ -1549,6 +1549,50 @@
     "server": {
       "additionalProperties": true,
       "properties": {
+        "csp": {
+          "additionalProperties": true,
+          "description": "The `Content-Security-Policy` the server attaches to every document. The policy itself is\nnot configurable — it is derived at startup from the `index.html` in `distDir`, hashing every\ninline `\u003cscript\u003e` in it, so it cannot drift from the frontend build. An unreadable shell\nfails the boot before the listener binds.",
+          "properties": {
+            "cloudflare": {
+              "additionalProperties": true,
+              "description": "Concessions to the Cloudflare products running in front of this deployment. All off:\neach one widens the policy, and only for a product that is actually switched on.",
+              "properties": {
+                "scriptNonce": {
+                  "default": false,
+                  "description": "Reserve a per-response nonce in `script-src` and serve documents `Cache-Control:\nno-cache` (`server.csp.cloudflare.script_nonce`). Needed by the products that inject an\ninline script at the edge — Bot Fight Mode, JavaScript Detections, the challenge\nplatform — which no hash can cover, because they run after the shell was hashed. It\ncarries one obligation the chart cannot enforce: **no Cloudflare Cache Rule may cache\nthe shell**, or a single nonce is shared by every reader of that cache entry.",
+                  "required": [],
+                  "title": "scriptNonce",
+                  "type": "boolean"
+                },
+                "turnstile": {
+                  "default": false,
+                  "description": "Admit `https://challenges.cloudflare.com` in `script-src` and `frame-src`\n(`server.csp.cloudflare.turnstile`), for a Turnstile widget rendered in a page this\nserver serves.",
+                  "required": [],
+                  "title": "turnstile",
+                  "type": "boolean"
+                },
+                "webAnalytics": {
+                  "default": false,
+                  "description": "Admit the Web Analytics beacon and the endpoint it reports to\n(`server.csp.cloudflare.web_analytics`). For the manually embedded snippet only — the\nautomatic edge injection needs `scriptNonce` instead.",
+                  "required": [],
+                  "title": "webAnalytics",
+                  "type": "boolean"
+                }
+              },
+              "required": [],
+              "title": "cloudflare"
+            },
+            "enabled": {
+              "default": true,
+              "description": "Attach the header at all (`server.csp.enabled`). Turn it off only when something in\nfront of this server already sets one.",
+              "required": [],
+              "title": "enabled",
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "title": "csp"
+        },
         "dataDir": {
           "default": "/dist/data",
           "description": "The converter's output, served under `/data` (`server.data_dir`). The default is where\nthe image puts it.",

--- a/charts/mp-stats-legacy-viewer/values.yaml
+++ b/charts/mp-stats-legacy-viewer/values.yaml
@@ -23,7 +23,7 @@ image:
   # -- The container image tag, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the
   # pull, while the tag stays on as the readable version marker. Defaults to the chart's
   # `appVersion` when empty.
-  tag: v0.15.0@sha256:f2bd04006f3942f5b725e9f2a6fff4f88fe9c03fbb558f63edb224b45b190a7a
+  tag: v0.16.0@sha256:3bd63be239ea5a290c59bdc9527d0869e25b7a6adb6f6c3ab1b360e3a7ec74a4
 
   # @schema
   # enum: ["", Always, IfNotPresent, Never]
@@ -65,6 +65,54 @@ server:
   # -- The converter's output, served under `/data` (`server.data_dir`). The default is where
   # the image puts it.
   dataDir: /dist/data
+
+  # @schema
+  # additionalProperties: true
+  # @schema
+  # -- The `Content-Security-Policy` the server attaches to every document. The policy itself is
+  # not configurable — it is derived at startup from the `index.html` in `distDir`, hashing every
+  # inline `<script>` in it, so it cannot drift from the frontend build. An unreadable shell
+  # fails the boot before the listener binds.
+  csp:
+    # @schema
+    # type: boolean
+    # @schema
+    # -- Attach the header at all (`server.csp.enabled`). Turn it off only when something in
+    # front of this server already sets one.
+    enabled: true
+
+    # @schema
+    # additionalProperties: true
+    # @schema
+    # -- Concessions to the Cloudflare products running in front of this deployment. All off:
+    # each one widens the policy, and only for a product that is actually switched on.
+    cloudflare:
+      # @schema
+      # type: boolean
+      # @schema
+      # -- Reserve a per-response nonce in `script-src` and serve documents `Cache-Control:
+      # no-cache` (`server.csp.cloudflare.script_nonce`). Needed by the products that inject an
+      # inline script at the edge — Bot Fight Mode, JavaScript Detections, the challenge
+      # platform — which no hash can cover, because they run after the shell was hashed. It
+      # carries one obligation the chart cannot enforce: **no Cloudflare Cache Rule may cache
+      # the shell**, or a single nonce is shared by every reader of that cache entry.
+      scriptNonce: false
+
+      # @schema
+      # type: boolean
+      # @schema
+      # -- Admit `https://challenges.cloudflare.com` in `script-src` and `frame-src`
+      # (`server.csp.cloudflare.turnstile`), for a Turnstile widget rendered in a page this
+      # server serves.
+      turnstile: false
+
+      # @schema
+      # type: boolean
+      # @schema
+      # -- Admit the Web Analytics beacon and the endpoint it reports to
+      # (`server.csp.cloudflare.web_analytics`). For the manually embedded snippet only — the
+      # automatic edge injection needs `scriptNonce` instead.
+      webAnalytics: false
 
 # @schema
 # type: object

--- a/charts/portfolio/Chart.yaml
+++ b/charts/portfolio/Chart.yaml
@@ -1,7 +1,7 @@
 name: portfolio
 description: Personal portfolio built with Rust (Yew frontend, Axum server).
-version: 4.0.0
-appVersion: v2.3.0
+version: 4.1.0
+appVersion: v2.4.0
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts
 sources:

--- a/charts/portfolio/README.md
+++ b/charts/portfolio/README.md
@@ -1,6 +1,6 @@
 # portfolio
 
-![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![AppVersion: v2.3.0](https://img.shields.io/badge/AppVersion-v2.3.0-informational?style=flat-square)
+![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![AppVersion: v2.4.0](https://img.shields.io/badge/AppVersion-v2.4.0-informational?style=flat-square)
 
 Personal portfolio built with Rust (Yew frontend, Axum server).
 
@@ -108,6 +108,37 @@ The server does not reload its configuration — only the loader half of the lib
 the chart keeps the conventional `checksum/config` pod annotation: a configuration change rolls
 the Deployment, which is the only way it takes effect.
 
+## Content-Security-Policy
+
+The header the server sends is derived, not configured: each document's inline `<script>` tags
+are hashed out of the response body itself, so the policy cannot drift from what is sent. The
+`csp` values decide only what that policy has to make room for.
+
+```yaml
+csp:
+  hashInlineScripts: true
+  cloudflare:
+    scriptNonce: true    # for the script Cloudflare's bot products inject at the edge
+    turnstile: false     # admits challenges.cloudflare.com in script-src *and* frame-src
+    webAnalytics: false  # admits the beacon and the endpoint it reports to
+```
+
+`scriptNonce` is on by default, because a script injected at the edge lands after the server
+hashed what it rendered — no hash can cover it, and without the nonce `script-src` refuses it
+and the bot detection silently never runs. The server discharges half of what that costs by
+serving every document `Cache-Control: no-cache`. The other half is yours:
+
+> [!IMPORTANT]
+> No Cloudflare Cache Rule may cache the shell. A "Cache Everything" rule overrides the origin's
+> `Cache-Control` and pins one nonce across every reader for the lifetime of the cache entry,
+> which is exactly what the nonce exists to prevent. Nothing inside the pod can detect it.
+
+**If a page renders blank**, the policy is refusing a script it should have admitted.
+`hashInlineScripts: false` restores `'unsafe-inline'` — but only together with
+`cloudflare.scriptNonce: false`, since a browser ignores `'unsafe-inline'` as soon as the policy
+carries a nonce. The chart rejects that pair at render time rather than letting the pod
+CrashLoopBackOff on its own boot check.
+
 ## Incremental static regeneration
 
 ISR is on by default and caches into `/tmp/isr`, inside the writable `emptyDir` the chart
@@ -184,6 +215,12 @@ curl http://localhost:8080/api/health
 | configExtraToml | string | `""` | Verbatim TOML appended after the rendered configuration. The escape hatch for anything the chart's TOML renderer cannot express, notably arrays of tables. |
 | configMount.configDir | string | `"/etc/portfolio/config"` | Directory the rendered `config.toml` is mounted at, passed as `PORTFOLIO_CONFIG`. |
 | configMount.secretsDir | string | `"/etc/portfolio/secrets"` | Directory credential files would be mounted at, passed as `PORTFOLIO_SECRETS_DIR`. The server reads no secret today — `github.token` belongs to the build-time repository builder — so nothing is mounted and the variable is not set; the value is here for an operator adding one through `extraVolumes`. |
+| csp | object | `{"cloudflare":{"scriptNonce":true,"turnstile":false,"webAnalytics":false},"hashInlineScripts":true}` | The `Content-Security-Policy` the server sends on every document. The policy itself is not configurable — it is built from the response body, hashing each inline `<script>` the document actually carries, so it cannot drift from what is sent. These keys decide only what it has to make room for. |
+| csp.cloudflare | object | `{"scriptNonce":true,"turnstile":false,"webAnalytics":false}` | Concessions to the Cloudflare products running in front of this origin. Each one widens the policy, so each is switched on only for a product that is actually in use. |
+| csp.cloudflare.scriptNonce | bool | `true` | Reserve a per-response nonce in `script-src` (`csp.cloudflare.script_nonce`) for the inline `<script>` Cloudflare's bot products — Bot Fight Mode, JavaScript Detections, the challenge platform — inject at the edge, after the server has hashed what it rendered. No hash can cover it, and without the nonce the detection is refused and silently never runs. On by default, and it carries one obligation the chart cannot enforce: **no Cloudflare Cache Rule may cache the shell**, or a single nonce is pinned across every reader for the lifetime of the cache entry. |
+| csp.cloudflare.turnstile | bool | `false` | Admit `https://challenges.cloudflare.com` in `script-src` *and* `frame-src` (`csp.cloudflare.turnstile`), for a Turnstile widget rendered in a page this server serves. Admitting only the first renders an empty box. |
+| csp.cloudflare.webAnalytics | bool | `false` | Admit the Cloudflare Web Analytics beacon and the endpoint it reports to (`csp.cloudflare.web_analytics`). For the manually embedded snippet only — the automatic edge injection is an inline script, which is what `scriptNonce` covers instead. |
+| csp.hashInlineScripts | bool | `true` | Hash the document's inline scripts (`csp.hash_inline_scripts`) instead of admitting all inline script with `'unsafe-inline'`. An escape hatch, not a preference: turning it off also requires `csp.cloudflare.scriptNonce: false`, because a browser ignores `'unsafe-inline'` as soon as the policy carries a nonce. The chart refuses the mismatched pair rather than letting the server fail its own boot. |
 | extraEnv | list | `[]` | Additional environment variables for the application container. |
 | extraVolumeMounts | list | `[]` | Additional volume mounts added to the application container. |
 | extraVolumes | list | `[]` | Additional volumes added to the pod. |
@@ -191,7 +228,7 @@ curl http://localhost:8080/api/health
 | image.pullPolicy | string | `""` | Kubernetes image pull policy. Empty resolves automatically from the tag/digest. |
 | image.registry | string | `""` | Registry host. Empty means Docker Hub. |
 | image.repository | string | `"timschoenle/portfolio"` | Container image repository where the Portfolio application image is stored. |
-| image.tag | string | `"v2.3.0@sha256:ae594c6c61f4f5b369803ba5e5b24294428ef8d4ebebf73e383efa57d63260ae"` | Container image tag to deploy, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the pull, while the tag stays on as the readable version marker. Defaults to the chart's `appVersion` when empty. |
+| image.tag | string | `"v2.4.0@sha256:5ddf87ca3ab9cb4b39a5555e6a494736c6f8185c881701c6a80284c0370c5fc8"` | Container image tag to deploy, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the pull, while the tag stays on as the readable version marker. Defaults to the chart's `appVersion` when empty. |
 | imagePullSecrets | list | `[]` | Optional image pull secrets for private registries. |
 | ingress.annotations | object | `{}` | Custom annotations for the Ingress resource. Example: ```yaml annotations:   cert-manager.io/cluster-issuer: "letsencrypt-prod"   nginx.ingress.kubernetes.io/ssl-redirect: "true" ``` |
 | ingress.enabled | bool | `false` | Enable or disable Kubernetes Ingress resource creation. |

--- a/charts/portfolio/README.md.gotmpl
+++ b/charts/portfolio/README.md.gotmpl
@@ -110,6 +110,37 @@ The server does not reload its configuration — only the loader half of the lib
 the chart keeps the conventional `checksum/config` pod annotation: a configuration change rolls
 the Deployment, which is the only way it takes effect.
 
+## Content-Security-Policy
+
+The header the server sends is derived, not configured: each document's inline `<script>` tags
+are hashed out of the response body itself, so the policy cannot drift from what is sent. The
+`csp` values decide only what that policy has to make room for.
+
+```yaml
+csp:
+  hashInlineScripts: true
+  cloudflare:
+    scriptNonce: true    # for the script Cloudflare's bot products inject at the edge
+    turnstile: false     # admits challenges.cloudflare.com in script-src *and* frame-src
+    webAnalytics: false  # admits the beacon and the endpoint it reports to
+```
+
+`scriptNonce` is on by default, because a script injected at the edge lands after the server
+hashed what it rendered — no hash can cover it, and without the nonce `script-src` refuses it
+and the bot detection silently never runs. The server discharges half of what that costs by
+serving every document `Cache-Control: no-cache`. The other half is yours:
+
+> [!IMPORTANT]
+> No Cloudflare Cache Rule may cache the shell. A "Cache Everything" rule overrides the origin's
+> `Cache-Control` and pins one nonce across every reader for the lifetime of the cache entry,
+> which is exactly what the nonce exists to prevent. Nothing inside the pod can detect it.
+
+**If a page renders blank**, the policy is refusing a script it should have admitted.
+`hashInlineScripts: false` restores `'unsafe-inline'` — but only together with
+`cloudflare.scriptNonce: false`, since a browser ignores `'unsafe-inline'` as soon as the policy
+carries a nonce. The chart rejects that pair at render time rather than letting the pod
+CrashLoopBackOff on its own boot check.
+
 ## Incremental static regeneration
 
 ISR is on by default and caches into `/tmp/isr`, inside the writable `emptyDir` the chart

--- a/charts/portfolio/templates/_helpers.tpl
+++ b/charts/portfolio/templates/_helpers.tpl
@@ -8,6 +8,12 @@ reads them from the environment itself, not to the `PORTFOLIO_` namespace this f
 {{- define "portfolio.derivedConfig" -}}
 assets:
   dist_dir: {{ .Values.assets.distDir | quote }}
+csp:
+  hash_inline_scripts: {{ .Values.csp.hashInlineScripts }}
+  cloudflare:
+    script_nonce: {{ .Values.csp.cloudflare.scriptNonce }}
+    turnstile: {{ .Values.csp.cloudflare.turnstile }}
+    web_analytics: {{ .Values.csp.cloudflare.webAnalytics }}
 isr:
   cache_dir: {{ .Values.isr.cacheDir | quote }}
   ttl_secs: {{ .Values.isr.ttlSecs }}
@@ -30,6 +36,35 @@ The complete `config.toml`: the effective tree, then the verbatim escape hatch.
 {{- define "portfolio.configToml" -}}
 {{- $config := include "portfolio.effectiveConfig" . | fromYaml -}}
 {{- include "common.configToml" (dict "ctx" . "maps" (list $config)) -}}
+{{- end -}}
+
+{{/*
+Refuse the one Content-Security-Policy combination the server refuses, at render time instead
+of at boot.
+
+Dropping the inline-script hashes restores `'unsafe-inline'`, and a browser ignores
+`'unsafe-inline'` as soon as the policy carries any nonce — so hashing off with the Cloudflare
+nonce still on is a policy that admits no inline script at all, and the page renders blank. The
+server fails its boot on it; catching it here turns a CrashLoopBackOff into a failed `helm
+upgrade` that names the two keys.
+
+The reverse pair is legitimate and deliberately not rejected: hashing on with the nonce off is
+simply a deployment with no Cloudflare bot product in front of it.
+
+Checked against the *effective* tree, so the pair is caught whether it arrives through the
+first-class values or through `config`. `configExtraToml` is appended verbatim and never parsed,
+so a chart that has one steps out of the way rather than rejecting what it cannot see.
+*/}}
+{{- define "portfolio.validateValues" -}}
+{{- if not .Values.configExtraToml -}}
+{{- $config := include "portfolio.effectiveConfig" . | fromYaml -}}
+{{- $hashInlineScripts := $config | dig "csp" "hash_inline_scripts" true -}}
+{{- $scriptNonce := $config | dig "csp" "cloudflare" "script_nonce" true -}}
+{{- if and (not $hashInlineScripts) $scriptNonce -}}
+{{- $messages := list "  - csp.hashInlineScripts is false while csp.cloudflare.scriptNonce is true: dropping the hashes restores 'unsafe-inline', which a browser ignores as soon as the policy carries a nonce, so every document would render blank. Turn scriptNonce off as well, or leave hashInlineScripts on." -}}
+{{- fail (printf "\n\nVALUES VALIDATION FAILED for chart %q:\n%s\n" .Chart.Name (join "\n" $messages)) -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/portfolio/templates/configmap.yaml
+++ b/charts/portfolio/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- include "portfolio.validateValues" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/portfolio/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/portfolio/tests/__snapshot__/snapshot_test.yaml.snap
@@ -6,6 +6,14 @@ matches the committed Deployment snapshot:
         [assets]
         dist_dir = "public"
 
+        [csp]
+        hash_inline_scripts = true
+
+        [csp.cloudflare]
+        script_nonce = true
+        turnstile = false
+        web_analytics = false
+
         [isr]
         cache_dir = "/tmp/isr"
         ttl_secs = 0
@@ -41,7 +49,7 @@ matches the committed Deployment snapshot:
       template:
         metadata:
           annotations:
-            checksum/configmap: 30d787efc49cddd7af7db2b5c8c5620a2260c3ecdb57c3c4455f43f3a584b1fb
+            checksum/configmap: 968ae17c11854c685e53a10c9d2a4fc04ec39a69cde248e46feaa908b9ead7d2
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -138,6 +146,14 @@ matches the committed Deployment snapshot with network policies and probes on:
         [assets]
         dist_dir = "public"
 
+        [csp]
+        hash_inline_scripts = true
+
+        [csp.cloudflare]
+        script_nonce = true
+        turnstile = false
+        web_analytics = false
+
         [isr]
         cache_dir = "/tmp/isr"
         ttl_secs = 0
@@ -173,7 +189,7 @@ matches the committed Deployment snapshot with network policies and probes on:
       template:
         metadata:
           annotations:
-            checksum/configmap: 30d787efc49cddd7af7db2b5c8c5620a2260c3ecdb57c3c4455f43f3a584b1fb
+            checksum/configmap: 968ae17c11854c685e53a10c9d2a4fc04ec39a69cde248e46feaa908b9ead7d2
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm

--- a/charts/portfolio/tests/configmap_test.yaml
+++ b/charts/portfolio/tests/configmap_test.yaml
@@ -38,6 +38,82 @@ tests:
           path: data["config.toml"]
           pattern: 'dist_dir = "/srv/public"'
 
+  # The policy itself is derived from the response body and is not configurable; what the chart
+  # writes is only what it has to make room for. `script_nonce` is on by default because this
+  # site is delivered through a Cloudflare Tunnel with the bot products active.
+  - it: renders the Content-Security-Policy defaults
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[csp\]\nhash_inline_scripts = true'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[csp\.cloudflare\]\nscript_nonce = true\nturnstile = false\nweb_analytics = false'
+
+  - it: admits the Cloudflare products that are switched on
+    set:
+      csp.cloudflare.turnstile: true
+      csp.cloudflare.webAnalytics: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'turnstile = true\nweb_analytics = true'
+
+  # A deployment with no Cloudflare bot product in front of it. Legitimate, and deliberately
+  # not caught by the validation below.
+  - it: allows the edge nonce to be dropped while the hashes stay on
+    set:
+      csp.cloudflare.scriptNonce: false
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'hash_inline_scripts = true'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'script_nonce = false'
+
+  # The escape hatch, which only works as a pair: `'unsafe-inline'` is what dropping the hashes
+  # restores, and a browser ignores it as soon as the policy carries a nonce.
+  - it: allows the escape hatch when both keys move together
+    set:
+      csp.hashInlineScripts: false
+      csp.cloudflare.scriptNonce: false
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'hash_inline_scripts = false'
+
+  - it: refuses hashes off while the edge nonce is still on
+    set:
+      csp.hashInlineScripts: false
+    asserts:
+      - failedTemplate:
+          errorPattern: "csp.hashInlineScripts is false while csp.cloudflare.scriptNonce is true"
+
+  # The pair is checked against the effective tree, so supplying it through `config` is caught
+  # exactly as the first-class values are.
+  - it: catches the refused pair supplied through the raw config tree
+    set:
+      config:
+        csp:
+          hash_inline_scripts: false
+    asserts:
+      - failedTemplate:
+          errorPattern: "csp.hashInlineScripts is false while csp.cloudflare.scriptNonce is true"
+
+  # `configExtraToml` is appended verbatim and never parsed, so the chart cannot see the whole
+  # configuration and steps out of the way rather than rejecting what it cannot check.
+  - it: steps aside when configExtraToml is in play
+    set:
+      csp.hashInlineScripts: false
+      configExtraToml: |
+        [csp.cloudflare]
+        script_nonce = false
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'hash_inline_scripts = false'
+
   # `PORT`, `IP` and `RUST_LOG` belong to the Dioxus toolchain, which reads them from the
   # environment itself. Writing them into the `PORTFOLIO_` configuration file would be writing
   # keys nothing reads.

--- a/charts/portfolio/values.schema.json
+++ b/charts/portfolio/values.schema.json
@@ -923,6 +923,50 @@
       "required": [],
       "title": "configMount"
     },
+    "csp": {
+      "additionalProperties": true,
+      "description": "The `Content-Security-Policy` the server sends on every document. The policy itself is not\nconfigurable — it is built from the response body, hashing each inline `\u003cscript\u003e` the document\nactually carries, so it cannot drift from what is sent. These keys decide only what it has to\nmake room for.",
+      "properties": {
+        "cloudflare": {
+          "additionalProperties": true,
+          "description": "Concessions to the Cloudflare products running in front of this origin. Each one widens\nthe policy, so each is switched on only for a product that is actually in use.",
+          "properties": {
+            "scriptNonce": {
+              "default": true,
+              "description": "Reserve a per-response nonce in `script-src` (`csp.cloudflare.script_nonce`) for the\ninline `\u003cscript\u003e` Cloudflare's bot products — Bot Fight Mode, JavaScript Detections, the\nchallenge platform — inject at the edge, after the server has hashed what it rendered. No\nhash can cover it, and without the nonce the detection is refused and silently never runs.\nOn by default, and it carries one obligation the chart cannot enforce: **no Cloudflare\nCache Rule may cache the shell**, or a single nonce is pinned across every reader for the\nlifetime of the cache entry.",
+              "required": [],
+              "title": "scriptNonce",
+              "type": "boolean"
+            },
+            "turnstile": {
+              "default": false,
+              "description": "Admit `https://challenges.cloudflare.com` in `script-src` *and* `frame-src`\n(`csp.cloudflare.turnstile`), for a Turnstile widget rendered in a page this server serves.\nAdmitting only the first renders an empty box.",
+              "required": [],
+              "title": "turnstile",
+              "type": "boolean"
+            },
+            "webAnalytics": {
+              "default": false,
+              "description": "Admit the Cloudflare Web Analytics beacon and the endpoint it reports to\n(`csp.cloudflare.web_analytics`). For the manually embedded snippet only — the automatic\nedge injection is an inline script, which is what `scriptNonce` covers instead.",
+              "required": [],
+              "title": "webAnalytics",
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "title": "cloudflare"
+        },
+        "hashInlineScripts": {
+          "default": true,
+          "description": "Hash the document's inline scripts (`csp.hash_inline_scripts`) instead of admitting all\ninline script with `'unsafe-inline'`. An escape hatch, not a preference: turning it off also\nrequires `csp.cloudflare.scriptNonce: false`, because a browser ignores `'unsafe-inline'` as\nsoon as the policy carries a nonce. The chart refuses the mismatched pair rather than\nletting the server fail its own boot.",
+          "required": [],
+          "title": "hashInlineScripts",
+          "type": "boolean"
+        }
+      },
+      "required": [],
+      "title": "csp"
+    },
     "extraEnv": {
       "description": "Additional environment variables for the application container.",
       "items": {
@@ -996,7 +1040,7 @@
           "type": "string"
         },
         "tag": {
-          "default": "v2.3.0@sha256:ae594c6c61f4f5b369803ba5e5b24294428ef8d4ebebf73e383efa57d63260ae",
+          "default": "v2.4.0@sha256:5ddf87ca3ab9cb4b39a5555e6a494736c6f8185c881701c6a80284c0370c5fc8",
           "description": "Container image tag to deploy, pinned by digest (`vX.Y.Z\nthe pull, while the tag stays on as the readable version marker. Defaults to the chart's\n`appVersion` when empty.",
           "required": [],
           "title": "tag",

--- a/charts/portfolio/values.yaml
+++ b/charts/portfolio/values.yaml
@@ -23,7 +23,7 @@ image:
   # -- Container image tag to deploy, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins
   # the pull, while the tag stays on as the readable version marker. Defaults to the chart's
   # `appVersion` when empty.
-  tag: v2.3.0@sha256:ae594c6c61f4f5b369803ba5e5b24294428ef8d4ebebf73e383efa57d63260ae
+  tag: v2.4.0@sha256:5ddf87ca3ab9cb4b39a5555e6a494736c6f8185c881701c6a80284c0370c5fc8
 
   # @schema
   # enum: ["", Always, IfNotPresent, Never]
@@ -103,6 +103,58 @@ assets:
   # directory. Only the readiness probe consults it; the bundle itself is served by the Dioxus
   # asset router, which resolves `public/` relative to the binary.
   distDir: public
+
+# @schema
+# additionalProperties: true
+# @schema
+# -- The `Content-Security-Policy` the server sends on every document. The policy itself is not
+# configurable — it is built from the response body, hashing each inline `<script>` the document
+# actually carries, so it cannot drift from what is sent. These keys decide only what it has to
+# make room for.
+csp:
+  # @schema
+  # type: boolean
+  # @schema
+  # -- Hash the document's inline scripts (`csp.hash_inline_scripts`) instead of admitting all
+  # inline script with `'unsafe-inline'`. An escape hatch, not a preference: turning it off also
+  # requires `csp.cloudflare.scriptNonce: false`, because a browser ignores `'unsafe-inline'` as
+  # soon as the policy carries a nonce. The chart refuses the mismatched pair rather than
+  # letting the server fail its own boot.
+  hashInlineScripts: true
+
+  # @schema
+  # additionalProperties: true
+  # @schema
+  # -- Concessions to the Cloudflare products running in front of this origin. Each one widens
+  # the policy, so each is switched on only for a product that is actually in use.
+  cloudflare:
+    # @schema
+    # type: boolean
+    # @schema
+    # -- Reserve a per-response nonce in `script-src` (`csp.cloudflare.script_nonce`) for the
+    # inline `<script>` Cloudflare's bot products — Bot Fight Mode, JavaScript Detections, the
+    # challenge platform — inject at the edge, after the server has hashed what it rendered. No
+    # hash can cover it, and without the nonce the detection is refused and silently never runs.
+    # On by default, and it carries one obligation the chart cannot enforce: **no Cloudflare
+    # Cache Rule may cache the shell**, or a single nonce is pinned across every reader for the
+    # lifetime of the cache entry.
+    scriptNonce: true
+
+    # @schema
+    # type: boolean
+    # @schema
+    # -- Admit `https://challenges.cloudflare.com` in `script-src` *and* `frame-src`
+    # (`csp.cloudflare.turnstile`), for a Turnstile widget rendered in a page this server serves.
+    # Admitting only the first renders an empty box.
+    turnstile: false
+
+    # @schema
+    # type: boolean
+    # @schema
+    # -- Admit the Cloudflare Web Analytics beacon and the endpoint it reports to
+    # (`csp.cloudflare.web_analytics`). For the manually embedded snippet only — the automatic
+    # edge injection is an inline script, which is what `scriptNonce` covers instead.
+    webAnalytics: false
 
 # @schema
 # additionalProperties: true


### PR DESCRIPTION
Consolidates #392 and #393 and carries the part they leave out.

Both bumps repin the image only. The releases behind them each add a derived `Content-Security-Policy`, and each takes a small set of configuration keys deciding what that policy has to make room for — none of which the charts exposed.

- Portfolio [v2.4.0](https://github.com/TimSchoenle/Portfolio/releases/tag/v2.4.0) — builds the policy per document with `csp-shell`
- mp-stats-legacy-viewer [v0.16.0](https://github.com/TimSchoenle/mp-stats-legacy-viewer/releases/tag/v0.16.0) — derives it from the served shell at startup

Neither policy is configurable, by design: it is computed from the bytes actually served, so it cannot drift from the bundle. What is configurable is which Cloudflare products the deployment runs.

## New values

**portfolio** — chart `4.0.0` → `4.1.0`, app `v2.3.0` → `v2.4.0`

| Value | Config path | Default |
|---|---|---|
| `csp.hashInlineScripts` | `csp.hash_inline_scripts` | `true` |
| `csp.cloudflare.scriptNonce` | `csp.cloudflare.script_nonce` | `true` |
| `csp.cloudflare.turnstile` | `csp.cloudflare.turnstile` | `false` |
| `csp.cloudflare.webAnalytics` | `csp.cloudflare.web_analytics` | `false` |

**mp-stats-legacy-viewer** — chart `2.0.0` → `2.1.0`, app `v0.15.0` → `v0.16.0`

| Value | Config path | Default |
|---|---|---|
| `server.csp.enabled` | `server.csp.enabled` | `true` |
| `server.csp.cloudflare.scriptNonce` | `server.csp.cloudflare.script_nonce` | `false` |
| `server.csp.cloudflare.turnstile` | `server.csp.cloudflare.turnstile` | `false` |
| `server.csp.cloudflare.webAnalytics` | `server.csp.cloudflare.web_analytics` | `false` |

Defaults match each application's own, including the deliberate difference on `script_nonce`: the portfolio is delivered through a Cloudflare Tunnel with the bot products active, mp-stats is not.

## The interlock

Portfolio's two hashing keys cannot move independently. Dropping the inline-script hashes restores `'unsafe-inline'`, and a browser ignores `'unsafe-inline'` as soon as the policy carries a nonce — so hashing off with the edge nonce still on is a policy admitting no inline script at all, and every document renders blank. The server refuses to boot on it.

The chart checks the pair against the **effective** configuration tree, so it is caught whether it arrives through the first-class values or through `config`, and fails the render with a message naming both keys — a failed `helm upgrade` instead of a CrashLoopBackOff. The reverse pair (hashing on, nonce off) is a deployment with no Cloudflare bot product in front of it and is explicitly allowed. `configExtraToml` is appended verbatim and never parsed, so a release using it steps out of the validation rather than being rejected on a tree the chart cannot see.

## The obligation neither chart can enforce

`scriptNonce` makes the server send every document `Cache-Control: no-cache`. The other half is a deployment concern, now documented in both READMEs:

> No Cloudflare Cache Rule may cache the shell. A "Cache Everything" rule overrides the origin's `Cache-Control` and pins one nonce across every reader for the lifetime of the cache entry.

## Why minor, not patch

#392 and #393 propose `4.0.1` and `2.0.1`. These are new optional values, not a repin, so `4.1.0` and `2.1.0`. Defaults reproduce current behaviour — no action needed on upgrade.

## Verification

- `helm lint` clean on both charts
- `helm unittest`: 125 passed across 14 suites (10 new tests covering the defaults, each toggle, both legitimate hash/nonce pairs, the refused pair via values and via `config`, and the `configExtraToml` bypass)
- `values.schema.json` regenerated with the same command CI runs; snapshots regenerated and reviewed
- Rendered TOML checked for both charts

Closes #392. Closes #393.
