### PR TITLE
feat(scripts): explain what a chart's pinned images read

### DIFF
--- a/.github/scripts/explain-config.py
+++ b/.github/scripts/explain-config.py
@@ -1,0 +1,979 @@
+#!/usr/bin/env python3
+"""Read a chart's vendored contracts back out, and say what the images it pins actually consume.
+
+Every other consumer of `charts/<chart>/contracts/` is a gate: it takes a rendered manifest, holds
+it against the contract and reports the difference. Nothing reads the contract for its own sake —
+so the one document in this repository that states, per setting, what the binary calls it, what it
+accepts, what it defaults to and whether a file may supply it is only ever consulted by a program.
+An operator asking "what can I put in `config.toml`, and why is the value I set being ignored?"
+has the chart's `values.yaml`, the chart's README and a 400 KB JSON file, and the answer is in the
+JSON file.
+
+This is that file, read out loud. Offline, read-only, no render, no network: it opens the same
+committed contracts `just check-config` does, through the same declaration and the same staleness
+interlock, and prints them.
+
+Three decisions are worth stating, because each of them is a place where the obvious
+implementation says something untrue:
+
+**Readers are derived, never listed.** `tankovault` pins nine images across nine documents, and
+which of them reads a given setting exists nowhere in this repository except in the nine contracts
+themselves — not in the chart, not in the declaration, not in the README. It is also the fact this
+command exists to produce: `internal.peers` being read by three services and `bind_addr` by all
+nine is what tells an operator whether a change is local or fleet-wide. So the attribution is
+computed by walking the contracts the declaration binds, and a hand-written map is exactly the
+thing that would be wrong within one release.
+
+**The merge here is tolerant where `union_contracts` is strict, and that is not a relaxation of
+the rule.** `cc.union_contracts` refuses two contracts that describe one key differently, because
+its output validates a document that all of them read — an unreconcilable pair there means the
+gate has nothing trustworthy to say. It cannot be reused across a chart's *documents*: nine
+separate `config.toml` files legitimately carry nine different `json_schema.title`, and merging
+them is not a question anyone asked. What this command wants is the opposite posture — a
+disagreement between two images about one setting is a finding, not a reason to print nothing —
+so the merge below keeps every image's description, shows the divergence, and reports it as a
+warning. `tankovault` v8.1.0 has seven, all on `docs`, and no gate can currently see them.
+
+**Loader variables get a section of their own**, beside the external ones the task asks for.
+`TANKOVAULT_CONFIG` and `TANKOVAULT_SECRETS_DIR` are neither settings nor foreign variables: they
+are what decides which file the settings come from, and an explanation of a configuration surface
+that omits how the surface is located is an explanation an operator cannot act on.
+
+Deliberately omitted: the merged `json_schema`. It is the same information as the key list in a
+form built for a validator rather than a person, `just check-config` is what consumes it, and
+printing 400 KB of it would bury the part that answers the question.
+
+Exit status, which is a decision rather than an accident:
+
+    0   the selection was printed
+    1   a pattern was given and matched nothing
+    2   no such chart, or a chart with no contract to read
+    3   the staleness interlock refused: the vendored contract is not for the pinned digest
+
+`1` is `grep`'s convention and it is the right one here. The question this command is asked is
+"does this image read this setting?", a pattern that matches nothing is the answer "no", and an
+answer that is indistinguishable from a typo in the pattern is not an answer. `just` prints its
+own failure line after a non-zero exit; the message this script prints first says what happened.
+
+Usage: python3 .github/scripts/explain-config.py
+       python3 .github/scripts/explain-config.py tankovault
+       python3 .github/scripts/explain-config.py tankovault tls
+       python3 .github/scripts/explain-config.py tankovault 'internal.*' --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import sys
+import textwrap
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import config_contract as cc  # noqa: E402
+from config_declaration import (  # noqa: E402
+    Declaration,
+    DeclarationError,
+    bind,
+    load_declaration,
+)
+from config_report import Report, warning  # noqa: E402
+
+CHARTS_DIR = Path("charts")
+
+# The contracts' prose is UTF-8 and uses it — em dashes, arrows, typographic quotes — and this
+# repository is developed from Git Bash on Windows, where Python's default console encoding is the
+# system code page. Left alone, every one of those characters raises `UnicodeEncodeError` and the
+# command dies part-way through a paragraph. Reconfiguring the streams is the whole fix, and
+# `errors="replace"` is the floor under it: a terminal that genuinely cannot render a character
+# should show a placeholder, never truncate the explanation.
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
+# Width the prose is re-wrapped to. `docs` arrives hard-wrapped at the producer's own width, which
+# is not this one, so paragraphs are re-flowed rather than printed as they came.
+WIDTH = 96
+
+# Column ceilings for the compact listing. The columns size themselves to the selection — a
+# filtered listing is narrower than the whole chart — and these only stop one 60-character type
+# from setting the width for 167 rows.
+MAX_PATH = 46
+MAX_TYPE = 30
+MAX_DEFAULT = 22
+
+# Fields whose representative value is the first *non-empty* one across the images that read a
+# setting. 22 of this repository's 491 declarations carry an empty `docs`, and an image that says
+# nothing about a key it shares has not contradicted the one that does.
+PROSE_FIELDS = ("docs", "note")
+
+# Constraint keywords rendered as prose, in the order they read best. Anything outside this list
+# is printed as `keyword=<json>` rather than dropped: under-reporting a constraint is the failure
+# this whole pipeline exists to remove, and it would be no better coming from the explainer.
+CONSTRAINT_ORDER = (
+    "type",
+    "const",
+    "enum",
+    "pattern",
+    "format",
+    "minimum",
+    "exclusiveMinimum",
+    "maximum",
+    "exclusiveMaximum",
+    "multipleOf",
+    "minLength",
+    "maxLength",
+)
+
+# Keywords `describe_constraint` folds into another keyword's phrase, or that are said elsewhere
+# in the entry. Listed so the catch-all below can tell "already reported" from "unrecognised".
+CONSTRAINT_FOLDED = frozenset(
+    {
+        "exclusiveMinimum",
+        "exclusiveMaximum",
+        "maximum",
+        "maxLength",
+        "description",
+        "title",
+        "default",
+        "examples",
+        "$comment",
+    }
+)
+
+
+# --------------------------------------------------------------------------------------------
+# The surface: every setting, and every image that reads it
+# --------------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Reader:
+    """One image a chart pins, named as the declaration names it.
+
+    The name is the vendored contract's stem rather than the repository part of the image
+    reference. `contracts/api.json` is what the declaration writes and what a maintainer edits,
+    it is short enough to list nine of on one line, and it maps one-to-one to an image — where
+    `docker.io/timschoenle/tankovault-api` does not fit and `tankovault-api` repeats the chart
+    name nine times. The full reference is in the header and in `--json`.
+    """
+
+    name: str
+    contract: str
+    image: str
+    digest: str
+    app: str
+    version: str
+    documents: tuple[str, ...]
+
+
+@dataclass
+class Setting:
+    """One setting, and every image that declared it.
+
+    Held as the occurrences rather than as a merged entry because the divergence between two
+    images' descriptions is a thing to print, not a thing to resolve. `representative()` is the
+    single answer for a compact line; `variants()` is what a full entry shows when there is more
+    than one.
+    """
+
+    name: str
+    occurrences: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
+
+    @property
+    def readers(self) -> list[str]:
+        return [reader for reader, _ in self.occurrences]
+
+    def value(self, name: str) -> Any:
+        """The value to show for one field, across every image that declared this setting.
+
+        `required` unions, which is `cc.UNIONED_FIELDS` restated: a setting any reader requires
+        must be present, so an image that does not require it cannot make it optional. Prose
+        takes the first non-empty. Everything else takes the first image's, and any disagreement
+        is reported separately rather than silently resolved here.
+        """
+        if name == "required":
+            return any(entry.get("required") for _, entry in self.occurrences)
+        if name in PROSE_FIELDS:
+            for _, entry in self.occurrences:
+                if entry.get(name):
+                    return entry[name]
+            return None
+        return self.occurrences[0][1].get(name)
+
+    def representative(self) -> dict[str, Any]:
+        """One entry standing for all of them, shaped exactly as a published entry is.
+
+        Shaped that way on purpose: `cc.text_form` and `cc.file_supplyable` are the normative
+        readings of an entry, and passing them a merged dictionary rather than reimplementing
+        their rules is what keeps this command agreeing with the gates.
+
+        Fields keep the order the producer published them in rather than being sorted, so
+        `--json` round-trips into something a reader can diff against the vendored file.
+        """
+        names: list[str] = []
+        for _, entry in self.occurrences:
+            for name in entry:
+                if name not in names:
+                    names.append(name)
+        return {name: self.value(name) for name in names}
+
+    def variants(self, name: str) -> list[tuple[Any, list[str]]]:
+        """Each distinct value of one field, with the images that published it."""
+        seen: list[tuple[Any, list[str]]] = []
+        for reader, entry in self.occurrences:
+            value = entry.get(name)
+            for known, readers in seen:
+                if known == value:
+                    readers.append(reader)
+                    break
+            else:
+                seen.append((value, [reader]))
+        return seen
+
+    def divergent(self) -> list[str]:
+        """Fields two images describe differently. `required` is excluded: it unions by rule."""
+        fields: set[str] = set()
+        for _, entry in self.occurrences:
+            fields.update(entry)
+        return sorted(
+            name
+            for name in fields - cc.UNIONED_FIELDS - cc.INTERNAL_FIELDS
+            if len(self.variants(name)) > 1
+        )
+
+
+@dataclass
+class Surface:
+    """Everything one chart's images read, merged across every document the chart declares."""
+
+    chart: str
+    dialect: dict[str, str] = field(default_factory=dict)
+    readers: list[Reader] = field(default_factory=list)
+    keys: dict[str, Setting] = field(default_factory=dict)
+    loader: dict[str, Setting] = field(default_factory=dict)
+    external: dict[str, Setting] = field(default_factory=dict)
+    ignore: list[str] = field(default_factory=list)
+    unknown: str = "reject"
+
+
+def collect(chart_dir: Path, declaration: Declaration, report: Report) -> Surface | None:
+    """Bind every declared document, then read the contracts binding proved belong to it.
+
+    `bind` is called for its interlock and for nothing else. It answers whether the vendored file
+    is for the digest the chart pins, which is the only question that decides whether anything
+    printed below describes the deployed image — and it is answered here exactly as the gates
+    answer it, so this command cannot report facts a gate would refuse to trust. What it returns
+    is shaped for validation (a union per document, a union per digest) and carries no
+    provenance, so the contracts are re-read afterwards for the image reference and the app
+    version. That is a second read of a file already proven, not a second opinion about it.
+    """
+    values = _read_yaml(chart_dir / "values.yaml")
+    app_version = _read_yaml(chart_dir / "Chart.yaml").get("appVersion")
+
+    surface = Surface(chart=declaration.chart)
+    by_contract: dict[str, list[str]] = {}
+    refused = False
+
+    for document in declaration.documents:
+        where = f"{declaration.chart}: {document.name}"
+        binding, problems = bind(chart_dir, document, values, app_version)
+        for problem in problems:
+            report.fail(where, problem)
+        if binding is None:
+            refused = True
+            continue
+        for reference in document.images:
+            by_contract.setdefault(reference.contract, []).append(document.name)
+
+    if refused:
+        return None
+
+    # Sorted, so the order every reader list and every "the images disagree" side is printed in is
+    # a property of the contracts rather than of where a maintainer happened to add a document.
+    for contract_path, documents in sorted(by_contract.items()):
+        vendored = cc.load_vendored(chart_dir / contract_path)
+        _absorb(surface, vendored, Path(contract_path).stem, tuple(documents), report)
+
+    return surface
+
+
+def _absorb(
+    surface: Surface,
+    vendored: cc.Vendored,
+    name: str,
+    documents: tuple[str, ...],
+    report: Report,
+) -> None:
+    """Fold one image's contract into the chart-wide surface."""
+    contract = vendored.contract
+    app = contract.get("app") or {}
+    surface.readers.append(
+        Reader(
+            name=name,
+            contract=str(vendored.path.name),
+            image=vendored.image,
+            digest=vendored.digest,
+            app=str(app.get("name") or name),
+            version=str(app.get("version") or "?"),
+            documents=documents,
+        )
+    )
+
+    dialect = contract["schema"]["dialect"]
+    if not surface.dialect:
+        surface.dialect = dict(dialect)
+        surface.unknown = contract["external"]["unknown"]
+    elif dialect != surface.dialect:
+        # `union_contracts` makes this fatal, and per document it must be: two images reading one
+        # file under different spelling rules do not share a namespace. Across documents it is
+        # merely surprising — nine separate files could legitimately use nine prefixes — so it is
+        # said rather than raised, and the header reports the first image's dialect.
+        report.add(
+            surface.chart,
+            warning(
+                f"{name} reads its configuration under the dialect "
+                f"{json.dumps(dialect, sort_keys=True)}, where the other images this chart pins "
+                f"use {json.dumps(surface.dialect, sort_keys=True)}; the header below reports "
+                "the latter"
+            ),
+        )
+
+    for entry in contract["schema"]["keys"]:
+        _record(surface.keys, entry, "path", name)
+    for entry in contract["schema"]["loader"]:
+        _record(surface.loader, entry, "env", name)
+    for entry in contract["external"]["env"]:
+        _record(surface.external, entry, "name", name)
+
+    for pattern in contract["external"]["ignore"]:
+        if pattern not in surface.ignore:
+            surface.ignore.append(pattern)
+    if cc.UNKNOWN_POLICIES.index(contract["external"]["unknown"]) > cc.UNKNOWN_POLICIES.index(
+        surface.unknown
+    ):
+        surface.unknown = contract["external"]["unknown"]
+
+
+def _record(into: dict[str, Setting], entry: dict[str, Any], key_field: str, reader: str) -> None:
+    name = entry.get(key_field)
+    if not isinstance(name, str):
+        raise cc.ContractError(f"{reader}: an entry has no `{key_field}`")
+    into.setdefault(name, Setting(name=name)).occurrences.append((reader, entry))
+
+
+def report_divergences(surface: Surface, pattern: str | None, report: Report) -> None:
+    """Say where two images describe one setting differently, within the selection.
+
+    Nothing else in this repository can see these. Each of a chart's documents is validated
+    against its own images' union, so two images that never share a document never have their
+    descriptions of a shared setting compared — and `tankovault`'s nine services share 77 of
+    their 167 settings without sharing a single file.
+
+    Scoped to the selection, because a warning about a setting the reader did not ask about is
+    noise on every run and would train them to ignore the one that matters.
+    """
+    for section, settings in (
+        ("key", surface.keys),
+        ("loader variable", surface.loader),
+        ("external variable", surface.external),
+    ):
+        for setting in select(settings, pattern):
+            for name in setting.divergent():
+                sides = "; ".join(
+                    f"{', '.join(readers)}: {_terse(value)}"
+                    for value, readers in setting.variants(name)
+                )
+                report.add(
+                    surface.chart,
+                    warning(
+                        f"the images pinned here describe the {section} {setting.name!r} "
+                        f"differently: `{name}` is {sides}"
+                    ),
+                )
+
+
+def _terse(value: Any, limit: int = 60) -> str:
+    text = json.dumps(value)
+    return text if len(text) <= limit else text[:limit] + "..."
+
+
+# --------------------------------------------------------------------------------------------
+# Selecting
+# --------------------------------------------------------------------------------------------
+
+
+def select(settings: dict[str, Setting], pattern: str | None) -> list[Setting]:
+    """The settings a pattern names, in path order.
+
+    A pattern carrying a glob metacharacter is matched as a glob against the whole name; anything
+    else is a case-insensitive substring, because the name an operator has in hand is usually a
+    fragment of a path they read in a values file. Both are anchored on the name alone — the
+    environment spelling is derived from it, so a pattern that matches the path matches the
+    variable a reader is actually holding.
+    """
+    chosen = sorted(settings.values(), key=lambda setting: setting.name)
+    if not pattern:
+        return chosen
+    if any(character in pattern for character in "*?["):
+        return [item for item in chosen if fnmatch.fnmatchcase(item.name, pattern)]
+    lowered = pattern.lower()
+    return [item for item in chosen if lowered in item.name.lower()]
+
+
+# --------------------------------------------------------------------------------------------
+# Rendering
+# --------------------------------------------------------------------------------------------
+
+
+def describe_constraint(constraint: Any) -> str:
+    """A flat JSON Schema constraint object, as a phrase.
+
+    Bounds are folded into one range because that is how they are read — `0 to 65535`, not
+    `integer, minimum 0, maximum 65535` — and an unrecognised keyword is printed rather than
+    dropped, so a vocabulary this renderer does not know still reaches the reader.
+    """
+    if not isinstance(constraint, dict) or not constraint:
+        return ""
+
+    parts: list[str] = []
+    for keyword in CONSTRAINT_ORDER:
+        if keyword not in constraint:
+            continue
+        value = constraint[keyword]
+        if keyword == "type":
+            parts.append(value if isinstance(value, str) else " or ".join(value))
+        elif keyword == "const":
+            parts.append(f"exactly {json.dumps(value)}")
+        elif keyword == "enum":
+            parts.append("one of " + " | ".join(json.dumps(item) for item in value))
+        elif keyword == "pattern":
+            parts.append(f"matching {value}")
+        elif keyword == "format":
+            parts.append(f"format {value}")
+        elif keyword == "multipleOf":
+            parts.append(f"a multiple of {value}")
+        elif keyword in ("minimum", "exclusiveMinimum"):
+            parts.append(_range(constraint))
+        elif keyword in ("maximum", "exclusiveMaximum"):
+            if "minimum" not in constraint and "exclusiveMinimum" not in constraint:
+                parts.append(_range(constraint))
+        elif keyword in ("minLength", "maxLength"):
+            if keyword == "minLength" or "minLength" not in constraint:
+                parts.append(_length(constraint))
+
+    for keyword, value in sorted(constraint.items()):
+        if keyword not in CONSTRAINT_ORDER and keyword not in CONSTRAINT_FOLDED:
+            parts.append(f"{keyword}={json.dumps(value)}")
+
+    return ", ".join(parts)
+
+
+def _range(constraint: dict[str, Any]) -> str:
+    low, low_open = constraint.get("minimum"), constraint.get("exclusiveMinimum")
+    high, high_open = constraint.get("maximum"), constraint.get("exclusiveMaximum")
+    lower = f"above {low_open}" if low_open is not None else (None if low is None else f"{low}")
+    upper = (
+        f"below {high_open}" if high_open is not None else (None if high is None else f"{high}")
+    )
+    if lower is not None and upper is not None and low_open is None and high_open is None:
+        return f"{lower} to {upper}"
+    if lower is not None and upper is not None:
+        return f"{lower}, {upper}"
+    if lower is not None:
+        return lower if low_open is not None else f"at least {lower}"
+    return upper if high_open is not None else f"at most {upper}"
+
+
+def _length(constraint: dict[str, Any]) -> str:
+    low, high = constraint.get("minLength"), constraint.get("maxLength")
+    if low is not None and high is not None:
+        return f"{low} to {high} characters"
+    if low is not None:
+        return f"at least {low} characters"
+    return f"at most {high} characters"
+
+
+def prose(text: str, indent: str) -> list[str]:
+    """Re-flow a `docs` block to this terminal's width, keeping its paragraph breaks."""
+    lines: list[str] = []
+    for index, paragraph in enumerate(text.split("\n\n")):
+        collapsed = " ".join(paragraph.split())
+        if not collapsed:
+            continue
+        if index and lines:
+            lines.append("")
+        lines.extend(textwrap.wrap(collapsed, width=WIDTH - len(indent)) or [""])
+    return [indent + line if line else "" for line in lines]
+
+
+def reader_list(setting: Setting, total: int) -> str:
+    """The images that read one setting, or `all N` when that is every image the chart pins.
+
+    `all 9` rather than nine names is not an abbreviation: the nine are listed in the header, and
+    the fact worth reading here is that the setting is fleet-wide. It is also what keeps a
+    `bind_addr` read by eight visibly different from a `TANKOVAULT_CONFIG` read by all nine.
+    """
+    if total > 1 and len(setting.readers) == total:
+        return f"all {total}"
+    return ", ".join(setting.readers)
+
+
+def markers(entry: dict[str, Any]) -> str:
+    """The two-character flag column: `R` required, `S` secret."""
+    return ("R" if entry.get("required") else ".") + ("S" if entry.get("secret") else ".")
+
+
+def shown_default(entry: dict[str, Any]) -> str:
+    """The default as the loader would read it, or `-` when the setting has none.
+
+    An empty string is a default, not an absence — `""` and "nothing is set" are two different
+    deployments — so it is spelt out rather than folded into the same dash.
+    """
+    value = entry.get("default")
+    if value is None:
+        return "-"
+    return "(empty)" if value == "" else str(value)
+
+
+def _clip(text: str, width: int) -> str:
+    return text if len(text) <= width else text[: width - 3] + "..."
+
+
+def compact(settings: list[Setting], total: int) -> list[str]:
+    """One line per setting: path, type, markers, default, and the images that read it.
+
+    The columns size themselves to the selection rather than to the chart, so `just explain
+    tankovault tls` is narrow where the whole chart is wide, and the default column disappears
+    entirely when nothing in the selection has one — which is every `tankovault` setting, since
+    that producer publishes no defaults at all. The reader list is last and unpadded: it is the
+    widest field and the one that varies most, and truncating it would hide the fact this listing
+    exists to show.
+    """
+    rows: list[tuple[str, str, str, str, str]] = []
+    for setting in settings:
+        entry = setting.representative()
+        rows.append(
+            (
+                _clip(setting.name, MAX_PATH),
+                _clip(str(entry.get("ty") or cc.text_form(entry)), MAX_TYPE),
+                markers(entry),
+                _clip(shown_default(entry), MAX_DEFAULT),
+                reader_list(setting, total) if total > 1 else "",
+            )
+        )
+
+    widths = [max((len(row[column]) for row in rows), default=0) for column in range(4)]
+    defaults = any(row[3] != "-" for row in rows)
+
+    lines = []
+    for name, ty, flags, default, readers in rows:
+        line = f"    {name:<{widths[0]}}  {ty:<{widths[1]}}  {flags}"
+        if defaults:
+            line = f"{line}  {default:<{widths[3]}}"
+        lines.append(f"{line.rstrip()}  {readers}" if readers else line.rstrip())
+    return lines
+
+
+def full(setting: Setting, dialect: dict[str, str], total: int) -> list[str]:
+    """Everything one contract says about one setting."""
+    entry = setting.representative()
+    form = cc.text_form(entry)
+    divergent = set(setting.divergent())
+
+    lines = [f"    {setting.name}"]
+
+    def row(label: str, value: str) -> None:
+        """One labelled line, wrapped under its own label rather than off the terminal.
+
+        A spelling or a type never needs this; a refusal explaining why a file cannot supply the
+        key always does, and an entry whose widest line is the one carrying the reason is the one
+        an operator will not read.
+        """
+        if not value:
+            return
+        margin = " " * 8 + f"{label:<14}"
+        # An environment spelling and a `pattern` are single tokens, and a token split across two
+        # lines is one nobody can copy — so a value wider than the terminal overflows rather than
+        # being broken.
+        lines.extend(
+            textwrap.wrap(
+                value,
+                width=WIDTH,
+                initial_indent=margin,
+                subsequent_indent=" " * len(margin),
+                break_long_words=False,
+                break_on_hyphens=False,
+            )
+            or [margin]
+        )
+
+    row("type", f"{entry.get('ty') or '?'}  (read as {form})")
+    row("required", "yes" if entry.get("required") else "no")
+    row("secret", "yes" if entry.get("secret") else "no")
+    if entry.get("reserved"):
+        row("reserved", "yes — the loader claims this path; a deployment must not set it")
+    row("default", shown_default(entry))
+    # Beside the default rather than at the end with the prose, because that is what a `note`
+    # turns out to be: both of the two in this repository gloss the default rather than the key
+    # ("permanent" for a TTL of `0`, "ISR off; the image sets `/tmp/isr`" for no cache directory),
+    # and a gloss printed six lines from the thing it glosses is a gloss nobody connects.
+    row("note", str(setting.value("note") or ""))
+    if entry.get("values"):
+        row("values", " | ".join(str(value) for value in entry["values"]))
+    row("accepts", describe_constraint(entry.get("constraint")))
+    row("as text", describe_constraint(entry.get("text_constraint")))
+
+    if total > 1:
+        row("read by", reader_list(setting, total))
+
+    for label, spelling in (
+        ("environment", "env"),
+        (f"{dialect.get('indirection_suffix', '_FILE')} form", "env_file"),
+        ("secrets file", "secrets_file"),
+    ):
+        if entry.get(spelling):
+            row(label, str(entry[spelling]))
+    for label, spelling in (
+        ("env aliases", "env_aliases"),
+        ("aliases", "aliases"),
+        ("secrets file aliases", "secrets_file_aliases"),
+    ):
+        if entry.get(spelling):
+            row(label, ", ".join(str(value) for value in entry[spelling]))
+
+    # `file_supplyable` is normative and counter-intuitive: the `_FILE` and secrets-file spellings
+    # above exist for every key, and for a key of any form but `text` neither of them can supply
+    # it — a file delivers a string and `Figment::extract` will not coerce one into a number, a
+    # boolean or a TOML literal. Printing the spelling without printing that is how an operator
+    # ends up mounting a Secret that is silently never read.
+    if entry.get("env_file") or entry.get("secrets_file"):
+        if cc.file_supplyable(entry):
+            row("from a file", "yes")
+        else:
+            row(
+                "from a file",
+                f"no — a file supplies text, and this key is read as {form}; "
+                "set it in the document or the environment",
+            )
+
+    if "docs" in divergent:
+        lines.append("        docs (the images disagree)")
+        for value, readers in setting.variants("docs"):
+            lines.append(f"          {', '.join(readers)}:")
+            lines.extend(prose(str(value or "(nothing)"), " " * 12))
+    elif setting.value("docs"):
+        lines.append("        docs")
+        lines.extend(prose(str(setting.value("docs")), " " * 12))
+
+    remaining = sorted(divergent - {"docs"})
+    if remaining:
+        row(
+            "disagreement",
+            f"the images describe {', '.join(remaining)} differently; the values above are "
+            f"{setting.readers[0]}'s",
+        )
+
+    lines.append("")
+    return lines
+
+
+def variable(setting: Setting, summary: str, total: int) -> list[str]:
+    """One loader or external variable: what it is, what it says, and who reads it.
+
+    Neither is a setting, so neither gets the full entry above — there is no path, no `_FILE`
+    spelling and no secrets file to report. What they have in common is a name, a one-line
+    summary and prose, which is this block.
+    """
+    lines = [f"    {setting.name}  ({summary})"]
+    if setting.value("docs"):
+        lines.extend(prose(str(setting.value("docs")), " " * 8))
+    if total > 1:
+        lines.append(f"        read by  {reader_list(setting, total)}")
+    return lines
+
+
+def print_surface(surface: Surface, args: argparse.Namespace, out) -> int:
+    """The whole report, for a human. Returns the exit status."""
+    keys = select(surface.keys, args.pattern)
+    loader = select(surface.loader, args.pattern)
+    external = select(surface.external, args.pattern)
+    total = len(surface.readers)
+
+    prefix = surface.dialect.get("prefix", "")
+    print(
+        f"==> {surface.chart}: {len(surface.keys)} setting(s) across "
+        f"{len(surface.readers)} image(s)",
+        file=out,
+    )
+    print(
+        f"    {prefix}* spellings, {surface.dialect.get('nesting_separator')} for nesting, "
+        f"{surface.dialect.get('indirection_suffix')} for a file reference",
+        file=out,
+    )
+    readers = sorted(surface.readers, key=lambda item: item.name)
+    name_width = max((len(reader.name) for reader in readers), default=0) + 2
+    image_width = max((len(reader.image) for reader in readers), default=0) + 2
+    for reader in readers:
+        print(
+            f"    {reader.name:<{name_width}}{reader.image:<{image_width}}"
+            f"{reader.version:<10}{reader.digest[:19]}...",
+            file=out,
+        )
+
+    if args.pattern:
+        print(
+            f"\n    matching {args.pattern!r}: {len(keys)} setting(s), "
+            f"{len(loader)} loader variable(s), {len(external)} external variable(s)",
+            file=out,
+        )
+
+    if keys:
+        print("\n==> settings\n", file=out)
+        if not (args.full or args.pattern):
+            columns = "path, type, flags, default"
+            if total > 1:
+                columns += ", and the images that read it"
+            print(f"    {columns}; R marks required, S marks secret\n", file=out)
+        if args.full or args.pattern:
+            for setting in keys:
+                print("\n".join(full(setting, surface.dialect, total)), file=out)
+        else:
+            print("\n".join(compact(keys, total)), file=out)
+
+    if loader:
+        print("\n==> loader variables — where the settings are read from\n", file=out)
+        blocks = []
+        for setting in loader:
+            entry = setting.representative()
+            summary = f"role {entry.get('role')}, default {shown_default(entry)}"
+            blocks.append("\n".join(variable(setting, summary, total)))
+        print("\n\n".join(blocks), file=out)
+
+    if external:
+        print("\n==> external variables — read by the image, and nobody's configuration\n", file=out)
+        print(
+            "\n".join(
+                prose(
+                    "These are not settings. They belong to a runtime or a library the image "
+                    "carries, they are outside the loader's namespace, and nothing in this "
+                    "chart's document can change one. A value set here and expected to reach "
+                    "the application's configuration is a value that is ignored.",
+                    "    ",
+                )
+            ),
+            file=out,
+        )
+        print(file=out)
+        blocks = []
+        for setting in external:
+            entry = setting.representative()
+            constraint = describe_constraint(entry.get("constraint"))
+            summary = (
+                f"owner {entry.get('owner')}, {entry.get('ty')}"
+                f"{', ' + constraint if constraint else ''}, "
+                f"default {shown_default(entry)}"
+            )
+            blocks.append("\n".join(variable(setting, summary, total)))
+        print("\n\n".join(blocks), file=out)
+
+        print(f"\n    unaccounted-for variables under {prefix}*: {surface.unknown}", file=out)
+        if surface.ignore:
+            print(f"    ignored by pattern: {', '.join(surface.ignore)}", file=out)
+
+    if args.pattern and not (keys or loader or external):
+        print(
+            f"    nothing this chart's images read matches {args.pattern!r}",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+# --------------------------------------------------------------------------------------------
+# The machine-readable form
+# --------------------------------------------------------------------------------------------
+
+
+def as_json(surface: Surface, pattern: str | None) -> dict[str, Any]:
+    """The same selection, for something other than a person.
+
+    Every entry is emitted as the contract published it, with the readers and the two derived
+    readings — `text_form` and `file_supplyable` — added. Deriving those here rather than leaving
+    them to the consumer is the point of the format: they are the rules a reimplementation gets
+    wrong.
+    """
+    return {
+        "chart": surface.chart,
+        "dialect": surface.dialect,
+        "unknown": surface.unknown,
+        "ignore": surface.ignore,
+        "pattern": pattern,
+        "images": [
+            {
+                "name": reader.name,
+                "contract": reader.contract,
+                "image": reader.image,
+                "digest": reader.digest,
+                "app": reader.app,
+                "version": reader.version,
+                "documents": list(reader.documents),
+            }
+            for reader in sorted(surface.readers, key=lambda item: item.name)
+        ],
+        "keys": [_setting_json(item, derive=True) for item in select(surface.keys, pattern)],
+        "loader": [_setting_json(item) for item in select(surface.loader, pattern)],
+        "external": [_setting_json(item, derive=True) for item in select(surface.external, pattern)],
+    }
+
+
+def _setting_json(setting: Setting, derive: bool = False) -> dict[str, Any]:
+    entry = cc.strip_internals(setting.representative())
+    entry["readers"] = setting.readers
+    if derive:
+        entry["text_form"] = cc.text_form(entry)
+        entry["file_supplyable"] = cc.file_supplyable(entry)
+    divergent = setting.divergent()
+    if divergent:
+        entry["divergent"] = {
+            name: [
+                {"value": value, "readers": readers} for value, readers in setting.variants(name)
+            ]
+            for name in divergent
+        }
+    return entry
+
+
+# --------------------------------------------------------------------------------------------
+# Entry point
+# --------------------------------------------------------------------------------------------
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def charts_with_contracts(charts: Path) -> list[tuple[str, Declaration]]:
+    """Every chart carrying a declaration, whether or not it declares any document."""
+    found = []
+    for chart_dir in sorted(charts.iterdir()):
+        if not (chart_dir / "Chart.yaml").is_file():
+            continue
+        declaration = load_declaration(chart_dir)
+        if declaration is not None:
+            found.append((chart_dir.name, declaration))
+    return found
+
+
+def list_charts(charts: Path, out) -> None:
+    covered = charts_with_contracts(charts)
+    if not covered:
+        print("==> no chart in this repository declares a configuration contract", file=out)
+        return
+    print("==> charts with a configuration contract\n", file=out)
+    for name, declaration in covered:
+        if not declaration.documents:
+            print(f"    {name:<38}opted out", file=out)
+            continue
+        images = sum(len(document.images) for document in declaration.documents)
+        print(
+            f"    {name:<38}{len(declaration.documents)} document(s), {images} image(s)",
+            file=out,
+        )
+    print("\n    just explain <chart> [pattern]", file=out)
+
+
+def describe_opt_out(declaration: Declaration, out) -> None:
+    print(f"==> {declaration.chart} has explicitly opted out of configuration contracts\n", file=out)
+    print("\n".join(prose(str(declaration.reason), "    ")), file=out)
+    if declaration.unconfigured:
+        print(
+            f"\n    images it pins that carry no contract: "
+            f"{', '.join(declaration.unconfigured)}",
+            file=out,
+        )
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Explain what a chart's pinned images read, from their vendored contracts"
+    )
+    parser.add_argument("chart", nargs="?", default="", help="the chart to explain")
+    parser.add_argument(
+        "pattern", nargs="?", default="", help="substring or glob over the setting's path"
+    )
+    parser.add_argument("--charts", default=str(CHARTS_DIR))
+    parser.add_argument(
+        "--full", action="store_true", help="print full entries even without a pattern"
+    )
+    parser.add_argument("--json", action="store_true", help="emit the same selection as JSON")
+    args = parser.parse_args(argv)
+    args.pattern = args.pattern or None
+
+    charts = Path(args.charts)
+    report = Report()
+
+    try:
+        if not args.chart:
+            list_charts(charts, sys.stdout)
+            return 0
+
+        chart_dir = charts / args.chart
+        declaration = load_declaration(chart_dir) if chart_dir.is_dir() else None
+        if declaration is None:
+            print(
+                f"error: {args.chart!r} is not a chart with a configuration contract",
+                file=sys.stderr,
+            )
+            list_charts(charts, sys.stderr)
+            return 2
+        if not declaration.documents:
+            describe_opt_out(declaration, sys.stdout)
+            return 0
+
+        surface = collect(chart_dir, declaration, report)
+        if surface is None:
+            # The interlock, and the reason it is worth honouring in a command that changes
+            # nothing: a contract that is not for the digest the chart pins describes some other
+            # build of the image, and printing its settings as this chart's would be a confident
+            # wrong answer to the only question anyone runs this to ask.
+            report.print(sys.stderr, sys.stderr)
+            print(
+                "\nerror: the vendored contracts are not for the images this chart pins, so "
+                "nothing here can be shown to describe what is deployed; run `just contracts`",
+                file=sys.stderr,
+            )
+            return 3
+
+        report_divergences(surface, args.pattern, report)
+    except (DeclarationError, cc.ContractError) as failure:
+        print(f"error: {failure}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        # Warnings go to stderr here rather than stdout, so `just explain ... --json | jq` reads
+        # JSON and nothing else. `Report.summary` is deliberately not called: this command is an
+        # explanation, not a gate, and it has no business writing a CI step summary.
+        report.print(sys.stderr, sys.stderr)
+        json.dump(as_json(surface, args.pattern), sys.stdout, indent=2, sort_keys=False)
+        print(file=sys.stdout)
+        selected = (
+            len(select(surface.keys, args.pattern))
+            + len(select(surface.loader, args.pattern))
+            + len(select(surface.external, args.pattern))
+        )
+        return 1 if args.pattern and not selected else 0
+
+    status = print_surface(surface, args, sys.stdout)
+    report.print(sys.stdout, sys.stderr)
+    return status
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/scripts/tests/test_contract_explain.py
+++ b/.github/scripts/tests/test_contract_explain.py
@@ -1,0 +1,609 @@
+#!/usr/bin/env python3
+"""Reading a chart's contracts back out, over fixtures rather than over the charts themselves.
+
+`explain-config.py` prints rather than fails, which is exactly why it needs tests: a gate that
+gets a rule wrong turns a pull request red, and an explanation that gets one wrong is believed. A
+key shown as supplyable from a file when the loader will not read it that way, or a setting
+attributed to seven images when eight read it, is a wrong answer nothing else in this repository
+would contradict.
+
+Three things here are worth holding still:
+
+**The reader attribution**, because it is the fact this command exists to produce and it exists
+nowhere else — not in a chart, not in a declaration, not in a README. A test over two fixture
+contracts that share a key is what says the attribution is derived rather than guessed.
+
+**The tolerant merge.** `union_contracts` refuses two contracts that describe one key
+differently, and it is right to: its output validates a document all of them read. This command
+must do the opposite and show the disagreement, because across a chart's *documents* nobody ever
+compares the two — `tankovault` v8.1.0 has seven such pairs today and no gate can see one of
+them. A merge that silently picked the first description would hide them again.
+
+**The staleness interlock**, honoured here for the same reason the gates honour it: a contract
+that is not for the pinned digest describes some other build, and printing its settings as this
+chart's is a confident wrong answer to the only question anyone runs this to ask.
+
+The fixtures are the ones the union tests already use — `api` and `worker` share `database.url`
+and `log.level` — wrapped in the `source` envelope a vendored file carries.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+
+import config_contract as cc  # noqa: E402
+from config_report import Report  # noqa: E402
+
+
+def _load(name: str, filename: str):
+    """Import a hyphenated entry point, which a plain `import` cannot name.
+
+    Registered in `sys.modules` before it is executed, which the same helper in
+    `test_contract_refresh.py` does not need to do: `@dataclass` resolves its own module out of
+    `sys.modules` to decide what a `ClassVar` is, and a module that is not there yet fails at
+    the decorator rather than at anything the test wrote.
+    """
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / filename)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+explain = _load("explain_config", "explain-config.py")
+
+FIXTURES = SCRIPTS.parent / "testdata" / "contracts"
+API_DIGEST = "sha256:" + "ab" * 32
+WORKER_DIGEST = "sha256:" + "cd" * 32
+OTHER_DIGEST = "sha256:" + "ef" * 32
+
+
+def fixture(name: str) -> dict:
+    return json.loads((FIXTURES / f"{name}.json").read_text(encoding="utf-8"))
+
+
+def setting(name: str, *occurrences: tuple[str, dict]) -> "explain.Setting":
+    return explain.Setting(name=name, occurrences=list(occurrences))
+
+
+# --------------------------------------------------------------------------------------------
+# A chart on disk
+# --------------------------------------------------------------------------------------------
+
+
+class ChartFixture(unittest.TestCase):
+    """A throwaway chart pinning one image per contract, wired exactly as a real one is."""
+
+    def build(self, *images: tuple[str, str, str], documents: str | None = None) -> Path:
+        """`images` is `(document name, fixture name, digest)`, one document per image."""
+        work = tempfile.TemporaryDirectory()
+        self.addCleanup(work.cleanup)
+        chart = Path(work.name) / "demo"
+        (chart / "contracts").mkdir(parents=True)
+
+        values = {}
+        declared = []
+        for name, contract, digest in images:
+            payload = fixture(contract)
+            (chart / "contracts" / f"{name}.json").write_text(
+                json.dumps(
+                    {
+                        "source": {
+                            "image": f"docker.io/demo/{name}",
+                            "digest": digest,
+                            "sha256": "0" * 64,
+                            "fetched": "2026-01-01T00:00:00Z",
+                        },
+                        "contract": payload,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            values[name] = {"repository": f"demo/{name}", "tag": f"v1@{digest}"}
+            declared.append(
+                f"  - name: {name}\n"
+                f"    source: {{ kind: ConfigMap, key: config.toml }}\n"
+                f"    images:\n"
+                f"      - values: {name}\n"
+                f"        contract: contracts/{name}.json\n"
+            )
+
+        (chart / "Chart.yaml").write_text("name: demo\nappVersion: v1\n", encoding="utf-8")
+        (chart / "values.yaml").write_text(json.dumps(values), encoding="utf-8")
+        (chart / "config-contract.yaml").write_text(
+            documents if documents is not None else "documents:\n" + "".join(declared),
+            encoding="utf-8",
+        )
+        return chart
+
+    def collect(self, chart: Path) -> tuple["explain.Surface | None", Report]:
+        from config_declaration import load_declaration
+
+        report = Report()
+        return explain.collect(chart, load_declaration(chart), report), report
+
+
+# --------------------------------------------------------------------------------------------
+# Which images read which setting
+# --------------------------------------------------------------------------------------------
+
+
+class TestReaderAttribution(ChartFixture):
+    """The one fact this command produces that exists nowhere else in the repository."""
+
+    def setUp(self):
+        self.chart = self.build(("api", "api", API_DIGEST), ("worker", "worker", WORKER_DIGEST))
+        self.surface, self.report = self.collect(self.chart)
+
+    def test_a_setting_only_one_image_reads_names_that_image(self):
+        self.assertEqual(self.surface.keys["auth.session_ttl"].readers, ["api"])
+        self.assertEqual(self.surface.keys["worker.concurrency"].readers, ["worker"])
+
+    def test_a_shared_setting_names_every_image_that_reads_it(self):
+        self.assertEqual(self.surface.keys["database.url"].readers, ["api", "worker"])
+
+    def test_every_image_contributes_its_own_settings(self):
+        self.assertEqual(
+            sorted(self.surface.keys),
+            [
+                "auth.session_ttl",
+                "database.url",
+                "github.repos",
+                "log.level",
+                "tuning.ratio",
+                "worker.concurrency",
+                "worker.debug",
+            ],
+        )
+
+    def test_the_images_are_named_by_their_contract_and_carry_their_provenance(self):
+        readers = {reader.name: reader for reader in self.surface.readers}
+        self.assertEqual(sorted(readers), ["api", "worker"])
+        self.assertEqual(readers["api"].image, "docker.io/demo/api")
+        self.assertEqual(readers["api"].digest, API_DIGEST)
+        self.assertEqual(readers["api"].documents, ("api",))
+
+    def test_readers_are_sorted_rather_than_declaration_ordered(self):
+        reversed_chart = self.build(
+            ("worker", "worker", WORKER_DIGEST), ("api", "api", API_DIGEST)
+        )
+        surface, _ = self.collect(reversed_chart)
+        self.assertEqual(surface.keys["database.url"].readers, ["api", "worker"])
+
+    def test_all_of_them_is_said_as_all_rather_than_listed(self):
+        shared = self.surface.keys["database.url"]
+        self.assertEqual(explain.reader_list(shared, 2), "all 2")
+        self.assertEqual(explain.reader_list(shared, 3), "api, worker")
+        # One image is not a fleet, and `all 1` would be a strange way to say `server`.
+        self.assertEqual(explain.reader_list(self.surface.keys["log.level"], 1), "api")
+
+
+# --------------------------------------------------------------------------------------------
+# Merging what several images say about one setting
+# --------------------------------------------------------------------------------------------
+
+
+class TestTolerantMerge(unittest.TestCase):
+    """A disagreement between two images is a finding here, not a refusal."""
+
+    def test_required_unions_because_any_reader_requiring_it_wins(self):
+        merged = setting(
+            "database.url",
+            ("api", {"path": "database.url", "required": False}),
+            ("worker", {"path": "database.url", "required": True}),
+        )
+        self.assertTrue(merged.value("required"))
+        # And the rule is `cc.UNIONED_FIELDS`, restated rather than reinvented, so a union is not
+        # reported as a disagreement.
+        self.assertNotIn("required", merged.divergent())
+
+    def test_empty_prose_is_an_absence_rather_than_a_contradiction(self):
+        merged = setting(
+            "bind_addr",
+            ("api", {"path": "bind_addr", "docs": ""}),
+            ("worker", {"path": "bind_addr", "docs": "The listener."}),
+        )
+        self.assertEqual(merged.value("docs"), "The listener.")
+
+    def test_two_descriptions_of_one_setting_are_both_kept(self):
+        merged = setting(
+            "bind_addr",
+            ("api", {"path": "bind_addr", "docs": "Public."}),
+            ("render", {"path": "bind_addr", "docs": ""}),
+            ("worker", {"path": "bind_addr", "docs": "Ops only."}),
+        )
+        self.assertEqual(merged.divergent(), ["docs"])
+        self.assertEqual(
+            merged.variants("docs"),
+            [("Public.", ["api"]), ("", ["render"]), ("Ops only.", ["worker"])],
+        )
+
+    def test_a_disagreement_about_a_constraint_is_reported_and_not_resolved(self):
+        merged = setting(
+            "port",
+            ("api", {"path": "port", "constraint": {"type": "integer", "maximum": 65535}}),
+            ("worker", {"path": "port", "constraint": {"type": "integer"}}),
+        )
+        self.assertEqual(merged.divergent(), ["constraint"])
+        self.assertEqual(merged.representative()["constraint"]["maximum"], 65535)
+
+    def test_a_field_only_one_image_publishes_is_still_carried(self):
+        merged = setting(
+            "log.level",
+            ("api", {"path": "log.level"}),
+            ("worker", {"path": "log.level", "note": "ignored in tests"}),
+        )
+        self.assertEqual(merged.value("note"), "ignored in tests")
+
+    def test_the_representative_keeps_the_publication_order_of_its_fields(self):
+        merged = setting(
+            "log.level",
+            ("api", {"path": "log.level", "env": "X", "ty": "Level"}),
+            ("worker", {"path": "log.level", "env": "X", "ty": "Level", "secret": False}),
+        )
+        self.assertEqual(list(merged.representative()), ["path", "env", "ty", "secret"])
+
+
+class TestDivergenceIsReported(ChartFixture):
+    """No gate compares two images that never share a document. This is the only thing that does."""
+
+    def test_a_shared_setting_described_differently_becomes_a_warning(self):
+        drifted = fixture("worker")
+        for entry in drifted["schema"]["keys"]:
+            if entry["path"] == "database.url":
+                entry["docs"] = "Somewhere else entirely."
+
+        chart = self.build(("api", "api", API_DIGEST), ("worker", "worker", WORKER_DIGEST))
+        path = chart / "contracts" / "worker.json"
+        vendored = json.loads(path.read_text(encoding="utf-8"))
+        vendored["contract"] = drifted
+        path.write_text(json.dumps(vendored), encoding="utf-8")
+
+        surface, report = self.collect(chart)
+        explain.report_divergences(surface, None, report)
+
+        messages = [finding.message for _, finding in report.warnings]
+        self.assertTrue(any("database.url" in message for message in messages), messages)
+        self.assertTrue(any("`docs`" in message for message in messages), messages)
+        self.assertEqual(report.errors, [])
+
+    def test_a_divergence_outside_the_selection_is_not_reported(self):
+        chart = self.build(("api", "api", API_DIGEST), ("worker", "worker", WORKER_DIGEST))
+        surface, report = self.collect(chart)
+        surface.keys["database.url"].occurrences[1][1]["docs"] = "drifted"
+        explain.report_divergences(surface, "log.level", report)
+        self.assertEqual(report.warnings, [])
+
+
+# --------------------------------------------------------------------------------------------
+# The interlock
+# --------------------------------------------------------------------------------------------
+
+
+class TestStalenessInterlock(ChartFixture):
+    """Printing a contract that is not for the pinned digest is a confident wrong answer."""
+
+    def test_a_bumped_digest_produces_no_surface_at_all(self):
+        chart = self.build(("api", "api", API_DIGEST))
+        values = json.loads((chart / "values.yaml").read_text(encoding="utf-8"))
+        values["api"]["tag"] = f"v2@{OTHER_DIGEST}"
+        (chart / "values.yaml").write_text(json.dumps(values), encoding="utf-8")
+
+        surface, report = self.collect(chart)
+        self.assertIsNone(surface)
+        self.assertTrue(report.errors)
+        self.assertIn("refreshes it", report.errors[0][1].message)
+
+    def test_one_stale_document_refuses_the_whole_chart(self):
+        # Rather than printing the eight that bound and quietly dropping the ninth: a listing
+        # missing a document is indistinguishable from an image that reads nothing.
+        chart = self.build(("api", "api", API_DIGEST), ("worker", "worker", WORKER_DIGEST))
+        values = json.loads((chart / "values.yaml").read_text(encoding="utf-8"))
+        values["worker"]["tag"] = f"v2@{OTHER_DIGEST}"
+        (chart / "values.yaml").write_text(json.dumps(values), encoding="utf-8")
+
+        surface, _ = self.collect(chart)
+        self.assertIsNone(surface)
+
+
+# --------------------------------------------------------------------------------------------
+# Selecting
+# --------------------------------------------------------------------------------------------
+
+
+class TestSelection(unittest.TestCase):
+    def setUp(self):
+        self.settings = {
+            name: setting(name, ("api", {"path": name}))
+            for name in ("auth.session_ttl", "database.url", "log.level", "Log.Rotation")
+        }
+
+    def test_no_pattern_takes_everything_in_path_order(self):
+        self.assertEqual(
+            [item.name for item in explain.select(self.settings, None)],
+            ["Log.Rotation", "auth.session_ttl", "database.url", "log.level"],
+        )
+
+    def test_a_plain_pattern_is_a_case_insensitive_substring(self):
+        self.assertEqual(
+            [item.name for item in explain.select(self.settings, "LOG")],
+            ["Log.Rotation", "log.level"],
+        )
+
+    def test_a_glob_is_matched_against_the_whole_path(self):
+        self.assertEqual(
+            [item.name for item in explain.select(self.settings, "log.*")], ["log.level"]
+        )
+
+    def test_a_glob_matching_nothing_selects_nothing(self):
+        self.assertEqual(explain.select(self.settings, "auth.*.ttl"), [])
+
+
+# --------------------------------------------------------------------------------------------
+# Rendering
+# --------------------------------------------------------------------------------------------
+
+
+class TestConstraintProse(unittest.TestCase):
+    def test_a_two_sided_bound_reads_as_a_range(self):
+        self.assertEqual(
+            explain.describe_constraint({"type": "integer", "minimum": 0, "maximum": 65535}),
+            "integer, 0 to 65535",
+        )
+
+    def test_a_one_sided_bound_says_which_side(self):
+        self.assertEqual(
+            explain.describe_constraint({"type": "integer", "minimum": 1}), "integer, at least 1"
+        )
+        self.assertEqual(
+            explain.describe_constraint({"type": "integer", "maximum": 9}), "integer, at most 9"
+        )
+
+    def test_an_exclusive_bound_is_not_reported_as_an_inclusive_one(self):
+        self.assertEqual(
+            explain.describe_constraint({"exclusiveMinimum": 0}),
+            "above 0",
+        )
+
+    def test_an_enum_lists_its_values(self):
+        self.assertEqual(
+            explain.describe_constraint({"type": "string", "enum": ["a", "b"]}),
+            'string, one of "a" | "b"',
+        )
+
+    def test_a_length_bound_says_characters(self):
+        self.assertEqual(
+            explain.describe_constraint({"type": "string", "minLength": 1, "maxLength": 64}),
+            "string, 1 to 64 characters",
+        )
+
+    def test_an_unrecognised_keyword_is_printed_rather_than_dropped(self):
+        # Under-reporting a constraint is the failure this pipeline exists to remove, and it is
+        # no better coming from the explainer than from a gate.
+        described = explain.describe_constraint({"type": "string", "contentEncoding": "base64"})
+        self.assertIn('contentEncoding="base64"', described)
+
+    def test_nothing_to_say_is_said_with_nothing(self):
+        self.assertEqual(explain.describe_constraint(None), "")
+        self.assertEqual(explain.describe_constraint({}), "")
+
+
+class TestFullEntry(unittest.TestCase):
+    DIALECT = {"prefix": "FIXTURE_", "nesting_separator": "__", "indirection_suffix": "_FILE"}
+
+    def entry(self, path: str) -> "explain.Setting":
+        for item in fixture("api")["schema"]["keys"]:
+            if item["path"] == path:
+                return setting(path, ("api", item))
+        raise AssertionError(path)
+
+    def rendered(self, path: str, total: int = 1) -> str:
+        return "\n".join(explain.full(self.entry(path), self.DIALECT, total))
+
+    def test_every_spelling_the_loader_accepts_is_shown(self):
+        text = self.rendered("database.url")
+        self.assertIn("FIXTURE_DATABASE__URL", text)
+        self.assertIn("FIXTURE_DATABASE__URL_FILE", text)
+        self.assertIn("database__url", text)
+
+    def test_a_text_key_is_shown_as_supplyable_from_a_file(self):
+        self.assertIn("from a file   yes", self.rendered("database.url"))
+
+    def test_a_key_no_file_can_supply_says_so_beside_the_spellings(self):
+        # The `_FILE` and secrets-file spellings exist for every key, and for anything but a
+        # `text` key neither of them works — a file delivers a string and `Figment::extract` will
+        # not coerce one. Printing the spelling without printing that is how an operator ends up
+        # mounting a Secret that is silently never read.
+        text = self.rendered("auth.session_ttl")
+        self.assertIn("FIXTURE_AUTH__SESSION_TTL_FILE", text)
+        self.assertIn("from a file   no", text)
+        self.assertIn("read as integer", text)
+
+    def test_the_markers_and_the_enum_reach_the_entry(self):
+        self.assertIn("secret        yes", self.rendered("database.url"))
+        self.assertIn("required      yes", self.rendered("database.url"))
+        self.assertIn("debug | info | warn", self.rendered("log.level"))
+
+    def test_a_single_image_chart_does_not_attribute_readers(self):
+        self.assertNotIn("read by", self.rendered("database.url", total=1))
+        self.assertIn("read by", self.rendered("database.url", total=2))
+
+
+class TestCompactListing(unittest.TestCase):
+    def rows(self, *paths: str, total: int = 1) -> list[str]:
+        keys = {item["path"]: item for item in fixture("api")["schema"]["keys"]}
+        return explain.compact([setting(path, ("api", keys[path])) for path in paths], total)
+
+    def test_required_and_secret_are_two_markers_in_one_column(self):
+        (line,) = self.rows("database.url")
+        self.assertIn("RS", line)
+        (line,) = self.rows("log.level")
+        self.assertIn("..", line)
+
+    def test_the_default_column_disappears_when_nothing_has_one(self):
+        # Every one of `tankovault`'s 454 declarations publishes no default, and 167 rows of a
+        # column holding only dashes is a column that costs width and says nothing.
+        (line,) = self.rows("log.level")
+        self.assertNotIn("-", line)
+        (line,) = self.rows("auth.session_ttl")
+        self.assertIn("3600", line)
+
+
+# --------------------------------------------------------------------------------------------
+# The command
+# --------------------------------------------------------------------------------------------
+
+
+class TestExitStatus(ChartFixture):
+    """The status is an answer, not an accident — see the module docstring for which is which."""
+
+    def run_main(self, *argv: str) -> tuple[int, str, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            status = explain.main(list(argv))
+        return status, out.getvalue(), err.getvalue()
+
+    def charts_root(self, chart: Path) -> str:
+        return str(chart.parent)
+
+    def test_no_chart_lists_the_charts_that_have_one(self):
+        chart = self.build(("api", "api", API_DIGEST))
+        status, out, _ = self.run_main("--charts", self.charts_root(chart))
+        self.assertEqual(status, 0)
+        self.assertIn("demo", out)
+
+    def test_an_unknown_chart_lists_them_and_fails(self):
+        chart = self.build(("api", "api", API_DIGEST))
+        status, _, err = self.run_main("nosuch", "--charts", self.charts_root(chart))
+        self.assertEqual(status, 2)
+        self.assertIn("is not a chart with a configuration contract", err)
+
+    def test_an_explicit_opt_out_is_reported_and_succeeds(self):
+        chart = self.build(
+            documents="documents: []\nreason: the image publishes no contract yet\n"
+        )
+        status, out, _ = self.run_main("demo", "--charts", self.charts_root(chart))
+        self.assertEqual(status, 0)
+        self.assertIn("opted out", out)
+        self.assertIn("publishes no contract yet", out)
+
+    def test_a_pattern_matching_nothing_is_answered_with_a_failure(self):
+        # `grep`'s convention. "Does this image read this setting?" is a question, and an answer
+        # indistinguishable from a typo in the pattern is not one.
+        chart = self.build(("api", "api", API_DIGEST))
+        status, _, err = self.run_main("demo", "zzz", "--charts", self.charts_root(chart))
+        self.assertEqual(status, 1)
+        self.assertIn("nothing this chart's images read matches", err)
+
+    def test_a_pattern_matching_something_succeeds(self):
+        chart = self.build(("api", "api", API_DIGEST))
+        status, out, _ = self.run_main("demo", "database", "--charts", self.charts_root(chart))
+        self.assertEqual(status, 0)
+        self.assertIn("FIXTURE_DATABASE__URL", out)
+
+    def test_a_stale_contract_refuses_to_print_anything(self):
+        chart = self.build(("api", "api", API_DIGEST))
+        values = json.loads((chart / "values.yaml").read_text(encoding="utf-8"))
+        values["api"]["tag"] = f"v2@{OTHER_DIGEST}"
+        (chart / "values.yaml").write_text(json.dumps(values), encoding="utf-8")
+
+        status, out, err = self.run_main("demo", "--charts", self.charts_root(chart))
+        self.assertEqual(status, 3)
+        self.assertNotIn("FIXTURE_DATABASE__URL", out)
+        self.assertIn("just contracts", err)
+
+    def test_the_whole_surface_is_printed_without_a_pattern(self):
+        chart = self.build(("api", "api", API_DIGEST), ("worker", "worker", WORKER_DIGEST))
+        status, out, _ = self.run_main("demo", "--charts", self.charts_root(chart))
+        self.assertEqual(status, 0)
+        self.assertIn("database.url", out)
+        self.assertIn("all 2", out)
+        self.assertIn("worker.concurrency  u16          ..  -  worker", out)
+        self.assertIn("loader variables", out)
+        self.assertIn("external variables", out)
+        self.assertIn("PORT", out)
+
+
+class TestJsonOutput(ChartFixture):
+    def emit(self, *argv: str) -> tuple[int, dict]:
+        out = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(io.StringIO()):
+            status = explain.main(list(argv) + ["--json"])
+        return status, json.loads(out.getvalue())
+
+    def setUp(self):
+        self.chart = self.build(("api", "api", API_DIGEST), ("worker", "worker", WORKER_DIGEST))
+        self.root = str(self.chart.parent)
+
+    def test_the_selection_carries_the_readers_and_the_derived_readings(self):
+        _, document = self.emit("demo", "database.url", "--charts", self.root)
+        (key,) = document["keys"]
+        self.assertEqual(key["readers"], ["api", "worker"])
+        self.assertEqual(key["text_form"], "text")
+        self.assertTrue(key["file_supplyable"])
+
+    def test_a_key_no_file_can_supply_says_so_to_a_machine_too(self):
+        _, document = self.emit("demo", "auth.session_ttl", "--charts", self.root)
+        (key,) = document["keys"]
+        self.assertEqual(key["text_form"], "integer")
+        self.assertFalse(key["file_supplyable"])
+
+    def test_the_images_carry_their_provenance(self):
+        _, document = self.emit("demo", "--charts", self.root)
+        self.assertEqual([image["name"] for image in document["images"]], ["api", "worker"])
+        self.assertEqual(document["images"][0]["digest"], API_DIGEST)
+        self.assertEqual(document["dialect"]["prefix"], "FIXTURE_")
+
+    def test_external_and_loader_variables_are_their_own_sections(self):
+        _, document = self.emit("demo", "--charts", self.root)
+        self.assertEqual([item["name"] for item in document["external"]], ["PORT"])
+        self.assertEqual(
+            [item["env"] for item in document["loader"]],
+            ["FIXTURE_CONFIG", "FIXTURE_SECRETS_DIR"],
+        )
+
+    def test_nothing_but_json_reaches_stdout_so_a_pipe_stays_usable(self):
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            explain.main(["demo", "--charts", self.root, "--json"])
+        json.loads(out.getvalue())
+
+    def test_a_pattern_matching_nothing_still_emits_a_document_and_fails(self):
+        # The status is the answer; the document is what a pipeline downstream still has to
+        # parse, so it is emitted either way.
+        status, document = self.emit("demo", "zzz", "--charts", self.root)
+        self.assertEqual(status, 1)
+        self.assertEqual(document["keys"], [])
+
+
+class TestUnionIsNotReused(ChartFixture):
+    """Why this command merges for itself rather than calling `cc.union_contracts`.
+
+    Two of a chart's documents legitimately carry different `json_schema.title` — they are
+    different files read by different binaries — and `union_contracts` is right to refuse that
+    pair, because its output is a schema one document is validated against. Reusing it across a
+    chart's documents would mean `just explain tankovault` printing nothing at all, so this is
+    the measurement behind that decision rather than an assumption about it.
+    """
+
+    def test_two_documents_cannot_be_unioned_but_can_be_explained(self):
+        with self.assertRaises(cc.ContractError):
+            cc.union_contracts([("api", fixture("api")), ("other", fixture("foreign-dialect"))])
+
+        chart = self.build(("api", "api", API_DIGEST), ("worker", "worker", WORKER_DIGEST))
+        surface, _ = self.collect(chart)
+        self.assertEqual(len(surface.readers), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/just/contracts.just
+++ b/just/contracts.just
@@ -142,3 +142,46 @@ test-contract-union:
     set -euo pipefail
     {{ resolve_python }}
     "$python" -m unittest discover -s {{ scripts }}/tests -p 'test_contract_*.py' -v
+
+# --------------------------------------------------------------------------------------------
+# Reading a contract, rather than checking against one
+# --------------------------------------------------------------------------------------------
+
+# Explain what a chart's pinned images read: every setting, its spellings, and which image reads it.
+#
+# Every other recipe in this group is a gate — it holds a rendered manifest against a contract and
+# reports the difference. None of them ever shows a contributor what the contract *says*, and the
+# vendored file is the only place in this repository that states, per setting, what the binary
+# calls it, what values it accepts, whether it is required, whether a file may supply it and what
+# happens when nothing sets it. Answering "what can I put in `config.toml`, and why is the value I
+# set being ignored?" out of a 400 KB JSON document is the job.
+#
+# The reader attribution is the part worth having. `tankovault` pins nine images across nine
+# documents, and which of them reads a given setting is stated nowhere else: not in the chart, not
+# in `config-contract.yaml`, not in the README. It is derived from the contracts the declaration
+# binds, so it cannot go stale against them — a bump that moves a setting from one service to
+# another moves this output with it — and it is how an operator tells a local change from a
+# fleet-wide one before making it.
+#
+# Offline and read-only, like every recipe here but the refresh, and honouring the same staleness
+# interlock the gates do: a contract that is not for the digest the chart pins describes some
+# other build, and a confident wrong answer is worse here than in a gate, because nothing
+# downstream re-checks what a person was told.
+#
+# Deliberately NOT in `just check`. It asserts nothing — it prints — and a recipe that cannot fail
+# has no business in an aggregate whose whole output is a pass or a fail.
+#
+# `just explain` alone lists the charts that have a contract. A second argument selects by
+# substring, or by glob when it carries one, over the setting's path and prints the full entry for
+# each match; `--full` does that without a pattern and `--json` emits the same selection for
+# something other than a person. A pattern matching nothing exits non-zero, which is `grep`'s
+# convention and the reason is in the script's docstring: an answer indistinguishable from a typo
+# in the pattern is not an answer.
+[doc("Explain what a chart's pinned images read: settings, spellings, and which image reads which")]
+[group('contracts')]
+explain chart='' pattern='' *flags:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    {{ resolve_python }}
+    "$python" {{ scripts }}/explain-config.py '{{ chart }}' '{{ pattern }}' \
+      --charts {{ charts }} {{ flags }}


### PR DESCRIPTION
Adds `just explain <chart> [pattern]` — offline, read-only introspection over the vendored configuration contracts. No render, no network.

## Why

491 key declarations are vendored under `charts/*/contracts/` and nothing surfaces them. For a multi-image chart, *which image reads which key* exists nowhere else in the repository — and 68 of TankoVault's 167 paths appear nowhere in the chart at all, reachable only by typing them blind into `config: {}`.

## What it shows

- Compact table by default; full entries for a pattern match or `--full`; `--json` for automation.
- Per key: type, `text_form`, required/secret, default, enum values, readable constraint prose, the environment and `_FILE` spellings, the secrets-file name, and **the images that read it**.
- Whether a mounted file can supply the key at all, via `cc.file_supplyable` — the `_FILE` and secrets-file spellings are printed for every key and work for none but a `text` one.
- Loader variables and `external.env` in their own sections. The latter matters: those are read by the image and are nobody's configuration, so a value set there and expected to reach the application is a value that is ignored.
- Exit status: 0 printed, 1 pattern matched nothing (grep's convention), 2 unknown chart, 3 staleness interlock refused.

## Verification

`just test-contract-union` — 187 passing on this branch (135 pre-existing + 48 new). Exercised against `portfolio` (7 keys, 1 image) and `tankovault` (167 paths, 9 images).

## Findings surfaced while building it

- **TankoVault declares nine documents, not one.** Each has its own per-component ConfigMap and exactly one image, so `union_contracts` is always the identity and has no production user. The repository's prose says otherwise in five places; corrected separately, not here.
- **TankoVault publishes no defaults at all** — 0 of 454 declarations, against 22 of 37 for the other five charts. Producer-side question.
- **Seven keys are documented inconsistently across images.** `bind_addr` is described three ways, six of them an empty string. Because each document has one reader, nothing ever compares them.

## Review notes

- 979 lines in one entry-point script. The rendering layer (~390 lines) is a separate concern and the repo already has the split pattern — `check-config.py` is 319 lines with seven supporting modules. Worth extracting before merge.
- Appends to `just/contracts.just`, as do the three sibling PRs; expect a trivial positional conflict.