### PR TITLE
fix(paperless-ngx): give Gotenberg's Chromium a writable home

### DIFF
--- a/charts/paperless-ngx/Chart.yaml
+++ b/charts/paperless-ngx/Chart.yaml
@@ -1,6 +1,6 @@
 name: paperless-ngx
 description: This chart deploys paperless-ngx — a document management system that scans, indexes and archives your paper documents — hardened to the restricted Pod Security Standard, with per-directory persistence, scheduled document_exporter backups and document_importer restores, optional bundled Valkey, PostgreSQL, Gotenberg and Tika, Ingress and Gateway API publishing, Grafana dashboards and Prometheus alerting rules.
-version: 2.0.0
+version: 2.0.1
 appVersion: 3.0.5
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts

--- a/charts/paperless-ngx/README.md
+++ b/charts/paperless-ngx/README.md
@@ -1,6 +1,6 @@
 # paperless-ngx
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![AppVersion: 3.0.5](https://img.shields.io/badge/AppVersion-3.0.5-informational?style=flat-square)
+![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![AppVersion: 3.0.5](https://img.shields.io/badge/AppVersion-3.0.5-informational?style=flat-square)
 
 This chart deploys paperless-ngx — a document management system that scans, indexes and archives your paper documents — hardened to the restricted Pod Security Standard, with per-directory persistence, scheduled document_exporter backups and document_importer restores, optional bundled Valkey, PostgreSQL, Gotenberg and Tika, Ingress and Gateway API publishing, Grafana dashboards and Prometheus alerting rules.
 

--- a/charts/paperless-ngx/templates/gotenberg.yaml
+++ b/charts/paperless-ngx/templates/gotenberg.yaml
@@ -3,7 +3,19 @@
 {{- /*
   Gotenberg renders office documents and e-mail to PDF with LibreOffice and Chromium. Both write
   their working files under /tmp, which the library already provisions as an emptyDir for a
-  read-only root filesystem, so nothing else has to be writable.
+  read-only root filesystem.
+
+  Chromium needs a second writable path, and it is not obvious from its logs which. Before it
+  opens a page it creates a crash-reporter database under $HOME/.config/chromium; on a read-only
+  root filesystem that fails, the crashpad handler is started without a --database, exits, and
+  takes the browser down with it. Every /forms/chromium/... request then answers 500 with
+  "chrome_crashpad_handler: --database is required" while the LibreOffice routes keep working -
+  Gotenberg gives those a temporary UserInstallation of their own - so a release looks healthy
+  and archives e-mail as nothing. The emptyDir on the image's home directory is what that costs.
+
+  HOME is set beside it rather than left to the image, which declares none: its value would
+  otherwise depend on the container runtime resolving UID 1001 in /etc/passwd, which is not
+  something to rely on when the failure it produces is this quiet.
 
   The two Chromium flags are the reason this is worth configuring rather than running stock. An
   `.eml` file is untrusted input, and a headless browser that executes its JavaScript and follows
@@ -20,6 +32,8 @@
       "livenessProbe" (merge (dict "periodSeconds" 30 "timeoutSeconds" 10 "failureThreshold" 5) (deepCopy $probe))
       "readinessProbe" (merge (dict "periodSeconds" 15 "timeoutSeconds" 5 "failureThreshold" 3) (deepCopy $probe))
     ) | fromYaml }}
+{{- /* The image's WORKDIR: where Chromium and fontconfig write, and what HOME points at. */}}
+{{- $homeDir := "/home/gotenberg" }}
 {{- $args := list "gotenberg" }}
 {{- if $gotenberg.disableJavaScript }}
 {{- $args = append $args "--chromium-disable-javascript=true" }}
@@ -57,8 +71,10 @@ spec:
               "command" (list "/usr/bin/tini" "--")
               "args" $args
               "ports" (list (dict "name" "gotenberg" "containerPort" 3000 "protocol" "TCP"))
+              "env" (list (dict "name" "HOME" "value" $homeDir))
+              "volumeMounts" (list (dict "name" "home" "mountPath" $homeDir))
             ) | nindent 8 }}
-      {{- with (include "common.volumes" (dict "ctx" $ctx)) }}
+      {{- with (include "common.volumes" (dict "ctx" $ctx "volumes" (list (dict "name" "home" "emptyDir" (dict))))) }}
       volumes:
         {{- . | nindent 8 }}
       {{- end }}

--- a/charts/paperless-ngx/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/paperless-ngx/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2571,6 +2571,9 @@ matches the committed snapshot for the full stack behind an Ingress:
               command:
                 - /usr/bin/tini
                 - --
