### PR TITLE
feat(tankovault): observe why a scan is slow

### DIFF
--- a/charts/tankovault/Chart.yaml
+++ b/charts/tankovault/Chart.yaml
@@ -1,6 +1,6 @@
 name: tankovault
 description: This chart deploys the full TankoVault manga aggregator stack — frontend, api, control-plane, worker, notifier, sync, challenge-solver and render — hardened to the restricted Pod Security Standard, with file-backed configuration that reloads in place instead of restarting pods, optional bundled PostgreSQL, Valkey, NATS JetStream and TRAWL, and optional Prometheus metrics, alerting rules and Grafana dashboards.
-version: 3.4.2
+version: 3.5.0
 appVersion: 3.7.0
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts

--- a/charts/tankovault/README.md
+++ b/charts/tankovault/README.md
@@ -1,6 +1,6 @@
 # tankovault
 
-![Version: 3.4.2](https://img.shields.io/badge/Version-3.4.2-informational?style=flat-square) ![AppVersion: 3.7.0](https://img.shields.io/badge/AppVersion-3.7.0-informational?style=flat-square)
+![Version: 3.5.0](https://img.shields.io/badge/Version-3.5.0-informational?style=flat-square) ![AppVersion: 3.7.0](https://img.shields.io/badge/AppVersion-3.7.0-informational?style=flat-square)
 
 This chart deploys the full TankoVault manga aggregator stack — frontend, api, control-plane, worker, notifier, sync, challenge-solver and render — hardened to the restricted Pod Security Standard, with file-backed configuration that reloads in place instead of restarting pods, optional bundled PostgreSQL, Valkey, NATS JetStream and TRAWL, and optional Prometheus metrics, alerting rules and Grafana dashboards.
 
@@ -545,6 +545,17 @@ modes are invisible everywhere else. A model that has stopped being built keeps 
 then empty, without a single error or a millisecond of added latency
 (`TankoVaultRecsysBuildFailing`); and an empty shelf is a `200` returned faster than a full one
 (`TankoVaultRecsysShelvesEmpty`). Neither moves the request-path metrics at all.
+
+The scan pipeline gets a section of its own for a different reason: `scan_task_duration_seconds`
+says a task took nine minutes and nothing about what for, which is the question an operator
+actually has. **Why a scan is slow** splits that wall clock two ways — the share spent waiting for
+*permission to send* (the concurrency gate, the token rate, the crawl delay and whatever adaptive
+penalty a 429 has earned), and, for the remainder, which stage of the task it went into. The two
+readings have opposite remedies, so each gets an alert. `TankoVaultScanPaceBound` means the
+crawler is being exactly as polite as it was configured to be, and only `politeness.rps` or
+`crawl_delay_ms` will change that; `TankoVaultScanIngestBound` means the time is in our own
+catalogue write, and the database is where to look. Both are `severity: info` — neither is an
+outage, and the value is the diagnosis rather than the page.
 
 Two alerts that a chart should not reinvent are deliberately absent, because the Prometheus
 Operator this chart already requires ships both: `KubeDeploymentReplicasMismatch` for replica

--- a/charts/tankovault/README.md.gotmpl
+++ b/charts/tankovault/README.md.gotmpl
@@ -548,6 +548,17 @@ then empty, without a single error or a millisecond of added latency
 (`TankoVaultRecsysBuildFailing`); and an empty shelf is a `200` returned faster than a full one
 (`TankoVaultRecsysShelvesEmpty`). Neither moves the request-path metrics at all.
 
+The scan pipeline gets a section of its own for a different reason: `scan_task_duration_seconds`
+says a task took nine minutes and nothing about what for, which is the question an operator
+actually has. **Why a scan is slow** splits that wall clock two ways — the share spent waiting for
+*permission to send* (the concurrency gate, the token rate, the crawl delay and whatever adaptive
+penalty a 429 has earned), and, for the remainder, which stage of the task it went into. The two
+readings have opposite remedies, so each gets an alert. `TankoVaultScanPaceBound` means the
+crawler is being exactly as polite as it was configured to be, and only `politeness.rps` or
+`crawl_delay_ms` will change that; `TankoVaultScanIngestBound` means the time is in our own
+catalogue write, and the database is where to look. Both are `severity: info` — neither is an
+outage, and the value is the diagnosis rather than the page.
+
 Two alerts that a chart should not reinvent are deliberately absent, because the Prometheus
 Operator this chart already requires ships both: `KubeDeploymentReplicasMismatch` for replica
 shortfalls (it reads kube-state-metrics, which knows the desired count; nothing this chart emits

--- a/charts/tankovault/UPGRADING.md
+++ b/charts/tankovault/UPGRADING.md
@@ -16,6 +16,29 @@ Some of them require a manual step that nothing will remind you about:
 The values contract is enforced by `values.schema.json`, so a key a new major removed or
 renamed fails the render with the offending path named, rather than being silently ignored.
 
+## 3.5.0
+
+**"Why is this scan slow" becomes a metric.** Nothing to do, and no values changed: the chart's
+rules and the scan-pipeline dashboard grow a section that reads three metrics app 3.7.0 already
+emits — `scan_stage_duration_seconds`, `scan_task_pace_wait_seconds` and
+`provider_pace_wait_seconds`. A release already on appVersion 3.7.0 starts populating the new
+panels on the next scrape; one on anything older sees them empty, exactly as the backlog row is
+empty without the NATS exporter.
+
+Five recording rules and two alerts come with it. Both alerts are `severity: info`, because
+neither is an outage — they are the two halves of a diagnosis that `scan_task_duration_seconds`
+alone could not make:
+
+| Alert | Says | Remedy |
+|---|---|---|
+| `TankoVaultScanPaceBound` | over 80% of a provider's task time is spent waiting for permission to send | raise `politeness.rps` or lower `crawl_delay_ms` for that provider, or accept the duration — no code change will help |
+| `TankoVaultScanIngestBound` | over half of a provider's stage time is `series_ingest`, and the crawl budget is not the reason | the database, not the provider; a newly added provider's first full scan is the benign case |
+
+If you route `severity: info` to a channel anyone reads, expect `TankoVaultScanPaceBound` to fire
+on any provider you have deliberately configured to be crawled slowly. That is the alert being
+correct rather than noisy, but it is a standing condition, not an event — silence it per provider
+rather than raising the threshold, which would only move the line.
+
 ## 3.4.0
 
 **Gateway API exposure and a Cilium policy engine.** Nothing to do: both are opt-in, both default

--- a/charts/tankovault/dashboards/tankovault-scan-pipeline.json
+++ b/charts/tankovault/dashboards/tankovault-scan-pipeline.json
@@ -1,7 +1,7 @@
 {
   "uid": "tankovault-scan-pipeline",
   "title": "TankoVault Scan Pipeline",
-  "description": "Everything between a scheduled scan and a user being told about a new chapter: scheduling, per-provider task throughput and backlog, outbound fetches and the throttling they earn, notification fan-out, AniList synchronisation, and the recommendation model built from the catalogue the rest of it fills. The backlog row needs `metrics.natsExporter.enabled` \u2014 NATS publishes no Prometheus exposition of its own, so those panels are empty rather than wrong without it.",
+  "description": "Everything between a scheduled scan and a user being told about a new chapter: scheduling, per-provider task throughput and backlog, where a slow run's wall clock actually went, outbound fetches and the throttling they earn, notification fan-out, AniList synchronisation, and the recommendation model built from the catalogue the rest of it fills. The backlog row needs `metrics.natsExporter.enabled` \u2014 NATS publishes no Prometheus exposition of its own, so those panels are empty rather than wrong without it.",
   "tags": [
     "tankovault"
   ],
@@ -643,6 +643,257 @@
       }
     },
     {
+      "id": 44,
+      "type": "row",
+      "title": "Why a scan is slow",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Share of task time by stage",
+      "description": "Where a scan task's wall clock goes, as each stage's share of all stage time for that provider. Time in a `*_fetch` stage is the provider's; `series_ingest` is our own write into the catalogue, and a rising ingest share is a database problem wearing a scan's clothes. Read this only once the pace-wait share to the right is low \u2014 on a politeness-bound provider these shares describe what little time was left over.",
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "namespace_provider_stage:scan_stage_duration_seconds:ratio_rate15m{namespace=\"$namespace\", provider=~\"$provider\"}",
+          "legendFormat": "{{provider}} \u2014 {{stage}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "last",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 30,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          },
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "id": 45,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 31
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Stage duration (p95)",
+      "description": "The same split in absolute terms: how long one task spends in one stage. The share panel says which stage dominates, this one says whether the stage itself got slower or simply ran more often.",
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "namespace_provider_stage:scan_stage_duration_seconds:p95_15m{namespace=\"$namespace\", provider=~\"$provider\"}",
+          "legendFormat": "{{provider}} \u2014 {{stage}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "last",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "min": 0
+        },
+        "overrides": []
+      },
+      "id": 46,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 31
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Pace-wait share of task time",
+      "description": "The first number to read on a slow scan: the share of a task spent waiting for *permission to send* \u2014 the concurrency gate, the token rate, the crawl delay and any adaptive 429 penalty. Near 1 the scan is polite, not broken, and nothing in the code will speed it up: raise `politeness.rps` or lower `crawl_delay_ms` for that provider, or accept the duration. Near 0 with a long task duration means the time is in the requests or in the ingest, and the stage panels say which.",
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "namespace_provider:scan_task_pace_wait:ratio_rate15m{namespace=\"$namespace\", provider=~\"$provider\"}",
+          "legendFormat": "{{provider}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "last",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "min": 0
+        },
+        "overrides": []
+      },
+      "id": 47,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 31
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Waiting for permission to send (p95)",
+      "description": "The same wait unscaled, at both layers that show it. `per task` is what one scan task accumulated across every request it made; `per request` is one request's wait, which climbs on its own when a provider starts answering 429/503 because the adaptive penalty widens that provider's spacing \u2014 a rise there with no configuration change is the throttle working rather than a fault.",
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "namespace_provider:scan_task_pace_wait_seconds:p95_15m{namespace=\"$namespace\", provider=~\"$provider\"}",
+          "legendFormat": "{{provider}} \u2014 per task"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "namespace_provider:provider_pace_wait_seconds:p95_15m{namespace=\"$namespace\", provider=~\"$provider\"}",
+          "legendFormat": "{{provider}} \u2014 per request"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "last",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "min": 0
+        },
+        "overrides": []
+      },
+      "id": 48,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 31
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      }
+    },
+    {
       "id": 13,
       "type": "row",
       "title": "Backlog (requires metrics.natsExporter)",
@@ -650,7 +901,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 39
       },
       "collapsed": false,
       "panels": []
