### PR TITLE
docs(contracts): stop citing tankovault as the union's live example

### DIFF
--- a/.github/scripts/check-config.py
+++ b/.github/scripts/check-config.py
@@ -21,12 +21,18 @@ next to it, one concern per module, so each piece is testable by calling it:
   config_coverage.py         the chart-level check that nothing opted out by forgetting
   config_report.py           collecting findings and rendering them
 
-**The scopes of the gates differ, and the difference is the point.** Gate 1 validates a file
-every binary reads, so it runs against the union of their contracts — a key belonging to one
-would otherwise be "unknown" to the schema of another, and a correct deployment rejected. Gates 2
-and 3 are about one container, which runs exactly one image, so they run against that image's own
-contract. A variable set on a sidecar that only the main image reads passes against the union and
-is exactly the defect gate 2 exists to catch.
+**The scopes of the gates differ, and the difference is the point.** Gate 1 validates a document,
+which the format lets any number of images read, so it runs against the union of their contracts:
+a key belonging to one would otherwise be "unknown" to the schema of another, and a correct
+deployment rejected. Gates 2 and 3 are about one container, which runs exactly one image, so they
+run against that image's own contract. A variable set on a sidecar that only the main image reads
+passes against the union and is exactly the defect gate 2 exists to catch.
+
+Every document declared in this repository binds exactly one image today — `tankovault` is nine
+services with nine per-component documents, and every other chart is a single binary — so that
+union is currently the identity and the two scopes coincide in practice. They are still not the
+same question: gate 1 asks what a file may contain, gates 2 and 3 what one process may be handed,
+and a document that gained a second reader would have to re-derive the distinction.
 
 Which contract belongs to which container is derived, not declared: every declared image resolves
 to a digest, every rendered container names one, and the two are matched. A hand-written mapping

--- a/.github/scripts/config_contract.py
+++ b/.github/scripts/config_contract.py
@@ -9,7 +9,7 @@ attached to the image digest as an OCI referrer and embedded in the image; this 
 vendors a copy per chart under `charts/<chart>/contracts/`.
 
 This module is the half of the pipeline worth testing without a registry, a cluster or a render:
-parsing the envelope, unioning the contracts of several images that read one document, and
+parsing the envelope, merging the contracts of every image that reads one document, and
 classifying a single environment variable. `check-config.py` supplies the manifests and the
 reporting; `refresh-contracts.py` supplies the network.
 
@@ -261,11 +261,15 @@ def check_envelope(contract: dict[str, Any], origin: str) -> None:
 class Union:
     """The contracts of every image that reads one document, merged into one description.
 
-    `tankovault` renders a single `config.toml` read by eight separate binaries under one prefix.
-    Each binary's contract covers only the keys it consumes, so validating that document against
-    one binary's schema with `additionalProperties: false` would reject a perfectly correct
-    deployment: every key belonging to the other seven would be "unknown". The object to validate
-    against is the union.
+    A document several binaries read is the case the format is built for. Each binary's contract
+    covers only the keys it consumes, so validating that document against one of them with
+    `additionalProperties: false` would reject a perfectly correct deployment: every key belonging
+    to the others would be "unknown". The object to validate against is the union.
+
+    No chart here declares such a document. `tankovault` is nine services, and each has its own
+    per-component ConfigMap and its own single contract; every other chart is one binary. So the
+    union is the identity everywhere in this repository, and what this type earns today is the
+    shape a second reader can be added to without a gate changing — not anything it merges.
     """
 
     sources: list[str] = field(default_factory=list)