+              env:
+                - name: HOME
+                  value: /home/gotenberg
               image: gotenberg/gotenberg:v0.0.0@sha256:4444444444444444444444444444444444444444444444444444444444444444
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -2609,6 +2612,8 @@ matches the committed snapshot for the full stack behind an Ingress:
               volumeMounts:
                 - mountPath: /tmp
                   name: tmp
+                - mountPath: /home/gotenberg
+                  name: home
           securityContext:
             fsGroup: 1001
             fsGroupChangePolicy: OnRootMismatch
@@ -2621,6 +2626,8 @@ matches the committed snapshot for the full stack behind an Ingress:
           volumes:
             - emptyDir: {}
               name: tmp
+            - emptyDir: {}
+              name: home
   6: |
     apiVersion: networking.k8s.io/v1
     kind: Ingress

--- a/charts/paperless-ngx/tests/components_test.yaml
+++ b/charts/paperless-ngx/tests/components_test.yaml
@@ -181,6 +181,32 @@ tests:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
           value: /health
 
+  # Chromium creates its crash-reporter database under $HOME before it opens a page, and a
+  # read-only root filesystem leaves it nowhere to put it: the crashpad handler is then started
+  # without a --database, exits, and takes the browser with it. The LibreOffice routes keep
+  # working throughout, so the release looks healthy and archives e-mail as nothing.
+  - it: gives Chromium a writable home, which it needs before it renders anything
+    set:
+      tika.enabled: true
+    template: gotenberg.yaml
+    documentIndex: 1
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HOME
+            value: /home/gotenberg
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: home
+            mountPath: /home/gotenberg
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: home
+            emptyDir: {}
+
   - it: probes Tika on the endpoint that proves it finished starting
     set:
       tika.enabled: true


### PR DESCRIPTION
## What

Gotenberg's Chromium cannot start under this chart's hardening, so every Chromium conversion fails with HTTP 500:

```
convert HTML to PDF: convert to PDF: process first start: start process: run exec allocator:
chrome failed to start:
chrome_crashpad_handler: --database is required
```

Chromium creates its crash-reporter database under `$HOME/.config/chromium` before it opens a page. The component runs `readOnlyRootFilesystem: true` with only `/tmp` writable, so that write fails, the crashpad handler is started without a `--database`, exits, and takes the browser with it.

The LibreOffice routes are unaffected — Gotenberg points those at a temporary `UserInstallation` of their own — so office documents keep converting while e-mail is archived as nothing, and the pod stays Ready throughout. Nothing in the chart's output shows the problem; it only appears in Gotenberg's own logs.

## Change

- `templates/gotenberg.yaml`: an `emptyDir` mounted at `/home/gotenberg`, plus `HOME=/home/gotenberg` set explicitly. The image declares no `HOME`, so its value would otherwise depend on the container runtime resolving UID 1001 in `/etc/passwd` — not something to rely on when the failure it produces is this quiet.
- `tests/components_test.yaml`: asserts the env var, the mount and the volume.
- Snapshot updated; chart bumped to 2.0.1.

The security posture is unchanged: the volume is an `emptyDir`, the root filesystem stays read-only, capabilities stay dropped, and the Chromium flags (`--chromium-disable-javascript`, the allow list) are untouched.

## Verification

Against `gotenberg/gotenberg:8.36.0` (the digest this chart pins), run under the constraints the chart renders — read-only root filesystem, tmpfs on `/tmp`, UID 1001, all capabilities dropped:

| container | `/forms/chromium/convert/html` | `/forms/libreoffice/convert` |
| --- | --- | --- |
| as rendered today | **500**, the log line above | 200 |
| writable root filesystem (control) | 200 | 200 |
| **with this change** | **200** | 200 |

`docker diff` on a successful run confirms the only writes outside `/tmp` are `/home/gotenberg/.config/chromium/Crash Reports`, `/home/gotenberg/.config/pdfcpu` and `/home/gotenberg/.cache/fontconfig`.

Gates run locally: `just test-unit paperless-ngx`, `just validate-manifests`, `just check-immutable`, `just lint-policy`, `just check-config`. The two pre-existing failures in `restore_test.yaml` and one snapshot in `snapshot_test.yaml` are a CRLF artifact of a Windows working tree, present on `main` unchanged, and are not touched by this branch.

## Follow-up

No test in this repository actually starts Gotenberg, which is why this shipped. Extending `.github/scripts/e2e/paperless-ngx.sh` with one Chromium conversion against the running container would catch the class of failure that a rendered-manifest assertion cannot.