@@ -704,7 +955,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 31
+        "y": 40
       },
       "datasource": {
         "type": "prometheus",
@@ -760,7 +1011,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 31
+        "y": 40
       },
       "datasource": {
         "type": "prometheus",
@@ -825,7 +1076,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 31
+        "y": 40
       },
       "datasource": {
         "type": "prometheus",
@@ -840,7 +1091,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 48
       },
       "collapsed": false,
       "panels": []
@@ -894,7 +1145,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 40
+        "y": 49
       },
       "datasource": {
         "type": "prometheus",
@@ -951,7 +1202,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 40
+        "y": 49
       },
       "datasource": {
         "type": "prometheus",
@@ -966,7 +1217,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 48
+        "y": 57
       },
       "collapsed": false,
       "panels": []
@@ -1020,7 +1271,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 49
+        "y": 58
       },
       "datasource": {
         "type": "prometheus",
@@ -1077,7 +1328,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 49
+        "y": 58
       },
       "datasource": {
         "type": "prometheus",
@@ -1133,7 +1384,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 49
+        "y": 58
       },
       "datasource": {
         "type": "prometheus",
@@ -1189,7 +1440,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 57
+        "y": 66
       },
       "datasource": {
         "type": "prometheus",
@@ -1245,7 +1496,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 57
+        "y": 66
       },
       "datasource": {
         "type": "prometheus",
@@ -1260,7 +1511,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 65
+        "y": 74
       },
       "collapsed": false,
       "panels": []