@@ -432,9 +436,9 @@ def _merge_schema(
     """Structurally merge two JSON Schema subtrees, closing every object as it goes.
 
     The first contract merged is merged into nothing, and takes the same path as every one after
-    it rather than being copied wholesale: a document read by a single image must come out just
-    as closed as one read by eight, or a producer that left a level open would leave the gate
-    open there too.
+    it rather than being copied wholesale: a document read by a single image — which every one
+    declared here is — must come out just as closed as one read by several, or a producer that
+    left a level open would leave the gate open there too.
     """
     merged = dict(into or {})
     for keyword, value in other.items():

--- a/.github/scripts/config_gate_document.py
+++ b/.github/scripts/config_gate_document.py
@@ -7,10 +7,12 @@ a wrong type, a missing required key, a value outside an enum, and a table where
 — the whole class of defect that renders cleanly, passes `values.schema.json`, passes kubeconform
 and then boots on a compiled default nobody chose.
 
-The union, not one image's contract: `tankovault` renders one `config.toml` read by eight
-binaries, each of whose contracts covers only the keys it consumes, so validating against one
-with `additionalProperties: false` would call the other seven binaries' keys unknown. Gates 2 and
-3 are the opposite case and live in `config_gate_container.py`.
+The union, not one image's contract, because a document may be read by several binaries: each of
+their contracts covers only the keys its own binary consumes, so validating against one with
+`additionalProperties: false` would call every other binary's keys unknown. No chart declares
+such a document — every one binds a single image, `tankovault` included, which renders one
+document per component — so the union is the identity here for now. Gates 2 and 3 are the
+opposite case and live in `config_gate_container.py`.
 
 Pure JSON Schema is delegated to a pinned binary rather than reimplemented. `jv` is a single Go
 binary installed exactly the way `kubeconform` already is, which keeps the scripts in this

--- a/.github/scripts/tests/test_contract_union.py
+++ b/.github/scripts/tests/test_contract_union.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
 """The union of several images' contracts, over fixtures rather than over a registry.
 
-`tankovault` renders one `config.toml` read by eight separate binaries under one prefix. Each
-binary's contract covers only the keys it consumes, so validating that document against one
-binary's schema with `additionalProperties: false` would reject a perfectly correct deployment:
-every key belonging to the other seven would be "unknown". The union is what makes the gate
-usable there, and it is the piece most worth testing — deterministic, offline, and the one place
-where getting it wrong turns a correct chart red.
+A document read by several binaries is the case the union exists for. Each contract covers only
+the keys its own binary consumes, so validating that document against one of them with
+`additionalProperties: false` would reject a perfectly correct deployment: every key belonging to
+the others would be "unknown".
+
+No chart declares one. Every document in this repository binds exactly one image — `tankovault`
+declares nine, one per service, each with its own ConfigMap and its own contract — so the merge
+is the identity in production and these fixtures are the only place its rules run at all. That is
+a reason to keep them rather than a reason to drop them: a document that gained a second reader
+lands straight on those rules, and this is the one place where getting them wrong turns a correct
+chart red.
 
 The fixtures in `.github/testdata/contracts/` are two contracts that share a key (`api`,
 `worker`), one that describes a shared key differently (`conflicting`), one under a foreign

--- a/charts/portfolio/Chart.yaml
+++ b/charts/portfolio/Chart.yaml
@@ -1,6 +1,6 @@
 name: portfolio
 description: Personal portfolio built with Rust (Yew frontend, Axum server).
-version: 5.1.0
+version: 5.1.1
 appVersion: v2.6.0
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts

--- a/charts/portfolio/README.md
+++ b/charts/portfolio/README.md
@@ -1,6 +1,6 @@
 # portfolio
 
-![Version: 5.1.0](https://img.shields.io/badge/Version-5.1.0-informational?style=flat-square) ![AppVersion: v2.6.0](https://img.shields.io/badge/AppVersion-v2.6.0-informational?style=flat-square)
+![Version: 5.1.1](https://img.shields.io/badge/Version-5.1.1-informational?style=flat-square) ![AppVersion: v2.6.0](https://img.shields.io/badge/AppVersion-v2.6.0-informational?style=flat-square)
 
 Personal portfolio built with Rust (Yew frontend, Axum server).
 

--- a/charts/portfolio/config-contract.yaml
+++ b/charts/portfolio/config-contract.yaml
@@ -28,7 +28,9 @@ documents:
       format: toml
 
     # Every binary that reads this document. Their contracts are unioned; one image here, so the
-    # union is the identity — `tankovault` is where it earns its keep.
+    # union is the identity — as it is for every document in this repository, `tankovault`
+    # included, since that chart declares one document per service rather than one shared by all
+    # nine.
     images:
       - values: image
         contract: contracts/server.json

--- a/just/contracts.just
+++ b/just/contracts.just
@@ -15,6 +15,11 @@
 #   the environment  every variable on every declared container, against that container's image
 #   the file names   the secrets directory's contents and every `_FILE` target
 #
+# Every document declared here binds exactly one image today — `tankovault`'s nine services each
+# render their own per-component ConfigMap — so that first union is the identity. The scope is
+# still the document rather than the image, because that is the boundary the format draws and the
+# one a document with a second reader would arrive on.
+#
 # Exactly one recipe here touches a network — `contracts`, the refresh. Everything else reads the
 # committed file, so a registry outage cannot fail a pull request that changes no image, and
 # re-running CI on an old commit validates against what was true then rather than what the registry
@@ -130,11 +135,12 @@ check-contract-coverage:
 
 # Unit tests for the contract model, over fixtures rather than over a registry.
 #
-# The union is the piece most worth testing: `tankovault` renders one document read by eight
-# binaries, and the rules for merging their contracts are what decide whether this scales past one
-# chart. Beside it are the classification order, the two-step value check and the file-supplyable
-# rule — every one of them normative, and every one of them a place where a plausible-looking
-# implementation quietly under-checks.
+# The union is tested here and nowhere else: every document in the repository binds a single image,
+# so the merge is the identity in production and these fixtures are the only place its rules run.
+# They are worth keeping — a document read by several binaries is what the format is for, and the
+# merge is what such a document would land on. Beside it are the classification order, the two-step
+# value check and the file-supplyable rule — every one of them normative, and every one of them a
+# place where a plausible-looking implementation quietly under-checks.
 [doc("Unit tests for the contract model, over fixtures rather than over a registry")]
 [group('contracts')]
 test-contract-union:


### PR DESCRIPTION
## What changed

Prose only. The configuration-contract tooling described `tankovault` as rendering one `config.toml` read by eight separate binaries under a shared prefix, with the union of their contracts being what makes gate 1 usable. That is not what the chart does.

`charts/tankovault/config-contract.yaml` declares **nine** documents, one per service — `frontend`, `api`, `control-plane`, `worker`, `notifier`, `sync`, `challenge-solver`, `render`, `bootstrap`. Each has its own per-component ConfigMap (`selector: { app.kubernetes.io/component: <service> }`, key `config.toml`) and exactly one entry under `images:`. There is no shared document.

## Why it matters

The correction has a substantive consequence, and the new prose states it rather than papering over it: **`union_contracts` has no production user.** Every declared document in every chart binds exactly one image, so the merge is the identity everywhere, and the fixtures under `.github/testdata/contracts/` are the only place its rules execute at all.

Verified across all six charts carrying a `config-contract.yaml`:

| chart | documents | images per document |
|---|---|---|
| cloudflare-access-webhook-redirect | 1 | 1 |
| mp-stats-legacy-viewer | 1 | 1 |
| netcup-offer-bot | 1 | 1 |
| portfolio | 1 | 1 |
| s3-bucket-perma-link | 1 | 1 |
| tankovault | 9 | 1 each |

The machinery and its tests stay exactly as they are. A document read by several binaries is the case the format is designed for, it is what any chart growing a second reader would land on immediately, and the merge is the one place where getting it wrong turns a correct chart red. What had to go is the claim that a reader can go look at the live example — because a reader who checks will find it is not there.

## Where

Five places named in the report, plus three more the same claim had spread to:

- `.github/scripts/check-config.py` — the gate-scope paragraph, plus a new paragraph on the union currently being the identity and why the two scopes are still distinct questions
- `.github/scripts/config_contract.py` — module docstring; **the `Union` class docstring**, which carried "eight separate binaries" as its primary justification; and **the `_merge_schema` docstring** ("as closed as one read by eight")
- `.github/scripts/config_gate_document.py` — **gate 1's own docstring**, which repeated "read by eight binaries / the other seven"
- `.github/scripts/tests/test_contract_union.py` — module docstring, now making the keep-it argument explicitly
- `just/contracts.just` — group header and the `test-contract-union` recipe comment
- `charts/portfolio/config-contract.yaml` — the `images:` comment

Left alone deliberately: `config_declaration.py`'s `Binding` docstring and `config_gate_container.py`'s header also discuss the union, but neither cites `tankovault` nor asserts a multi-image document exists — they describe the scope split in the format's own terms, which is still accurate. The three other `tankovault` references in `check-config.py` (nine services, seed Jobs, three Jobs reading the bootstrap document) all check out against the chart as written.

## Reviewer notes

- **No behaviour change.** The diff touches only comments and docstrings — with one exception below.
- **`charts/portfolio` takes a patch bump** (5.1.0 → 5.1.1, with the README badge regenerated by hand to match). `ct lint` treats any changed file under a chart directory as a changed chart and requires the version to move, and `config-contract.yaml` lives under `charts/portfolio/`. Nothing rendered by the chart changed.
- `just test-contract-union` is green: 135 tests, OK.