@@ -1313,7 +1564,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 66
+        "y": 75
       },
       "datasource": {
         "type": "prometheus",
@@ -1370,7 +1621,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 66
+        "y": 75
       },
       "datasource": {
         "type": "prometheus",
@@ -1426,7 +1677,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 66
+        "y": 75
       },
       "datasource": {
         "type": "prometheus",
@@ -1441,7 +1692,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 73
+        "y": 82
       },
       "collapsed": false,
       "panels": []
@@ -1496,7 +1747,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 74
+        "y": 83
       },
       "datasource": {
         "type": "prometheus",
@@ -1552,7 +1803,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 74
+        "y": 83
       },
       "datasource": {
         "type": "prometheus",
@@ -1617,7 +1868,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 74
+        "y": 83
       },
       "datasource": {
         "type": "prometheus",
@@ -1632,7 +1883,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 81
+        "y": 90
       },
       "collapsed": false,
       "panels": []
@@ -1686,7 +1937,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 82
+        "y": 91
       },
       "datasource": {
         "type": "prometheus",
@@ -1743,7 +1994,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 82
+        "y": 91
       },
       "datasource": {
         "type": "prometheus",
@@ -1799,7 +2050,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 82
+        "y": 91
       },
       "datasource": {
         "type": "prometheus",
@@ -1814,7 +2065,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 89
+        "y": 98
       },
       "collapsed": false,
       "panels": []
@@ -1874,7 +2125,7 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 90
+        "y": 99
       },
       "datasource": {
         "type": "prometheus",
@@ -1930,7 +2181,7 @@
         "h": 6,
         "w": 9,
         "x": 6,
-        "y": 90
+        "y": 99
       },
       "datasource": {
         "type": "prometheus",
@@ -1986,7 +2237,7 @@
         "h": 6,
         "w": 9,
         "x": 15,
-        "y": 90
+        "y": 99
       },
       "datasource": {
         "type": "prometheus",
@@ -2051,7 +2302,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 96
+        "y": 105
       },
       "datasource": {
         "type": "prometheus",
@@ -2107,7 +2358,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 96
+        "y": 105
       },
       "datasource": {
         "type": "prometheus",

--- a/charts/tankovault/rules-tests/scan_pipeline_test.yml
+++ b/charts/tankovault/rules-tests/scan_pipeline_test.yml
@@ -282,6 +282,142 @@ tests:
           - labels: 'ALERTS{alertname="TankoVaultChaptersAllRejected", alertstate="firing", namespace="tv", provider="redesigned", severity="info"}'
             value: 1
 
+  # Why a scan is slow, half one: a provider whose tasks are almost entirely spent waiting for
+  # permission to send. 54 seconds of pace-wait accrued per 60 seconds of task time is 0.9 — the
+  # crawler is being exactly as polite as it was configured to be, a state nothing else in this
+  # rule set can tell apart from a worker that has wedged. `brisk` is the control: same volume,
+  # same shape, a tenth of the wait, and it must stay silent.
+  - interval: 1m
+    input_series:
+      - series: 'scan_task_pace_wait_seconds_sum{namespace="tv", job="worker", pod="w-1", provider="polite"}'
+        values: '0+54x200'
+      - series: 'scan_task_duration_seconds_sum{namespace="tv", job="worker", pod="w-1", provider="polite", scan="full", kind="series"}'
+        values: '0+60x200'
+      - series: 'scan_tasks_served_total{namespace="tv", job="worker", pod="w-1", provider="polite", scan="full"}'
+        values: '0+1x200'
+      - series: 'scan_task_pace_wait_seconds_sum{namespace="tv", job="worker", pod="w-1", provider="brisk"}'
+        values: '0+6x200'
+      - series: 'scan_task_duration_seconds_sum{namespace="tv", job="worker", pod="w-1", provider="brisk", scan="full", kind="series"}'
+        values: '0+60x200'
+      - series: 'scan_tasks_served_total{namespace="tv", job="worker", pod="w-1", provider="brisk", scan="full"}'
+        values: '0+1x200'
+    promql_expr_test:
+      - expr: namespace_provider:scan_task_pace_wait:ratio_rate15m
+        eval_time: 60m
+        exp_samples:
+          - labels: 'namespace_provider:scan_task_pace_wait:ratio_rate15m{namespace="tv", provider="brisk"}'
+            value: 0.1
+          - labels: 'namespace_provider:scan_task_pace_wait:ratio_rate15m{namespace="tv", provider="polite"}'
+            value: 0.9
+      - expr: ALERTS{alertname="TankoVaultScanPaceBound", alertstate="firing"}
+        eval_time: 130m
+        exp_samples:
+          - labels: 'ALERTS{alertname="TankoVaultScanPaceBound", alertstate="firing", namespace="tv", provider="polite", severity="info"}'
+            value: 1
+
+  # Why a scan is slow, half two: the wait is not the crawl budget and the fetches are not the
+  # cost — 70% of the stage time is `series_ingest`, which is our own write into the catalogue and
+  # therefore a database problem wearing a scan's clothes.
+  - interval: 1m
+    input_series:
+      - series: 'scan_stage_duration_seconds_sum{namespace="tv", job="worker", pod="w-1", provider="slowdb", kind="series", stage="series_ingest"}'
+        values: '0+42x200'
+      - series: 'scan_stage_duration_seconds_sum{namespace="tv", job="worker", pod="w-1", provider="slowdb", kind="series", stage="series_chapters"}'
+        values: '0+18x200'
+      - series: 'scan_task_pace_wait_seconds_sum{namespace="tv", job="worker", pod="w-1", provider="slowdb"}'
+        values: '0+6x200'
+      - series: 'scan_task_duration_seconds_sum{namespace="tv", job="worker", pod="w-1", provider="slowdb", scan="full", kind="series"}'
+        values: '0+60x200'
+      - series: 'scan_tasks_served_total{namespace="tv", job="worker", pod="w-1", provider="slowdb", scan="full"}'
+        values: '0+1x200'
+    promql_expr_test:
+      # `kind` is dropped by the rule, so the two stages of one task kind arrive as two series and
+      # not as four. The shares sum to 1 by construction, which is what makes the threshold on the
+      # ingest share readable without knowing the fleet size.
+      - expr: namespace_provider_stage:scan_stage_duration_seconds:ratio_rate15m
+        eval_time: 60m
+        exp_samples:
+          - labels: 'namespace_provider_stage:scan_stage_duration_seconds:ratio_rate15m{namespace="tv", provider="slowdb", stage="series_chapters"}'
+            value: 0.3
+          - labels: 'namespace_provider_stage:scan_stage_duration_seconds:ratio_rate15m{namespace="tv", provider="slowdb", stage="series_ingest"}'
+            value: 0.7
+      - expr: ALERTS{alertname="TankoVaultScanIngestBound", alertstate="firing"}
+        eval_time: 130m
+        exp_samples:
+          - labels: 'ALERTS{alertname="TankoVaultScanIngestBound", alertstate="firing", namespace="tv", provider="slowdb", stage="series_ingest", severity="info"}'
+            value: 1
+      - expr: ALERTS{alertname="TankoVaultScanPaceBound"}
+        eval_time: 130m
+        exp_samples: []
+
+  # The gate between the two, and the reason the ingest alert carries a pace-wait conjunct at all.
+  # This provider's ingest share is the same 0.7 that fired above, but 90% of its task time went
+  # on waiting for permission to send — so the stage shares describe only what little was left
+  # over. The correct diagnosis is politeness, and the two remedies are opposites: raise this
+  # provider's request rate, do not go looking at the database.
+  - interval: 1m
+    input_series:
+      - series: 'scan_stage_duration_seconds_sum{namespace="tv", job="worker", pod="w-1", provider="polite", kind="series", stage="series_ingest"}'
+        values: '0+42x200'
+      - series: 'scan_stage_duration_seconds_sum{namespace="tv", job="worker", pod="w-1", provider="polite", kind="series", stage="series_chapters"}'
+        values: '0+18x200'
+      - series: 'scan_task_pace_wait_seconds_sum{namespace="tv", job="worker", pod="w-1", provider="polite"}'
+        values: '0+54x200'
+      - series: 'scan_task_duration_seconds_sum{namespace="tv", job="worker", pod="w-1", provider="polite", scan="full", kind="series"}'
+        values: '0+60x200'
+      - series: 'scan_tasks_served_total{namespace="tv", job="worker", pod="w-1", provider="polite", scan="full"}'
+        values: '0+1x200'
+    promql_expr_test:
+      - expr: ALERTS{alertname="TankoVaultScanIngestBound"}
+        eval_time: 130m
+        exp_samples: []
+      - expr: ALERTS{alertname="TankoVaultScanPaceBound", alertstate="firing"}
+        eval_time: 130m
+        exp_samples:
+          - labels: 'ALERTS{alertname="TankoVaultScanPaceBound", alertstate="firing", namespace="tv", provider="polite", severity="info"}'
+            value: 1
+
+  # The three bucket-based rules behind the "why a scan is slow" panels. Nothing alerts on them,
+  # which is exactly why they need a test: a quantile rule that names a bucket series wrongly
+  # records nothing, and the only symptom is an empty Grafana panel. Every observation sits in one
+  # bucket per histogram so the interpolated quantile is deterministic.
+  - interval: 1m
+    input_series:
+      - series: 'provider_pace_wait_seconds_bucket{namespace="tv", job="worker", pod="w-1", provider="p", le="0.5"}'
+        values: '0x60'
+      - series: 'provider_pace_wait_seconds_bucket{namespace="tv", job="worker", pod="w-1", provider="p", le="1"}'
+        values: '0+6x60'
+      - series: 'provider_pace_wait_seconds_bucket{namespace="tv", job="worker", pod="w-1", provider="p", le="+Inf"}'
+        values: '0+6x60'
+      - series: 'scan_task_pace_wait_seconds_bucket{namespace="tv", job="worker", pod="w-1", provider="p", le="5"}'
+        values: '0x60'
+      - series: 'scan_task_pace_wait_seconds_bucket{namespace="tv", job="worker", pod="w-1", provider="p", le="15"}'
+        values: '0+2x60'
+      - series: 'scan_task_pace_wait_seconds_bucket{namespace="tv", job="worker", pod="w-1", provider="p", le="+Inf"}'
+        values: '0+2x60'
+      - series: 'scan_stage_duration_seconds_bucket{namespace="tv", job="worker", pod="w-1", provider="p", kind="series", stage="series_ingest", le="1"}'
+        values: '0x60'
+      - series: 'scan_stage_duration_seconds_bucket{namespace="tv", job="worker", pod="w-1", provider="p", kind="series", stage="series_ingest", le="5"}'
+        values: '0+2x60'
+      - series: 'scan_stage_duration_seconds_bucket{namespace="tv", job="worker", pod="w-1", provider="p", kind="series", stage="series_ingest", le="+Inf"}'
+        values: '0+2x60'
+    promql_expr_test:
+      - expr: namespace_provider:provider_pace_wait_seconds:p95_15m
+        eval_time: 30m
+        exp_samples:
+          - labels: 'namespace_provider:provider_pace_wait_seconds:p95_15m{namespace="tv", provider="p"}'
+            value: 0.975
+      - expr: namespace_provider:scan_task_pace_wait_seconds:p95_15m
+        eval_time: 30m
+        exp_samples:
+          - labels: 'namespace_provider:scan_task_pace_wait_seconds:p95_15m{namespace="tv", provider="p"}'
+            value: 14.499999999999998
+      - expr: namespace_provider_stage:scan_stage_duration_seconds:p95_15m
+        eval_time: 30m
+        exp_samples:
+          - labels: 'namespace_provider_stage:scan_stage_duration_seconds:p95_15m{namespace="tv", provider="p", stage="series_ingest"}'
+            value: 4.799999999999999
+
   # Worker task concurrency, averaged across replicas rather than summed. Two workers pinned at
   # the default cap of 4 must record 4, not 8: the cap is per replica, so a sum would grow with
   # the fleet and could never be read against it. A third replica sitting idle pulls the average

--- a/charts/tankovault/rules/tankovault-alerts.rules.yml
+++ b/charts/tankovault/rules/tankovault-alerts.rules.yml
@@ -457,6 +457,71 @@ groups:
             adapter, some tasks failing points at particular series — often ones whose pages have
             been removed.
 
+      # Neither an outage nor a defect: the scan is being crawled exactly as fast as this
+      # provider's configured budget allows. It earns an alert anyway, because it is the one cause
+      # of a slow scan that no code change fixes, and because its only other visible symptom —
+      # runs that take hours — is indistinguishable from a worker that has wedged.
+      #
+      # grounding: baseline-needed — upstream frames the ratio as "near 1 means polite, not
+      # broken" without naming a number, and 0.8 is simply where a task is more waiting than work
+      # on any reading. The `increase1h > 20` floor keeps a provider that ran three tasks in an
+      # hour from tripping this on one unlucky one.
+      - alert: TankoVaultScanPaceBound
+        expr: >-
+          namespace_provider:scan_task_pace_wait:ratio_rate15m{tankovault_scope=~".*"} > 0.8
+            and namespace_provider:scan_tasks_served:increase1h{tankovault_scope=~".*"} > 20
+        for: 1h
+        labels:
+          severity: info
+        annotations:
+          summary: "{{ $labels.provider }} scans spend {{ $value | humanizePercentage }} of their time waiting for permission to send"
+          description: >-
+            Scans for this provider are polite, not broken. Most of each task's wall clock is the
+            concurrency gate, the token rate, the crawl delay and any adaptive 429 penalty — not
+            the provider answering slowly, and not our own ingest. The tasks complete, so nothing
+            else here fires; they simply take proportionally longer, and a full run can start
+            overlapping its own schedule. Either raise `politeness.rps` or lower `crawl_delay_ms`
+            for {{ $labels.provider }} in the console, accepting the extra load on the source, or
+            accept the duration. Check `TankoVaultProviderThrottlingHeavily` for the same provider
+            first: if it is firing, the wait is an earned 429 penalty rather than the configured
+            budget, and the fix is then to ask for *less* rather than more.
+
+      # The opposite diagnosis, and the one that is a genuine problem: the time is neither the
+      # provider's nor the crawl budget's, it is our own catalogue write. Gated on the pace-wait
+      # share being low, because on a politeness-bound provider the stage shares describe what
+      # little time was left over and mean nothing.
+      #
+      # grounding: baseline-needed — 0.5 and 0.25 are judgement about where ingest stops being a
+      # share of the work and starts being the work. A provider's *first* full scan legitimately
+      # looks like this, since every series is new and every chapter an insert, which is what the
+      # 1h fuse and the runbook's discovery check are for.
+      - alert: TankoVaultScanIngestBound
+        expr: >-
+          namespace_provider_stage:scan_stage_duration_seconds:ratio_rate15m{tankovault_scope=~".*",
+                                                                             stage="series_ingest"}
+            > 0.5
+            and on (namespace, provider)
+              namespace_provider:scan_task_pace_wait:ratio_rate15m{tankovault_scope=~".*"} < 0.25
+            and on (namespace, provider)
+              namespace_provider:scan_tasks_served:increase1h{tankovault_scope=~".*"} > 20
+        for: 1h
+        labels:
+          severity: info
+        annotations:
+          summary: "{{ $labels.provider }} scans spend {{ $value | humanizePercentage }} of their stage time writing to the catalogue"
+          description: >-
+            A scan that is slow because of us rather than because of the provider: over half of
+            this provider's stage time is `series_ingest` — writing one series' metadata and
+            chapters into the catalogue — and the pace-wait share is low enough to rule out the
+            crawl budget. Check `TankoVaultDatabasePoolSaturated` for the worker first, since an
+            ingest queueing for a connection reads exactly like this, then `pg_stat_activity` for
+            a slow upsert, which after a migration usually means an index that was not rebuilt.
+            One benign cause to exclude before digging: a provider's first full scan inserts every
+            series and every chapter it finds rather than diffing against what is already stored,
+            so a newly added provider is legitimately ingest-bound until its catalogue exists —
+            `namespace_provider:chapters_discovered:increase1h` still climbing steeply means a
+            backfill, flat means the writes are slow rather than merely numerous.
+
       # Exactly one control-plane replica should hold the lease.
       - alert: TankoVaultNoSchedulerLeader
         expr: namespace:scheduler_leader:sum{tankovault_scope=~".*"} == 0

--- a/charts/tankovault/rules/tankovault-recording.rules.yml
+++ b/charts/tankovault/rules/tankovault-recording.rules.yml
@@ -184,9 +184,9 @@ groups:
             db_pool_connections{tankovault_scope=~".*", state="in_use"})
             / sum by (namespace, job) (db_pool_max_connections{tankovault_scope=~".*"})
 
-  # The crawler's view of the sites it fetches from. All of this is emitted by `worker`; the
-  # `provider` label is the adapter slug, so these sit alongside the scan-pipeline series below
-  # and can be read on the same axis.
+  # The crawler's view of the sites it fetches from. All of this is emitted by `worker` except
+  # `provider_pace_wait_seconds`, which `sync` emits too; the `provider` label is the adapter slug,
+  # so these sit alongside the scan-pipeline series below and can be read on the same axis.
   - name: tankovault-provider-recording
     interval: 30s
     rules:
@@ -227,6 +227,25 @@ groups:
         expr: >-
           sum by (namespace, provider) (
             rate(provider_backoff_wait_seconds_sum{tankovault_scope=~".*"}[15m]))
+
+      # How long one request waited for *permission to send* — the concurrency gate, the token
+      # rate, the crawl delay, and whichever adaptive penalty this provider's recent 429s have
+      # earned — before the fetch itself began. Distinct from the backoff series above, which
+      # counts only the penalty: this is the whole budget, so a provider that is never throttled
+      # still records a wait here whenever its configured rate is the binding constraint.
+      #
+      # It climbs on its own when a provider starts answering 429/503, because the adaptive
+      # penalty widens that provider's spacing — a rise here with no configuration change is the
+      # throttle working rather than a fault.
+      #
+      # `job` is dropped, as everywhere else in this group. `sync` emits this metric too, for its
+      # own AniList traffic, and that lands in its own `provider` series rather than summing into
+      # a crawler's.
+      - record: namespace_provider:provider_pace_wait_seconds:p95_15m
+        expr: >-
+          histogram_quantile(0.95,
+            sum by (namespace, provider, le) (
+              rate(provider_pace_wait_seconds_bucket{tankovault_scope=~".*"}[15m])))
 
   # scan_tasks_served_total{provider,scan} counts tasks handed out, so a redelivered task counts
   # again — see the retry caveat in upstream's docs/OBSERVABILITY.md. `scan_tasks_settled_total`
@@ -269,6 +288,59 @@ groups:
           histogram_quantile(0.95,
             sum by (namespace, scan, le) (
               rate(scan_task_duration_seconds_bucket{tankovault_scope=~".*"}[15m])))
+
+      # Why a scan is slow, rather than that it is. The duration above says a task took nine
+      # minutes and nothing about what for, which is the question an operator actually has; the
+      # four rules that follow split that wall clock the two ways it can be acted on (upstream
+      # docs/OBSERVABILITY.md, "Why a scan is slow").
+      #
+      # This is the one to read first: the share of a task spent waiting for *permission to send*
+      # — the concurrency gate, the token rate, the crawl delay and any adaptive 429 penalty.
+      # Near 1 the scan is polite, not broken, and nothing in the code will make it faster; near 0
+      # with a long duration the time is in the requests themselves or in the ingest, and the
+      # stage split below says which.
+      #
+      # Both sides are `_sum` rates over the same window rather than quantiles, because a ratio of
+      # two p95s is not the p95 of the ratio. Seconds of wait accrued per second of task time is a
+      # real quantity, and it is the figure upstream's runbook names.
+      - record: namespace_provider:scan_task_pace_wait:ratio_rate15m
+        expr: >-
+          sum by (namespace, provider) (
+            rate(scan_task_pace_wait_seconds_sum{tankovault_scope=~".*"}[15m]))
+            / sum by (namespace, provider) (
+                rate(scan_task_duration_seconds_sum{tankovault_scope=~".*"}[15m]))
+
+      - record: namespace_provider:scan_task_pace_wait_seconds:p95_15m
+        expr: >-
+          histogram_quantile(0.95,
+            sum by (namespace, provider, le) (
+              rate(scan_task_pace_wait_seconds_bucket{tankovault_scope=~".*"}[15m])))
+
+      # Where the rest of the time goes, as each stage's share of all stage time for that
+      # provider. A share rather than the raw duty cycle because the number has to be readable
+      # without knowing how many tasks ran concurrently: `series_ingest` at 0.6 is three fifths of
+      # the work spent on our own catalogue write whatever the fleet size, while 0.6 seconds of
+      # ingest per second means nothing until you know how many worker slots were open.
+      #
+      # `on (namespace, provider) group_left ()` is the many-to-one join the division needs. The
+      # numerator carries `stage` and the denominator cannot; without it Prometheus matches on
+      # identical label sets, finds none, and the rule records nothing at all.
+      - record: namespace_provider_stage:scan_stage_duration_seconds:ratio_rate15m
+        expr: >-
+          sum by (namespace, provider, stage) (
+            rate(scan_stage_duration_seconds_sum{tankovault_scope=~".*"}[15m]))
+            / on (namespace, provider) group_left ()
+              sum by (namespace, provider) (
+                rate(scan_stage_duration_seconds_sum{tankovault_scope=~".*"}[15m]))
+
+      # The absolute companion: how long one task spent in one stage. Time in a `*_fetch` stage is
+      # the provider's, time in `series_ingest` is ours, and which of the two is growing is the
+      # difference between a source that has stopped answering and a database that has.
+      - record: namespace_provider_stage:scan_stage_duration_seconds:p95_15m
+        expr: >-
+          histogram_quantile(0.95,
+            sum by (namespace, provider, stage, le) (
+              rate(scan_stage_duration_seconds_bucket{tankovault_scope=~".*"}[15m])))
 
       - record: namespace_provider:chapters_discovered:increase1h
         expr: >-


### PR DESCRIPTION
Syncs the chart's observability surface with [TankoVault `ecda051`](https://github.com/TimSchoenle/TankoVault/commit/ecda0514eb5b5d5a651060caf69db0d6cab06595) (upstream #172), which shipped in **v3.7.0** — the appVersion this chart already pins. The bump PR carried the digests and none of this.

Three new metrics, read by nothing until now:

| Metric | Labels | Emitted by |
|---|---|---|
| `scan_stage_duration_seconds` | `provider`, `kind`, `stage` | `worker` |
| `scan_task_pace_wait_seconds` | `provider` | `worker` |
| `provider_pace_wait_seconds` | `provider` | `worker`, `sync` |

`scan_task_duration_seconds` says a task took nine minutes and nothing about what for, which is the question an operator actually has.

## Recording rules

Five, splitting a task's wall clock the two ways it can be acted on:

- `namespace_provider:scan_task_pace_wait:ratio_rate15m` — the share spent waiting for *permission to send* (concurrency gate, token rate, crawl delay, adaptive 429 penalty). Read first. Both sides are `_sum` rates over the same window, not a ratio of two p95s.
- `namespace_provider:scan_task_pace_wait_seconds:p95_15m`
- `namespace_provider_stage:scan_stage_duration_seconds:ratio_rate15m` — each stage's share of that provider's stage time. Needs `on (namespace, provider) group_left ()`; without the join Prometheus matches on identical label sets, finds none, and records nothing.
- `namespace_provider_stage:scan_stage_duration_seconds:p95_15m`
- `namespace_provider:provider_pace_wait_seconds:p95_15m` — the same wait per request rather than per task; climbs on its own when a provider answers 429/503.

## Alerts

Both `severity: info` — neither is an outage, and the value is the diagnosis rather than the page.

| Alert | Fires on | Remedy |
|---|---|---|
| `TankoVaultScanPaceBound` | pace-wait > 80% of task time, sustained 1h, past a 20-task/h floor | raise `politeness.rps` or lower `crawl_delay_ms` for that provider, or accept the duration — no code change helps |
| `TankoVaultScanIngestBound` | `series_ingest` > 50% of stage time **and** pace-wait < 25% | the database, not the provider |

The pace-wait conjunct on the second is load-bearing: on a politeness-bound provider the stage shares describe only the time left over, and the two diagnoses have opposite remedies. Both thresholds are marked `grounding: baseline-needed` — upstream frames the ratio as "near 1 means polite, not broken" without naming a number.

## Dashboard

A **Why a scan is slow** row on the scan-pipeline dashboard: stage share (stacked), stage p95, pace-wait share, and the per-task/per-request wait side by side. Existing rows shift down by 9.

## Tests

Four new promtool cases in `scan_pipeline_test.yml`: each alert firing, the gate between them (same 0.7 ingest share, 0.9 pace-wait — only `ScanPaceBound` may fire), and the three quantile rules nothing alerts on, since a mis-named bucket series records nothing and surfaces only as an empty Grafana panel.

Gates run locally, all green: `test-rules.sh` (audit + promtool, committed and rendered forms), `helm unittest` (157), `check-immutable-fields.py`, `validate-manifests.sh` against 1.34.0.

## Notes

- Chart `3.4.2` → `3.5.0`. **No values changed**, so no schema churn; `appVersion` stays at `3.7.0` because this commit is already in it.
- A release on an older appVersion sees empty panels rather than wrong ones, exactly as the backlog row does without the NATS exporter.
- The README version badge and table are helm-docs output; expect the maintenance bot to rewrite them on this branch.
