### PR TITLE
feat(scripts): report how a chart's configuration contract changed

### DIFF
--- a/.github/scripts/config_diff.py
+++ b/.github/scripts/config_diff.py
@@ -1,0 +1,1000 @@
+#!/usr/bin/env python3
+"""What changed between two versions of a vendored contract, and what it costs the chart.
+
+Renovate opens a pull request that repins a digest, the Documentation job runs `just contracts`
+into the same branch, and the reviewer is handed several hundred lines of reordered JSON. The
+question they actually have — did the application gain a setting the chart has to write, drop one
+the chart still writes, or move a default out from under it — is answerable from those bytes and
+nobody answers it. This module turns the two documents into that answer, and into a defensible
+suggestion about the chart's own version number.
+
+Pure and offline: it takes two parsed documents and returns findings. Reading the old bytes out of
+git, walking the charts and printing anything belongs to `contract-diff.py`, which is what lets
+every rule in here be tested by calling it.
+
+Four decisions in here are deliberate rather than incidental.
+
+**This does not run `check_envelope`.** Every other consumer of a vendored contract refuses a
+document whose `terrace_contract` it does not recognise, which is right for a gate: misreading a
+document is worse than not reading it. It is wrong here, because "the envelope version changed"
+is one of the findings this tool exists to report, and a tool that crashes on the one document it
+most needs to describe is useless on the day it matters. So both sides are read defensively,
+field by field, and an envelope this repository could not validate is reported as the major
+change it is.
+
+**The severity table is a suggestion with its reasons attached, never an edit.** `SUGGESTION` maps
+a finding to the smallest chart version bump that finding justifies, and the chart's impact is the
+largest of them. Nothing here writes `Chart.yaml`: the mapping is a defensible default and the
+reviewer is the one who knows whether the chart writes the key that moved. A tool that edited the
+version would be asserting it knows that, and would be wrong the first time a removed key was one
+no template ever emitted.
+
+**Removing something is graded by what the loader does next, not by the shape of the diff.**
+`external.unknown` is `reject` across every contract in this repository, so an unrecognised
+variable is a boot failure rather than a no-op. A removed *key* falls to step 4 of
+`config_contract.classify` — inside the prefix and spelling nothing — which sits above both
+external lists, so nothing can absorb it and it is always major. A removed *external* entry falls
+past step 4 to the ignore patterns, so it is major only when no surviving pattern catches it; that
+downgrade is decided by calling `matches_ignore` rather than by a second opinion about the
+language.
+
+**Rename detection is deliberately absent.** A renamed key would arrive here as one removal and
+one addition — a major finding and a minor one, for a change that is neither. The producer's
+`aliases`, `env_aliases`, `env_file_aliases` and `secrets_file_aliases` are what would collapse
+the pair, and they are empty in all 491 key declarations this repository vendors today, so any
+rename detector written now would be untestable against a real document. The model is shaped so
+that it becomes a small addition rather than a rewrite: `Change.kind` is a string with `RENAMED`
+reserved beside `ADDED` and `REMOVED`, and the alias fields are already compared, so the whole
+addition is one pass over the added keys looking for a removed key's path among their aliases,
+collapsing the pair into one `RENAMED` change. Until a producer populates the field there is
+nothing to collapse and the pass would only ever be dead code.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any, Iterable
+
+import config_contract as cc
+
+# --------------------------------------------------------------------------------------------
+# Severity
+# --------------------------------------------------------------------------------------------
+
+# The three semver impacts a finding can justify, plus the absence of any change. Ordered, because
+# a chart's impact is the largest of its findings and a contract's is the largest of its changes.
+MAJOR = "major"
+MINOR = "minor"
+PATCH = "patch"
+NONE = "none"
+
+RANK = {NONE: 0, PATCH: 1, MINOR: 2, MAJOR: 3}
+
+
+def worst(severities: Iterable[str]) -> str:
+    """The largest impact in a set of findings, or `none` for an empty one."""
+    return max(severities, key=lambda level: RANK[level], default=NONE)
+
+
+# What each area of the document is, for a reader scanning one column of output.
+ENVELOPE = "envelope"
+LOADER = "loader"
+KEY = "key"
+EXTERNAL = "external"
+
+# What happened to a subject. `RENAMED` is reserved rather than emitted — see the module
+# docstring for why nothing can produce it yet and what would.
+ADDED = "added"
+REMOVED = "removed"
+CHANGED = "changed"
+RENAMED = "renamed"
+
+# What happened to a whole contract file between the two revisions.
+STATUS_ADDED = "added"
+STATUS_REMOVED = "removed"
+STATUS_CHANGED = "changed"
+STATUS_UNCHANGED = "unchanged"
+
+
+@dataclass(frozen=True)
+class Change:
+    """One difference, and the smallest chart version bump it justifies.
+
+    `area`, `kind`, `subject` and `field` are the machine-readable half — enough for a pull
+    request comment to group findings without parsing English — and `message` is the sentence a
+    reviewer reads. `old` and `new` are the raw JSON values, so a consumer that wants to render a
+    before/after does not have to recover them from the prose.
+    """
+
+    severity: str
+    area: str
+    kind: str
+    subject: str
+    field: str | None
+    old: Any
+    new: Any
+    message: str
+
+    def as_json(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ContractDiff:
+    """One `charts/<chart>/contracts/<name>.json`, across the two revisions."""
+
+    chart: str
+    name: str
+    path: str
+    status: str
+    changes: list[Change] = field(default_factory=list)
+    old_image: str | None = None
+    new_image: str | None = None
+
+    @property
+    def impact(self) -> str:
+        return worst(change.severity for change in self.changes)
+
+    def as_json(self) -> dict[str, Any]:
+        return {
+            "chart": self.chart,
+            "name": self.name,
+            "path": self.path,
+            "status": self.status,
+            "impact": self.impact,
+            "image": {"old": self.old_image, "new": self.new_image},
+            "changes": [change.as_json() for change in self.changes],
+        }
+
+
+@dataclass
+class ChartDiff:
+    """Every contract a chart carries, and what the set of them implies for its version.
+
+    `old_version` and `new_version` are the chart's own `Chart.yaml` version at the comparison
+    revision and in the working tree. Reporting both is what turns the suggestion into a review
+    finding: the reviewer's real question is not "what bump does this deserve" but "is the bump
+    already in this branch big enough", and only the pair answers that.
+    """
+
+    chart: str
+    contracts: list[ContractDiff] = field(default_factory=list)
+    old_version: str | None = None
+    new_version: str | None = None
+
+    @property
+    def impact(self) -> str:
+        return worst(contract.impact for contract in self.contracts)
+
+    @property
+    def drivers(self) -> list[Change]:
+        """The findings that set the impact — the "because" the suggestion is shown with."""
+        level = self.impact
+        if level == NONE:
+            return []
+        return [
+            change
+            for contract in self.contracts
+            for change in contract.changes
+            if change.severity == level
+        ]
+
+    def as_json(self) -> dict[str, Any]:
+        return {
+            "chart": self.chart,
+            "impact": self.impact,
+            # References rather than copies: every driver is already in `contracts`, and a
+            # driver is an added or removed declaration whose full entry is the largest object in
+            # the document. A headline paragraph needs the sentence and the name, not the entry.
+            "drivers": [
+                {
+                    "area": change.area,
+                    "kind": change.kind,
+                    "subject": change.subject,
+                    "field": change.field,
+                    "message": change.message,
+                }
+                for change in self.drivers
+            ],
+            "version": {
+                "old": self.old_version,
+                "new": self.new_version,
+                "bumped": self.old_version != self.new_version,
+                "suggested": suggest_version(self.new_version, self.impact),
+                "satisfied": self.satisfied,
+            },
+            "contracts": [contract.as_json() for contract in self.contracts],
+        }
+
+    @property
+    def satisfied(self) -> bool | None:
+        """Whether the bump already in the branch is at least as large as the suggested one.
+
+        `None` when it cannot be decided — an unparseable version, or a chart whose `Chart.yaml`
+        did not exist at the comparison revision.
+        """
+        if self.impact == NONE:
+            return True
+        observed = observed_bump(self.old_version, self.new_version)
+        if observed is None:
+            return None
+        return RANK[observed] >= RANK[self.impact]
+
+
+# --------------------------------------------------------------------------------------------
+# The chart's own version
+# --------------------------------------------------------------------------------------------
+
+
+def parse_version(version: str | None) -> tuple[int, int, int] | None:
+    """The `major.minor.patch` of a chart version, or `None` if it is not one.
+
+    Deliberately not a full semver parser: chart versions in this repository are three integers,
+    and a pre-release or build suffix is a case that has never occurred here. Returning `None`
+    rather than guessing keeps the suggestion honest — a version this cannot read produces no
+    suggestion instead of a wrong one.
+    """
+    if not isinstance(version, str):
+        return None
+    parts = version.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        major, minor, patch = (int(part) for part in parts)
+    except ValueError:
+        return None
+    if major < 0 or minor < 0 or patch < 0:
+        return None
+    return major, minor, patch
+
+
+def suggest_version(current: str | None, impact: str) -> str | None:
+    """The version the suggested impact would produce from the working tree's current one."""
+    parsed = parse_version(current)
+    if parsed is None or impact == NONE:
+        return None
+    major, minor, patch = parsed
+    if impact == MAJOR:
+        return f"{major + 1}.0.0"
+    if impact == MINOR:
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def observed_bump(old: str | None, new: str | None) -> str | None:
+    """Which component of the chart version already moved between the two revisions."""
+    before, after = parse_version(old), parse_version(new)
+    if before is None or after is None:
+        return None
+    if after[0] != before[0]:
+        return MAJOR
+    if after[1] != before[1]:
+        return MINOR
+    if after[2] != before[2]:
+        return PATCH
+    return NONE
+
+
+# --------------------------------------------------------------------------------------------
+# Comparing one contract
+# --------------------------------------------------------------------------------------------
+
+# Per-field severity for a key that exists on both sides. Three groups, and the reasoning for each
+# is the same reasoning the gates in `check-config.py` apply at deployment time:
+#
+#   major   the chart's own spelling of the setting stopped being the one the image reads. A
+#           `env` / `env_file` / `secrets_file` change is derived from the path and the dialect,
+#           so it should be unreachable without one of those moving — and if it happens anyway it
+#           is exactly as severe as a dialect change, which is the most severe thing here.
+#   minor   the value the chart writes is still spelled right but may no longer be accepted, or a
+#           default moved out from under a chart that relied on it.
+#   patch   prose. Real, and not a reason to bump anything.
+#
+# `required` and `text_form` are absent because neither is a fixed severity; both are graded by
+# direction below.
+KEY_FIELDS = {
+    "env": MAJOR,
+    "env_file": MAJOR,
+    "secrets_file": MAJOR,
+    "ty": MINOR,
+    "values": MINOR,
+    "constraint": MINOR,
+    "text_constraint": MINOR,
+    "secret": MINOR,
+    "reserved": MINOR,
+    "aliases": MINOR,
+    "env_aliases": MINOR,
+    "env_file_aliases": MINOR,
+    "secrets_file_aliases": MINOR,
+    "docs": PATCH,
+    "note": PATCH,
+}
+
+# An external variable carries a smaller entry, and its spellings are its own name rather than
+# something derived — so there is no equivalent of the major group here.
+EXTERNAL_FIELDS = {
+    "owner": PATCH,
+    "ty": MINOR,
+    "values": MINOR,
+    "constraint": MINOR,
+    "text_constraint": MINOR,
+    "secret": MINOR,
+    "docs": PATCH,
+}
+
+# Compared as a pair rather than as two fields: `default` is the text the loader would use and
+# `default_value` is that text parsed, so they move together and reporting both is one fact
+# printed twice.
+DEFAULT_FIELDS = ("default", "default_value")
+
+# Fields a key entry carries that are compared by name above, plus the ones handled specially.
+# Anything outside the union is a field the producer added under an envelope version this
+# repository still claims to read, and it is reported rather than dropped: a diff that silently
+# ignores what it does not recognise is the failure mode this whole pipeline exists to remove.
+KEY_KNOWN = set(KEY_FIELDS) | set(DEFAULT_FIELDS) | {"path", "required", "text_form"}
+EXTERNAL_KNOWN = set(EXTERNAL_FIELDS) | {"name", "default", "required", "text_form"}
+
+
+def diff_contract(
+    chart: str,
+    name: str,
+    path: str,
+    old: dict[str, Any] | None,
+    new: dict[str, Any] | None,
+) -> ContractDiff:
+    """Compare two vendored documents — the `{source, contract}` envelope, not the contract alone.
+
+    Either side may be `None`: a contract that did not exist at the comparison revision, or one
+    the working tree no longer carries. Both are ordinary outcomes of a refresh rather than
+    errors, and both are graded — gaining coverage is minor, losing it is major.
+    """
+    if old is None and new is None:
+        raise ValueError(f"{path}: compared two absent documents")
+
+    if old is None:
+        diff = ContractDiff(chart, name, path, STATUS_ADDED, new_image=_source(new, "image"))
+        diff.changes.append(
+            Change(
+                MINOR,
+                ENVELOPE,
+                ADDED,
+                name,
+                None,
+                None,
+                _source(new, "image"),
+                f"contract is new: {_source(new, 'image')} publishes a document this chart did "
+                f"not vendor before, so its settings are gated from now on",
+            )
+        )
+        return diff
+
+    if new is None:
+        diff = ContractDiff(chart, name, path, STATUS_REMOVED, old_image=_source(old, "image"))
+        diff.changes.append(
+            Change(
+                MAJOR,
+                ENVELOPE,
+                REMOVED,
+                name,
+                None,
+                _source(old, "image"),
+                None,
+                "contract is gone: nothing validates the settings this document covered, and a "
+                "chart that still writes them is no longer checked against anything",
+            )
+        )
+        return diff
+
+    changes: list[Change] = []
+    changes += _diff_source(old, new)
+    changes += _diff_envelope(_contract(old), _contract(new))
+    changes += _diff_loader(_contract(old), _contract(new))
+    key_changes = _diff_keys(_contract(old), _contract(new))
+    changes += key_changes
+    changes += _diff_external(_contract(old), _contract(new))
+
+    # The published JSON Schema is derived from the keys, so it moves whenever they do and saying
+    # so again would be noise. It is worth a line in exactly one case: it moved and the keys did
+    # not, which means the document changed in a way nothing above models.
+    if not key_changes and _contract(old).get("json_schema") != _contract(new).get("json_schema"):
+        changes.append(
+            Change(
+                PATCH,
+                ENVELOPE,
+                CHANGED,
+                "json_schema",
+                None,
+                None,
+                None,
+                "the published JSON Schema changed while no key declaration did; this diff does "
+                "not model whatever moved, so read the raw document",
+            )
+        )
+
+    status = STATUS_CHANGED if changes else STATUS_UNCHANGED
+    return ContractDiff(
+        chart,
+        name,
+        path,
+        status,
+        changes,
+        old_image=_source(old, "image"),
+        new_image=_source(new, "image"),
+    )
+
+
+def _source(document: dict[str, Any] | None, name: str) -> Any:
+    source = (document or {}).get("source")
+    return source.get(name) if isinstance(source, dict) else None
+
+
+def _contract(document: dict[str, Any]) -> dict[str, Any]:
+    contract = document.get("contract")
+    return contract if isinstance(contract, dict) else {}
+
+
+def _diff_source(old: dict[str, Any], new: dict[str, Any]) -> list[Change]:
+    """The provenance envelope the chart repository writes, not the published document.
+
+    `fetched` is not compared: `refresh-contracts.py` refuses to rewrite a file whose only
+    difference is that timestamp, so a `fetched` that moved is always accompanied by something
+    that matters, and reporting it would manufacture a finding out of a field the producer already
+    treats as noise. `sha256` is not compared either — it is over the published bytes, so it is
+    true exactly when something below is, and it names nothing.
+    """
+    changes: list[Change] = []
+    if _source(old, "image") != _source(new, "image"):
+        changes.append(
+            Change(
+                MINOR,
+                ENVELOPE,
+                CHANGED,
+                "source.image",
+                "image",
+                _source(old, "image"),
+                _source(new, "image"),
+                f"the chart pins a different image: {_source(old, 'image')} -> "
+                f"{_source(new, 'image')}",
+            )
+        )
+    if _source(old, "digest") != _source(new, "digest"):
+        changes.append(
+            Change(
+                PATCH,
+                ENVELOPE,
+                CHANGED,
+                "source.digest",
+                "digest",
+                _source(old, "digest"),
+                _source(new, "digest"),
+                f"image digest {_short(_source(old, 'digest'))} -> "
+                f"{_short(_source(new, 'digest'))}",
+            )
+        )
+    return changes
+
+
+def _diff_envelope(old: dict[str, Any], new: dict[str, Any]) -> list[Change]:
+    """The published document's own identity: its version, the application, and the dialect."""
+    changes: list[Change] = []
+
+    if old.get("terrace_contract") != new.get("terrace_contract"):
+        changes.append(
+            Change(
+                MAJOR,
+                ENVELOPE,
+                CHANGED,
+                "terrace_contract",
+                None,
+                old.get("terrace_contract"),
+                new.get("terrace_contract"),
+                f"envelope version {old.get('terrace_contract')!r} -> "
+                f"{new.get('terrace_contract')!r}; this repository reads "
+                f"{cc.ENVELOPE_VERSION}, so every gate reading this document is affected",
+            )
+        )
+
+    old_app = old.get("app") if isinstance(old.get("app"), dict) else {}
+    new_app = new.get("app") if isinstance(new.get("app"), dict) else {}
+    for name, severity in (("name", MINOR), ("version", PATCH), ("source", PATCH)):
+        if old_app.get(name) != new_app.get(name):
+            changes.append(
+                Change(
+                    severity,
+                    ENVELOPE,
+                    CHANGED,
+                    f"app.{name}",
+                    name,
+                    old_app.get(name),
+                    new_app.get(name),
+                    f"app.{name} {old_app.get(name)!r} -> {new_app.get(name)!r}",
+                )
+            )
+
+    old_schema = old.get("schema") if isinstance(old.get("schema"), dict) else {}
+    new_schema = new.get("schema") if isinstance(new.get("schema"), dict) else {}
+    if old_schema.get("schema_version") != new_schema.get("schema_version"):
+        changes.append(
+            Change(
+                MAJOR,
+                ENVELOPE,
+                CHANGED,
+                "schema.schema_version",
+                None,
+                old_schema.get("schema_version"),
+                new_schema.get("schema_version"),
+                f"schema version {old_schema.get('schema_version')!r} -> "
+                f"{new_schema.get('schema_version')!r}",
+            )
+        )
+
+    # The single most severe thing this tool can find. The prefix, the nesting separator and the
+    # indirection suffix are what every environment variable name and every secret file name the
+    # chart writes is built from, so one character moving here renames all of them at once — and
+    # every one of the old names lands on step 4 of `classify`, which `external.unknown: reject`
+    # turns into a pod that does not start. Nothing in the rendered manifests looks different.
+    old_dialect = old_schema.get("dialect") if isinstance(old_schema.get("dialect"), dict) else {}
+    new_dialect = new_schema.get("dialect") if isinstance(new_schema.get("dialect"), dict) else {}
+    for name in ("prefix", "nesting_separator", "indirection_suffix"):
+        if old_dialect.get(name) != new_dialect.get(name):
+            changes.append(
+                Change(
+                    MAJOR,
+                    ENVELOPE,
+                    CHANGED,
+                    f"dialect.{name}",
+                    name,
+                    old_dialect.get(name),
+                    new_dialect.get(name),
+                    f"dialect {name} {old_dialect.get(name)!r} -> {new_dialect.get(name)!r}; "
+                    f"every environment and secret-file spelling this chart writes is derived "
+                    f"from it, so all of them change at once and none of them renders differently",
+                )
+            )
+
+    old_external = old.get("external") if isinstance(old.get("external"), dict) else {}
+    new_external = new.get("external") if isinstance(new.get("external"), dict) else {}
+    if old_external.get("unknown") != new_external.get("unknown"):
+        # Tightening is what breaks a running deployment: a variable the image used to tolerate
+        # now stops it from booting. Relaxing can only turn a rejection into acceptance.
+        tightened = new_external.get("unknown") == "reject"
+        changes.append(
+            Change(
+                MAJOR if tightened else MINOR,
+                ENVELOPE,
+                CHANGED,
+                "external.unknown",
+                None,
+                old_external.get("unknown"),
+                new_external.get("unknown"),
+                f"unknown-variable policy {old_external.get('unknown')!r} -> "
+                f"{new_external.get('unknown')!r}",
+            )
+        )
+
+    for kind, name in _list_delta(old_external.get("ignore"), new_external.get("ignore")):
+        changes.append(
+            Change(
+                MINOR,
+                ENVELOPE,
+                kind,
+                f"ignore {name}",
+                "ignore",
+                name if kind == REMOVED else None,
+                name if kind == ADDED else None,
+                f"ignore pattern {name!r} {kind}",
+            )
+        )
+
+    return changes
+
+
+def _diff_loader(old: dict[str, Any], new: dict[str, Any]) -> list[Change]:
+    """The variables that tell the loader where its layers are.
+
+    These are the variables the chart sets to point the image at its ConfigMap and its mounted
+    Secret. A renamed or removed one is not a validation failure anywhere — the chart keeps
+    setting the old name, the pod keeps starting, and the application silently loads none of the
+    configuration the chart mounted. That is why a removal here is graded with a dialect change
+    rather than with a key change.
+    """
+    old_entries = _by(old.get("schema"), "loader", "env")
+    new_entries = _by(new.get("schema"), "loader", "env")
+    changes: list[Change] = []
+
+    for name in sorted(set(new_entries) - set(old_entries)):
+        entry = new_entries[name]
+        changes.append(
+            Change(
+                MINOR,
+                LOADER,
+                ADDED,
+                name,
+                None,
+                None,
+                entry,
+                f"loader variable {name} added (role {entry.get('role')!r})",
+            )
+        )
+    for name in sorted(set(old_entries) - set(new_entries)):
+        entry = old_entries[name]
+        changes.append(
+            Change(
+                MAJOR,
+                LOADER,
+                REMOVED,
+                name,
+                None,
+                entry,
+                None,
+                f"loader variable {name} (role {entry.get('role')!r}) is gone; a chart still "
+                f"setting it points the image at a layer it no longer reads, and nothing fails",
+            )
+        )
+    for name in sorted(set(old_entries) & set(new_entries)):
+        before, after = old_entries[name], new_entries[name]
+        for field_name, severity in (("role", MAJOR), ("default", MINOR), ("docs", PATCH)):
+            if before.get(field_name) != after.get(field_name):
+                changes.append(
+                    Change(
+                        severity,
+                        LOADER,
+                        CHANGED,
+                        name,
+                        field_name,
+                        before.get(field_name),
+                        after.get(field_name),
+                        f"loader variable {name}: {field_name} {before.get(field_name)!r} -> "
+                        f"{after.get(field_name)!r}",
+                    )
+                )
+    return changes
+
+
+def _diff_keys(old: dict[str, Any], new: dict[str, Any]) -> list[Change]:
+    """The key declarations — the half of the document a chart's rendered settings answer to."""
+    old_keys = _by(old.get("schema"), "keys", "path")
+    new_keys = _by(new.get("schema"), "keys", "path")
+    changes: list[Change] = []
+
+    for path in sorted(set(new_keys) - set(old_keys)):
+        entry = new_keys[path]
+        # A new *required* key is the same deployment failure as one that became required: the
+        # chart does not write it, and the image refuses to start without it. The stated rule
+        # calls an added key minor, which is right for the optional case and wrong for this one.
+        required = bool(entry.get("required"))
+        changes.append(
+            Change(
+                MAJOR if required else MINOR,
+                KEY,
+                ADDED,
+                path,
+                None,
+                None,
+                entry,
+                f"{path} added ({_shape(entry)}); the chart writes nothing for it"
+                + (
+                    ", and it is required, so the image will not start until the chart does"
+                    if required
+                    else ""
+                ),
+            )
+        )
+
+    for path in sorted(set(old_keys) - set(new_keys)):
+        entry = old_keys[path]
+        # No downgrade is possible. The old spelling still begins with the prefix, so `classify`
+        # stops at step 4 — above both external lists — and `external.unknown: reject` turns it
+        # into a container that does not start.
+        changes.append(
+            Change(
+                MAJOR,
+                KEY,
+                REMOVED,
+                path,
+                None,
+                entry,
+                None,
+                f"{path} is gone; a chart still emitting {entry.get('env')} or mounting "
+                f"{entry.get('secrets_file')} is refused at boot, not ignored",
+            )
+        )
+
+    for path in sorted(set(old_keys) & set(new_keys)):
+        changes += _diff_entry(KEY, path, old_keys[path], new_keys[path], KEY_FIELDS, KEY_KNOWN)
+
+    return changes
+
+
+def _diff_external(old: dict[str, Any], new: dict[str, Any]) -> list[Change]:
+    """The variables the image reads that are nobody's configuration — `PORT`, `RUST_LOG`.
+
+    A removal is graded by what `classify` does with the name afterwards. Having fallen past the
+    prefix step, it reaches the ignore patterns, so a surviving pattern that matches absorbs it
+    and the removal costs nothing; with no pattern matching, it reaches `external.unknown` and a
+    chart still setting it stops booting.
+    """
+    old_env = _by(old.get("external"), "env", "name")
+    new_env = _by(new.get("external"), "env", "name")
+    policy = (new.get("external") or {}).get("unknown")
+    patterns = [
+        pattern
+        for pattern in ((new.get("external") or {}).get("ignore") or [])
+        if isinstance(pattern, str)
+    ]
+    changes: list[Change] = []
+
+    for name in sorted(set(new_env) - set(old_env)):
+        entry = new_env[name]
+        required = bool(entry.get("required"))
+        changes.append(
+            Change(
+                MAJOR if required else MINOR,
+                EXTERNAL,
+                ADDED,
+                name,
+                None,
+                None,
+                entry,
+                f"external variable {name} added, owned by {entry.get('owner')!r}"
+                + (" and required" if required else ""),
+            )
+        )
+
+    for name in sorted(set(old_env) - set(new_env)):
+        absorbed = any(cc.matches_ignore(pattern, name) for pattern in patterns)
+        rejected = policy == "reject" and not absorbed
+        changes.append(
+            Change(
+                MAJOR if rejected else MINOR,
+                EXTERNAL,
+                REMOVED,
+                name,
+                None,
+                old_env[name],
+                None,
+                f"external variable {name} is no longer declared; "
+                + (
+                    f"a chart still setting it is refused at boot (external.unknown is "
+                    f"{policy!r})"
+                    if rejected
+                    else "a surviving ignore pattern still absorbs it"
+                    if absorbed
+                    else f"the image's unknown-variable policy is {policy!r}"
+                ),
+            )
+        )
+
+    for name in sorted(set(old_env) & set(new_env)):
+        changes += _diff_entry(
+            EXTERNAL, name, old_env[name], new_env[name], EXTERNAL_FIELDS, EXTERNAL_KNOWN
+        )
+
+    return changes
+
+
+def _diff_entry(
+    area: str,
+    subject: str,
+    old: dict[str, Any],
+    new: dict[str, Any],
+    fields: dict[str, str],
+    known: set[str],
+) -> list[Change]:
+    """One declaration that exists on both sides, field by field."""
+    changes: list[Change] = []
+
+    for name, severity in sorted(fields.items()):
+        if old.get(name) != new.get(name):
+            changes.append(
+                Change(
+                    severity,
+                    area,
+                    CHANGED,
+                    subject,
+                    name,
+                    old.get(name),
+                    new.get(name),
+                    f"{subject}: {name} {_render(old.get(name))} -> {_render(new.get(name))}",
+                )
+            )
+
+    changes += _diff_required(area, subject, old, new)
+    changes += _diff_text_form(area, subject, old, new)
+    changes += _diff_default(area, subject, old, new)
+
+    # A field the producer added that this diff has no opinion about. Reported at patch so it is
+    # visible without claiming a severity nobody has reasoned about.
+    for name in sorted((set(old) | set(new)) - known):
+        if old.get(name) != new.get(name):
+            changes.append(
+                Change(
+                    PATCH,
+                    area,
+                    CHANGED,
+                    subject,
+                    name,
+                    old.get(name),
+                    new.get(name),
+                    f"{subject}: {name} changed, and this diff models no severity for that "
+                    f"field: {_render(old.get(name))} -> {_render(new.get(name))}",
+                )
+            )
+
+    return changes
+
+
+def _diff_required(
+    area: str, subject: str, old: dict[str, Any], new: dict[str, Any]
+) -> list[Change]:
+    """`required` is graded by direction: gaining it breaks a chart, losing it cannot."""
+    before, after = bool(old.get("required")), bool(new.get("required"))
+    if before == after:
+        return []
+    if after:
+        return [
+            Change(
+                MAJOR,
+                area,
+                CHANGED,
+                subject,
+                "required",
+                before,
+                after,
+                f"{subject} is now required; a chart that does not write it will not start",
+            )
+        ]
+    return [
+        Change(
+            MINOR,
+            area,
+            CHANGED,
+            subject,
+            "required",
+            before,
+            after,
+            f"{subject} is no longer required",
+        )
+    ]
+
+
+def _diff_text_form(
+    area: str, subject: str, old: dict[str, Any], new: dict[str, Any]
+) -> list[Change]:
+    """`text_form` decides the parse, and with it whether a file can supply the setting at all.
+
+    The escalation is the point. A file — the secrets directory or `_FILE` indirection — delivers
+    its contents as a string with no parse, so only a `text` key can be supplied by one. A key
+    that moves from `text` to `integer` is still spelled the same and still renders the same, and
+    the Secret the chart mounts for it stops loading. The stated severity table has no rule for
+    `text_form` at all; graded flat it would be minor, which is wrong for exactly this case.
+    """
+    before, after = old.get("text_form"), new.get("text_form")
+    if before == after:
+        return []
+
+    lost_file = _file_supplyable(old) and not _file_supplyable(new)
+    return [
+        Change(
+            MAJOR if lost_file else MINOR,
+            area,
+            CHANGED,
+            subject,
+            "text_form",
+            before,
+            after,
+            f"{subject}: text_form {before!r} -> {after!r}"
+            + (
+                "; it can no longer be supplied by a mounted file, because a file delivers text "
+                "and the loader does not coerce it"
+                if lost_file
+                else ""
+            ),
+        )
+    ]
+
+
+def _file_supplyable(entry: dict[str, Any]) -> bool:
+    """`config_contract`'s rule, tolerating an entry this repository could not otherwise read.
+
+    The gates are right to refuse an unknown `text_form` outright. Here a document carrying one is
+    the thing being described, so the question "could a file supply this" simply has no answer and
+    `False` is the safe one: it cannot produce a false major, only miss one.
+    """
+    try:
+        return cc.file_supplyable(entry)
+    except cc.ContractError:
+        return False
+
+
+def _diff_default(
+    area: str, subject: str, old: dict[str, Any], new: dict[str, Any]
+) -> list[Change]:
+    """`default` and `default_value` are one fact — the text, and that text parsed.
+
+    Compared as a pair because they move together, and reporting both is one change printed
+    twice. A moved default is minor rather than patch: a chart that deliberately writes nothing
+    for a key is relying on the value the image chooses, and the value it chooses just changed.
+    """
+    before = tuple(old.get(name) for name in DEFAULT_FIELDS)
+    after = tuple(new.get(name) for name in DEFAULT_FIELDS)
+    if before == after:
+        return []
+    return [
+        Change(
+            MINOR,
+            area,
+            CHANGED,
+            subject,
+            "default",
+            {name: old.get(name) for name in DEFAULT_FIELDS},
+            {name: new.get(name) for name in DEFAULT_FIELDS},
+            f"{subject}: default {_render(before[0])} -> {_render(after[0])}"
+            + (
+                ""
+                if before[0] != after[0]
+                else f" (text unchanged; parsed {_render(before[1])} -> {_render(after[1])})"
+            ),
+        )
+    ]
+
+
+# --------------------------------------------------------------------------------------------
+# Small shared helpers
+# --------------------------------------------------------------------------------------------
+
+
+def _by(section: Any, name: str, key: str) -> dict[str, dict[str, Any]]:
+    """Index one list of declarations by the field that names it, dropping what is not one.
+
+    Defensive by design: this reads documents the gates would refuse, so a section that is
+    missing, is not a list, or holds something other than named objects has to produce an empty
+    index rather than an exception. Whatever is wrong with such a document shows up as the
+    envelope or dialect finding that explains it.
+    """
+    entries = (section or {}).get(name) if isinstance(section, dict) else None
+    if not isinstance(entries, list):
+        return {}
+    return {
+        entry[key]: entry
+        for entry in entries
+        if isinstance(entry, dict) and isinstance(entry.get(key), str)
+    }
+
+
+def _list_delta(old: Any, new: Any) -> list[tuple[str, str]]:
+    """Added and removed members of a list of strings, order-insensitively."""
+    before = {item for item in (old or []) if isinstance(item, str)}
+    after = {item for item in (new or []) if isinstance(item, str)}
+    return [(ADDED, item) for item in sorted(after - before)] + [
+        (REMOVED, item) for item in sorted(before - after)
+    ]
+
+
+def _shape(entry: dict[str, Any]) -> str:
+    """A key's one-line shape, for a message that would otherwise say only its name."""
+    parts = [str(entry.get("text_form") or "unknown")]
+    if entry.get("secret"):
+        parts.append("secret")
+    if entry.get("default") is not None:
+        parts.append(f"default {_render(entry.get('default'))}")
+    else:
+        parts.append("no default")
+    return ", ".join(parts)
+
+
+def _render(value: Any) -> str:
+    """One JSON value on one line, short enough to sit inside a sentence."""
+    if value is None:
+        return "unset"
+    if isinstance(value, str):
+        return repr(value) if len(value) <= 60 else repr(value[:57] + "...")
+    text = json.dumps(value, sort_keys=True, separators=(",", ":"))
+    return text if len(text) <= 60 else text[:57] + "..."
+
+
+def _short(digest: Any) -> str:
+    if not isinstance(digest, str):
+        return "unset"
+    return digest[:19] + "..." if len(digest) > 22 else digest

--- a/.github/scripts/contract-diff.py
+++ b/.github/scripts/contract-diff.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Report how a chart's configuration contract changed against another revision, and what it costs.
+
+`just contracts` runs inside the Renovate pull request that repins the digest, so the refreshed
+contract and the bump arrive together — which is the design's whole point, and also why the
+reviewer is looking at a large reordered JSON diff instead of a sentence. This is the sentence:
+what the image gained, what it dropped, what moved out from under the chart, and the smallest
+chart version bump that set of findings justifies.
+
+The loop, the git plumbing and the output live here; every rule about what a difference means and
+what it costs lives in `config_diff.py`, so each rule is testable by calling it with two
+dictionaries. The split is the one `check-config.py` already draws.
+
+**Offline, like every gate that reads a contract.** The old bytes come from `git show <ref>:<path>`
+and never from a registry, so this answers the same way on a laptop with no network and on a
+re-run of an old commit, and it cannot disagree with the committed file about what the previous
+revision said.
+
+**The working tree is one of the two sides, deliberately.** Not the index and not `HEAD`: the
+refresh writes files, and a contract for a newly declared document is untracked until someone adds
+it — the case `just check-contracts` already goes out of its way to catch. Comparing `HEAD` would
+report nothing for exactly the change most worth reporting.
+
+**Exit status separates "there are differences" from "this could not be answered."** Differences
+are the normal outcome — every Renovate bump has them — so by default they exit 0 and only a
+failure to answer exits 1. A caller that wants the distinction as a status rather than as output
+passes `--exit-code` and gets three: 0 identical, 1 error, 2 differences. Three rather than
+`git diff --exit-code`'s two, because git's 1 means both "differences" and "something broke" and a
+caller cannot tell a changed contract from an unreadable one. The JSON carries the impact anyway,
+so an automated consumer never needs the status at all.
+
+`--json` is shaped for the pull request comment this is meant to feed: a top-level impact for the
+comment's headline, per-chart drivers for its first paragraph, and the full per-contract change
+list for the collapsed detail. The workflow step that posts it is deliberately not built here —
+the reporting has to be trustworthy before anything comments with it.
+
+Usage: python3 .github/scripts/contract-diff.py
+       python3 .github/scripts/contract-diff.py tankovault --ref HEAD~1
+       python3 .github/scripts/contract-diff.py --json --exit-code
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import config_diff as cd  # noqa: E402
+from config_report import Report, error  # noqa: E402
+
+CHARTS_DIR = Path("charts")
+DEFAULT_REF = "origin/main"
+
+# The JSON's own version, on the same reasoning as `terrace_contract`: a consumer that does not
+# recognise the shape should refuse it by name rather than misread it.
+JSON_VERSION = 1
+
+
+class GitError(Exception):
+    """A revision that does not exist, or a repository this cannot be run from."""
+
+
+# --------------------------------------------------------------------------------------------
+# Reading the other revision
+# --------------------------------------------------------------------------------------------
+
+
+class Revision:
+    """One git revision, as a source of file bytes.
+
+    Every read is a `git show`, which is the only reason this needs a subprocess at all — and the
+    reason there is no fallback to the network. A revision that cannot be resolved is refused
+    once, up front, rather than turning every contract into a separate confusing failure.
+    """
+
+    def __init__(self, ref: str):
+        self.ref = ref
+        self.root = Path(self._git("rev-parse", "--show-toplevel").strip())
+        resolved = self._try("rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}")
+        if resolved is None:
+            raise GitError(
+                f"{ref}: no such revision. Pass --ref, or run `git fetch origin` if the default "
+                f"{DEFAULT_REF} is simply not present in this clone."
+            )
+        self.commit = resolved.strip()
+
+    def spec(self, path: Path) -> str:
+        """A repository-relative, forward-slashed path — the only spelling `git show` accepts."""
+        return path.resolve().relative_to(self.root).as_posix()
+
+    def read(self, path: Path) -> str | None:
+        """The file's contents at this revision, or `None` if it did not exist there."""
+        return self._try("show", f"{self.commit}:{self.spec(path)}")
+
+    def contracts(self, charts: Path) -> set[str]:
+        """Every vendored contract path that existed at this revision, repository-relative."""
+        listed = self._git("ls-tree", "-r", "--name-only", self.commit, "--", self.spec(charts))
+        return {
+            line
+            for line in listed.splitlines()
+            if line.endswith(".json") and "/contracts/" in line
+        }
+
+    def _git(self, *args: str) -> str:
+        result = self._run(args)
+        if result.returncode != 0:
+            raise GitError(f"git {' '.join(args)}: {result.stderr.strip()}")
+        return result.stdout
+
+    def _try(self, *args: str) -> str | None:
+        result = self._run(args)
+        return result.stdout if result.returncode == 0 else None
+
+    @staticmethod
+    def _run(args) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["git", *args], capture_output=True, text=True, encoding="utf-8", check=False
+        )
+
+
+# --------------------------------------------------------------------------------------------
+# Walking the charts
+# --------------------------------------------------------------------------------------------
+
+
+def collect(
+    charts: Path, revision: Revision, only: str | None, report: Report
+) -> list[cd.ChartDiff]:
+    """Every chart carrying a contract at either revision, and the diff of each of its contracts.
+
+    Contracts are found by walking the files rather than by reading `config-contract.yaml`. The
+    unit being compared is the vendored document, and a document whose declaration was deleted is
+    one of the cases most worth reporting — reading the declaration to find the files would hide
+    exactly that.
+    """
+    old_paths = revision.contracts(charts)
+    new_paths = {
+        revision.spec(path) for path in sorted(charts.glob("*/contracts/*.json")) if path.is_file()
+    }
+
+    charted: dict[str, list[str]] = {}
+    for spec in sorted(old_paths | new_paths):
+        chart = Path(spec).parent.parent.name
+        if only is not None and chart != only:
+            continue
+        charted.setdefault(chart, []).append(spec)
+
+    diffs: list[cd.ChartDiff] = []
+    for chart, specs in sorted(charted.items()):
+        diff = cd.ChartDiff(
+            chart,
+            old_version=chart_version(revision.read(charts / chart / "Chart.yaml")),
+            new_version=chart_version(_read(charts / chart / "Chart.yaml")),
+        )
+        for spec in specs:
+            contract = compare(chart, spec, revision, report)
+            if contract is not None:
+                diff.contracts.append(contract)
+        diffs.append(diff)
+    return diffs
+
+
+def compare(chart: str, spec: str, revision: Revision, report: Report) -> cd.ContractDiff | None:
+    """One contract at both revisions, or `None` when either side cannot be parsed as JSON.
+
+    A document that is not readable JSON is reported and skipped rather than raised, matching what
+    every other gate in this repository does: one broken file must not hide the state of the rest.
+    Nothing beyond "it is an object with a `contract` object in it" is asserted, because reporting
+    an envelope this repository cannot validate is this tool's job rather than its failure mode —
+    see `config_diff`'s module docstring.
+    """
+    old = _parse(revision.read(revision.root / spec), f"{spec} at {revision.ref}", report)
+    new = _parse(_read(revision.root / spec), spec, report)
+    if old is None and new is None:
+        return None
+    return cd.diff_contract(chart, Path(spec).stem, spec, old, new)
+
+
+def _parse(text: str | None, origin: str, report: Report) -> dict[str, Any] | None:
+    if text is None:
+        return None
+    try:
+        document = json.loads(text)
+    except json.JSONDecodeError as failure:
+        report.add(origin, error(f"is not valid JSON: {failure}"))
+        return None
+    if not isinstance(document, dict) or not isinstance(document.get("contract"), dict):
+        report.add(origin, error("is not a vendored contract: no `contract` object"))
+        return None
+    return document
+
+
+def _read(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def chart_version(text: str | None) -> str | None:
+    """The `version` out of a `Chart.yaml`, or `None` when there is not one to read."""
+    if text is None:
+        return None
+    try:
+        parsed = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return None
+    version = parsed.get("version") if isinstance(parsed, dict) else None
+    return version if isinstance(version, str) else None
+
+
+# --------------------------------------------------------------------------------------------
+# Output
+# --------------------------------------------------------------------------------------------
+
+# `docs` and `note` are prose. They are real changes and they are shown, but one line per key
+# would bury the findings a reviewer is here for, so they collapse into a single line per contract.
+PROSE_FIELDS = {"docs", "note"}
+
+
+def render(diffs: list[cd.ChartDiff], ref: str, stream) -> None:
+    """The human report: one block per chart, and the suggestion with its reasons under it."""
+    changed = [diff for diff in diffs if diff.impact != cd.NONE]
+    if not changed:
+        print(f"==> no vendored contract differs from {ref}", file=stream)
+        return
+
+    for diff in changed:
+        print(f"==> {diff.chart}", file=stream)
+        for contract in diff.contracts:
+            if contract.status == cd.STATUS_UNCHANGED:
+                continue
+            print(f"  {contract.path}  ({contract.status})", file=stream)
+            prose = []
+            # Severity order, stable within a level. The reviewer's first question is whether
+            # anything here is major, and a document-order listing buries the answer under the
+            # digest line that every single refresh produces.
+            for change in sorted(contract.changes, key=lambda c: -cd.RANK[c.severity]):
+                if change.field in PROSE_FIELDS and change.severity == cd.PATCH:
+                    prose.append(change.subject)
+                    continue
+                print(f"    {change.severity:<5}  {change.area:<8}  {change.message}", file=stream)
+            if prose:
+                print(
+                    f"    {cd.PATCH:<5}  {'docs':<8}  "
+                    f"{len(prose)} documentation-only change(s): {', '.join(sorted(set(prose)))}",
+                    file=stream,
+                )
+
+        print(f"  impact: {diff.impact}", file=stream)
+        # Named rather than repeated in full: every driver has already been printed above, and the
+        # question this block answers is which of those lines set the impact.
+        for change in diff.drivers:
+            print(f"    because  {change.area} {change.kind}  {change.subject}", file=stream)
+        print(f"  {_version_line(diff, ref)}", file=stream)
+        print(file=stream)
+
+    print(
+        f"==> {len(changed)} of {len(diffs)} chart(s) changed against {ref}; "
+        f"suggested impact {cd.worst(diff.impact for diff in changed)}",
+        file=stream,
+    )
+
+
+def _version_line(diff: cd.ChartDiff, ref: str) -> str:
+    """What the chart's version is, and whether the bump already in the branch is large enough."""
+    suggested = cd.suggest_version(diff.new_version, diff.impact)
+    where = f"version: {diff.old_version} at {ref}, {diff.new_version} in the working tree"
+    if suggested is None:
+        return f"{where}; suggested impact is {diff.impact}"
+    if diff.satisfied is None:
+        return f"{where}; a {diff.impact} change suggests {suggested}"
+    if diff.satisfied:
+        return f"{where}; the bump in this branch already covers a {diff.impact} change"
+    return (
+        f"{where}; a {diff.impact} change suggests {suggested}, which this branch does not carry"
+    )
+
+
+def as_json(diffs: list[cd.ChartDiff], ref: str, commit: str, report: Report) -> dict[str, Any]:
+    """The automation surface: everything the report says, with nothing to parse out of prose."""
+    return {
+        "tool": "contract-diff",
+        "version": JSON_VERSION,
+        "ref": ref,
+        "commit": commit,
+        "changed": any(diff.impact != cd.NONE for diff in diffs),
+        "impact": cd.worst(diff.impact for diff in diffs),
+        "charts": [diff.as_json() for diff in diffs],
+        "problems": [
+            {"where": where, "level": finding.level, "message": finding.message}
+            for where, finding in report.findings
+        ],
+    }
+
+
+# --------------------------------------------------------------------------------------------
+# Entry point
+# --------------------------------------------------------------------------------------------
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Report how vendored configuration contracts changed against another revision"
+    )
+    parser.add_argument("chart", nargs="?", help="one chart; omit for every chart with contracts")
+    parser.add_argument(
+        "--ref", default=DEFAULT_REF, help=f"revision to compare against (default {DEFAULT_REF})"
+    )
+    parser.add_argument("--charts", default=str(CHARTS_DIR))
+    parser.add_argument("--json", action="store_true", help="machine-readable report on stdout")
+    parser.add_argument(
+        "--exit-code",
+        action="store_true",
+        help="exit 2 when contracts differ, so a caller can tell that from an error (1)",
+    )
+    args = parser.parse_args(argv)
+
+    report = Report()
+    try:
+        revision = Revision(args.ref)
+        charts = Path(args.charts)
+        if not charts.is_dir():
+            raise GitError(f"{charts}: no such directory")
+        diffs = collect(charts, revision, args.chart, report)
+    except GitError as failure:
+        print(f"error: {failure}", file=sys.stderr)
+        return 1
+
+    if args.chart is not None and not diffs:
+        print(
+            f"error: {args.chart} carries no vendored contract, at {args.ref} or in the working "
+            f"tree",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.json:
+        json.dump(as_json(diffs, args.ref, revision.commit, report), sys.stdout, indent=2)
+        print()
+    else:
+        render(diffs, args.ref, sys.stdout)
+        report.print(sys.stdout, sys.stderr)
+
+    if report.errors:
+        return 1
+    if args.exit_code and any(diff.impact != cd.NONE for diff in diffs):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/scripts/tests/test_contract_diff.py
+++ b/.github/scripts/tests/test_contract_diff.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""What a contract diff says changed, and what it says that costs.
+
+The severity table is the part worth testing. Every one of its entries is a claim about what the
+loader does at boot with a chart that was written against the older document — a removed key
+lands on `classify` step 4 and is refused, a `text` key that became an `integer` one stops being
+supplyable by the Secret the chart mounts for it, a removed external variable is absorbed only if
+a surviving ignore pattern catches it. Each of those is a sentence a reviewer will act on, and
+each is a place where a plausible-looking implementation grades a boot failure as a minor bump.
+
+Everything here is two dictionaries in and findings out. The git plumbing, the chart walk and the
+printing live in `contract-diff.py` and are deliberately not exercised from here: they are the
+parts that need a repository, and none of them decides anything.
+
+The documents come from `.github/testdata/contracts/`, wrapped in the `source` envelope the
+vendored files carry — the same fixtures `test_contract_union.py` uses, so a change to the shape
+of a contract is felt in one place rather than two.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+import unittest
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import config_diff as cd  # noqa: E402
+
+FIXTURES = Path(__file__).resolve().parents[2] / "testdata" / "contracts"
+
+SOURCE = {
+    "image": "docker.io/example/api",
+    "digest": "sha256:" + "a" * 64,
+    "sha256": "b" * 64,
+    "fetched": "2026-01-01T00:00:00Z",
+}
+
+
+def vendored(name: str = "api") -> dict[str, Any]:
+    """One fixture contract inside the provenance envelope a vendored file carries."""
+    contract = json.loads((FIXTURES / f"{name}.json").read_text(encoding="utf-8"))
+    return {"source": copy.deepcopy(SOURCE), "contract": contract}
+
+
+def diff(old: dict[str, Any], new: dict[str, Any]) -> cd.ContractDiff:
+    return cd.diff_contract("demo", "api", "charts/demo/contracts/api.json", old, new)
+
+
+def key(document: dict[str, Any], path: str) -> dict[str, Any]:
+    for entry in document["contract"]["schema"]["keys"]:
+        if entry["path"] == path:
+            return entry
+    raise AssertionError(f"no key {path} in the fixture")
+
+
+def drop_key(document: dict[str, Any], path: str) -> None:
+    keys = document["contract"]["schema"]["keys"]
+    keys.remove(key(document, path))
+
+
+def only(result: cd.ContractDiff, **match: Any) -> cd.Change:
+    """The single change matching every named attribute, asserting there is exactly one."""
+    found = [
+        change
+        for change in result.changes
+        if all(getattr(change, name) == value for name, value in match.items())
+    ]
+    if len(found) != 1:
+        raise AssertionError(f"expected one change matching {match}, found {found}")
+    return found[0]
+
+
+class TestNoChange(unittest.TestCase):
+    def test_two_identical_documents_produce_nothing(self):
+        result = diff(vendored(), vendored())
+        self.assertEqual(result.status, cd.STATUS_UNCHANGED)
+        self.assertEqual(result.changes, [])
+        self.assertEqual(result.impact, cd.NONE)
+
+    def test_a_moved_fetched_timestamp_is_not_a_change(self):
+        new = vendored()
+        new["source"]["fetched"] = "2026-06-06T06:06:06Z"
+        self.assertEqual(diff(vendored(), new).changes, [])
+
+    def test_a_moved_sha256_alone_is_not_a_change(self):
+        new = vendored()
+        new["source"]["sha256"] = "c" * 64
+        self.assertEqual(diff(vendored(), new).changes, [])
+
+
+class TestEnvelope(unittest.TestCase):
+    def test_a_repin_alone_is_a_patch(self):
+        new = vendored()
+        new["source"]["digest"] = "sha256:" + "d" * 64
+        result = diff(vendored(), new)
+        self.assertEqual(result.impact, cd.PATCH)
+        self.assertEqual(only(result, subject="source.digest").severity, cd.PATCH)
+
+    def test_a_different_image_is_a_minor(self):
+        new = vendored()
+        new["source"]["image"] = "docker.io/example/api-v2"
+        self.assertEqual(only(diff(vendored(), new), subject="source.image").severity, cd.MINOR)
+
+    def test_the_application_version_is_a_patch(self):
+        new = vendored()
+        new["contract"]["app"]["version"] = "2.0.0"
+        self.assertEqual(only(diff(vendored(), new), subject="app.version").severity, cd.PATCH)
+
+    def test_the_envelope_version_is_a_major(self):
+        new = vendored()
+        new["contract"]["terrace_contract"] = 2
+        change = only(diff(vendored(), new), subject="terrace_contract")
+        self.assertEqual(change.severity, cd.MAJOR)
+
+    def test_an_unreadable_envelope_is_reported_rather_than_raised(self):
+        # The gates refuse a document whose envelope they do not recognise. This one has to
+        # describe it instead, so the whole contract body being unreadable must still produce a
+        # finding rather than an exception.
+        new = {"source": copy.deepcopy(SOURCE), "contract": {"terrace_contract": 99}}
+        result = diff(vendored(), new)
+        self.assertEqual(result.impact, cd.MAJOR)
+        self.assertEqual(only(result, subject="terrace_contract").new, 99)
+
+    def test_the_schema_version_is_a_major(self):
+        new = vendored()
+        new["contract"]["schema"]["schema_version"] = 2
+        self.assertEqual(
+            only(diff(vendored(), new), subject="schema.schema_version").severity, cd.MAJOR
+        )
+
+    def test_every_dialect_field_is_a_major(self):
+        for name, value in (
+            ("prefix", "OTHER_"),
+            ("nesting_separator", "_"),
+            ("indirection_suffix", "_PATH"),
+        ):
+            with self.subTest(name):
+                new = vendored()
+                new["contract"]["schema"]["dialect"][name] = value
+                change = only(diff(vendored(), new), subject=f"dialect.{name}")
+                self.assertEqual(change.severity, cd.MAJOR)
+
+    def test_tightening_the_unknown_policy_is_a_major_and_relaxing_it_is_a_minor(self):
+        old = vendored()
+        old["contract"]["external"]["unknown"] = "warn"
+        self.assertEqual(
+            only(diff(old, vendored()), subject="external.unknown").severity, cd.MAJOR
+        )
+        self.assertEqual(
+            only(diff(vendored(), old), subject="external.unknown").severity, cd.MINOR
+        )
+
+    def test_an_ignore_pattern_is_a_minor_either_way(self):
+        new = vendored()
+        new["contract"]["external"]["ignore"] = ["OTEL_*"]
+        result = diff(vendored(), new)
+        self.assertTrue(result.changes)
+        self.assertEqual({change.severity for change in result.changes}, {cd.MINOR})
+
+
+class TestLoader(unittest.TestCase):
+    def test_a_removed_loader_variable_is_a_major(self):
+        new = vendored()
+        loader = new["contract"]["schema"]["loader"]
+        loader[:] = [entry for entry in loader if entry["role"] != "secrets_dir"]
+        change = only(diff(vendored(), new), area=cd.LOADER, kind=cd.REMOVED)
+        self.assertEqual(change.severity, cd.MAJOR)
+        self.assertEqual(change.subject, "FIXTURE_SECRETS_DIR")
+
+    def test_an_added_loader_variable_is_a_minor(self):
+        new = vendored()
+        new["contract"]["schema"]["loader"].append(
+            {"env": "FIXTURE_PROFILE", "role": "profile", "docs": "", "default": None}
+        )
+        self.assertEqual(only(diff(vendored(), new), area=cd.LOADER).severity, cd.MINOR)
+
+    def test_a_loader_role_change_is_a_major(self):
+        new = vendored()
+        new["contract"]["schema"]["loader"][0]["role"] = "secrets_dir"
+        change = only(diff(vendored(), new), area=cd.LOADER, field="role")
+        self.assertEqual(change.severity, cd.MAJOR)
+
+
+class TestKeys(unittest.TestCase):
+    def test_a_removed_key_is_a_major_naming_both_spellings(self):
+        new = vendored()
+        drop_key(new, "database.url")
+        change = only(diff(vendored(), new), kind=cd.REMOVED, area=cd.KEY)
+        self.assertEqual(change.severity, cd.MAJOR)
+        self.assertIn("FIXTURE_DATABASE__URL", change.message)
+        self.assertIn("database__url", change.message)
+
+    def test_an_added_optional_key_is_a_minor(self):
+        old = vendored()
+        drop_key(old, "log.level")
+        change = only(diff(old, vendored()), kind=cd.ADDED, area=cd.KEY)
+        self.assertEqual(change.severity, cd.MINOR)
+
+    def test_an_added_required_key_is_a_major(self):
+        # Not in the stated table, which calls every added key minor. A key the chart does not
+        # write and the image will not start without is the same failure as one that became
+        # required, and grading it minor would recommend a bump that hides a broken deployment.
+        old = vendored()
+        drop_key(old, "database.url")
+        new = vendored()
+        key(new, "database.url")["required"] = True
+        change = only(diff(old, new), kind=cd.ADDED, area=cd.KEY)
+        self.assertEqual(change.severity, cd.MAJOR)
+
+    def test_becoming_required_is_a_major_and_losing_it_is_a_minor(self):
+        new = vendored()
+        key(new, "log.level")["required"] = True
+        self.assertEqual(only(diff(vendored(), new), field="required").severity, cd.MAJOR)
+        self.assertEqual(only(diff(new, vendored()), field="required").severity, cd.MINOR)
+
+    def test_a_moved_default_is_one_minor_change_not_two(self):
+        new = vendored()
+        entry = key(new, "auth.session_ttl")
+        entry["default"], entry["default_value"] = "7200", 7200
+        change = only(diff(vendored(), new), field="default")
+        self.assertEqual(change.severity, cd.MINOR)
+        self.assertEqual(change.old, {"default": "3600", "default_value": 3600})
+
+    def test_a_secret_flip_is_a_minor(self):
+        new = vendored()
+        key(new, "database.url")["secret"] = False
+        self.assertEqual(only(diff(vendored(), new), field="secret").severity, cd.MINOR)
+
+    def test_losing_file_supplyability_escalates_a_text_form_change(self):
+        # `database.url` is `text`, so a mounted Secret file can supply it. As an `integer` it
+        # cannot: a file delivers a string and the loader does not coerce one into a number, so
+        # the Secret the chart already mounts silently stops loading.
+        new = vendored()
+        entry = key(new, "database.url")
+        entry["text_form"] = "integer"
+        change = only(diff(vendored(), new), field="text_form")
+        self.assertEqual(change.severity, cd.MAJOR)
+        self.assertIn("mounted file", change.message)
+
+    def test_a_text_form_change_that_keeps_a_key_unsupplyable_is_a_minor(self):
+        new = vendored()
+        key(new, "auth.session_ttl")["text_form"] = "boolean"
+        self.assertEqual(only(diff(vendored(), new), field="text_form").severity, cd.MINOR)
+
+    def test_constraints_types_and_enums_are_minor(self):
+        for name, value in (
+            ("constraint", {"type": "integer", "minimum": 60}),
+            ("text_constraint", {"type": "string", "pattern": "^[0-9]+$"}),
+            ("ty", "u32"),
+            ("values", ["a", "b"]),
+        ):
+            with self.subTest(name):
+                new = vendored()
+                key(new, "auth.session_ttl")[name] = value
+                self.assertEqual(only(diff(vendored(), new), field=name).severity, cd.MINOR)
+
+    def test_a_changed_spelling_is_a_major(self):
+        new = vendored()
+        key(new, "database.url")["env"] = "FIXTURE_DATABASE__DSN"
+        self.assertEqual(only(diff(vendored(), new), field="env").severity, cd.MAJOR)
+
+    def test_prose_is_a_patch(self):
+        new = vendored()
+        key(new, "database.url")["docs"] = "Rewritten for clarity."
+        result = diff(vendored(), new)
+        self.assertEqual(result.impact, cd.PATCH)
+        self.assertEqual(only(result, field="docs").severity, cd.PATCH)
+
+    def test_a_field_this_diff_does_not_model_is_still_reported(self):
+        new = vendored()
+        key(new, "database.url")["deprecated_since"] = "1.4.0"
+        change = only(diff(vendored(), new), field="deprecated_since")
+        self.assertEqual(change.severity, cd.PATCH)
+        self.assertIn("models no severity", change.message)
+
+
+class TestExternal(unittest.TestCase):
+    def _with_external(self, entries: list[dict[str, Any]], ignore: list[str]) -> dict[str, Any]:
+        document = vendored()
+        document["contract"]["external"]["env"] = entries
+        document["contract"]["external"]["ignore"] = ignore
+        document["contract"]["external"]["unknown"] = "reject"
+        return document
+
+    @staticmethod
+    def _entry(name: str, **overrides: Any) -> dict[str, Any]:
+        entry = {
+            "name": name,
+            "owner": "runtime",
+            "docs": "",
+            "ty": "String",
+            "values": [],
+            "constraint": {"type": "string"},
+            "text_constraint": None,
+            "text_form": "text",
+            "default": None,
+            "required": False,
+            "secret": False,
+        }
+        entry.update(overrides)
+        return entry
+
+    def test_a_removed_external_variable_no_pattern_absorbs_is_a_major(self):
+        old = self._with_external([self._entry("RUST_LOG")], ["KUBERNETES_*"])
+        new = self._with_external([], ["KUBERNETES_*"])
+        change = only(diff(old, new), area=cd.EXTERNAL, kind=cd.REMOVED)
+        self.assertEqual(change.severity, cd.MAJOR)
+        self.assertIn("refused at boot", change.message)
+
+    def test_a_surviving_ignore_pattern_downgrades_a_removal(self):
+        # `matches_ignore` is the producer's language, not a second opinion about it: a trailing
+        # star matches any suffix and everything else is exact.
+        old = self._with_external([self._entry("RUST_LOG")], ["RUST_*"])
+        new = self._with_external([], ["RUST_*"])
+        change = only(diff(old, new), area=cd.EXTERNAL, kind=cd.REMOVED)
+        self.assertEqual(change.severity, cd.MINOR)
+        self.assertIn("absorbs it", change.message)
+
+    def test_an_added_required_external_variable_is_a_major(self):
+        old = self._with_external([], [])
+        new = self._with_external([self._entry("OTEL_ENDPOINT", required=True)], [])
+        self.assertEqual(only(diff(old, new), area=cd.EXTERNAL).severity, cd.MAJOR)
+
+    def test_an_added_optional_external_variable_is_a_minor(self):
+        old = self._with_external([], [])
+        new = self._with_external([self._entry("OTEL_ENDPOINT")], [])
+        self.assertEqual(only(diff(old, new), area=cd.EXTERNAL).severity, cd.MINOR)
+
+    def test_an_external_constraint_change_is_a_minor(self):
+        old = self._with_external([self._entry("PORT")], [])
+        new = self._with_external([self._entry("PORT", constraint={"type": "integer"})], [])
+        self.assertEqual(only(diff(old, new), field="constraint").severity, cd.MINOR)
+
+
+class TestWholeFile(unittest.TestCase):
+    def test_a_new_contract_is_a_minor(self):
+        result = cd.diff_contract("demo", "api", "p.json", None, vendored())
+        self.assertEqual(result.status, cd.STATUS_ADDED)
+        self.assertEqual(result.impact, cd.MINOR)
+        self.assertEqual(result.new_image, SOURCE["image"])
+
+    def test_a_deleted_contract_is_a_major(self):
+        result = cd.diff_contract("demo", "api", "p.json", vendored(), None)
+        self.assertEqual(result.status, cd.STATUS_REMOVED)
+        self.assertEqual(result.impact, cd.MAJOR)
+        self.assertEqual(result.old_image, SOURCE["image"])
+
+    def test_comparing_two_absent_documents_is_a_programming_error(self):
+        with self.assertRaises(ValueError):
+            cd.diff_contract("demo", "api", "p.json", None, None)
+
+    def test_a_json_schema_that_moves_alone_is_reported(self):
+        new = vendored()
+        new["contract"]["json_schema"]["title"] = "Changed"
+        change = only(diff(vendored(), new), subject="json_schema")
+        self.assertEqual(change.severity, cd.PATCH)
+
+    def test_a_json_schema_that_moves_with_a_key_is_not_reported_twice(self):
+        new = vendored()
+        new["contract"]["json_schema"]["title"] = "Changed"
+        key(new, "database.url")["ty"] = "Url"
+        result = diff(vendored(), new)
+        self.assertEqual([change.subject for change in result.changes], ["database.url"])
+
+
+class TestChartImpact(unittest.TestCase):
+    def _chart(self, *impacts: str) -> cd.ChartDiff:
+        chart = cd.ChartDiff("demo", old_version="1.2.3", new_version="1.2.3")
+        for index, severity in enumerate(impacts):
+            contract = cd.ContractDiff("demo", f"c{index}", "p.json", cd.STATUS_CHANGED)
+            contract.changes.append(
+                cd.Change(severity, cd.KEY, cd.CHANGED, f"k{index}", None, None, None, "")
+            )
+            chart.contracts.append(contract)
+        return chart
+
+    def test_the_largest_finding_sets_the_impact(self):
+        self.assertEqual(self._chart(cd.PATCH, cd.MAJOR, cd.MINOR).impact, cd.MAJOR)
+        self.assertEqual(self._chart(cd.PATCH, cd.MINOR).impact, cd.MINOR)
+        self.assertEqual(self._chart().impact, cd.NONE)
+
+    def test_only_the_findings_at_that_level_are_shown_as_drivers(self):
+        chart = self._chart(cd.PATCH, cd.MAJOR, cd.MINOR)
+        self.assertEqual([change.subject for change in chart.drivers], ["k1"])
+
+    def test_worst_of_nothing_is_none(self):
+        self.assertEqual(cd.worst([]), cd.NONE)
+
+
+class TestVersionSuggestion(unittest.TestCase):
+    def test_each_impact_moves_the_component_it_names(self):
+        self.assertEqual(cd.suggest_version("5.1.0", cd.MAJOR), "6.0.0")
+        self.assertEqual(cd.suggest_version("5.1.0", cd.MINOR), "5.2.0")
+        self.assertEqual(cd.suggest_version("5.1.0", cd.PATCH), "5.1.1")
+        self.assertIsNone(cd.suggest_version("5.1.0", cd.NONE))
+
+    def test_a_version_this_cannot_read_produces_no_suggestion(self):
+        for version in (None, "5.1", "5.1.0-rc.1", "v5.1.0", "five"):
+            with self.subTest(version):
+                self.assertIsNone(cd.suggest_version(version, cd.MAJOR))
+
+    def test_the_observed_bump_is_the_largest_component_that_moved(self):
+        self.assertEqual(cd.observed_bump("5.1.0", "6.0.0"), cd.MAJOR)
+        self.assertEqual(cd.observed_bump("5.1.0", "5.2.0"), cd.MINOR)
+        self.assertEqual(cd.observed_bump("5.1.0", "5.1.1"), cd.PATCH)
+        self.assertEqual(cd.observed_bump("5.1.0", "5.1.0"), cd.NONE)
+        self.assertIsNone(cd.observed_bump("5.1.0", None))
+
+    def test_a_bump_already_in_the_branch_can_satisfy_the_suggestion(self):
+        chart = cd.ChartDiff("demo", old_version="5.1.0", new_version="6.0.0")
+        contract = cd.ContractDiff("demo", "api", "p.json", cd.STATUS_CHANGED)
+        contract.changes.append(
+            cd.Change(cd.MAJOR, cd.KEY, cd.REMOVED, "a.b", None, None, None, "")
+        )
+        chart.contracts.append(contract)
+        self.assertTrue(chart.satisfied)
+
+        chart.new_version = "5.2.0"
+        self.assertFalse(chart.satisfied)
+
+        chart.new_version = None
+        self.assertIsNone(chart.satisfied)
+
+    def test_a_chart_with_no_findings_is_always_satisfied(self):
+        self.assertTrue(cd.ChartDiff("demo", old_version="1.0.0", new_version="1.0.0").satisfied)
+
+
+class TestJson(unittest.TestCase):
+    def test_the_report_survives_a_round_trip_through_json(self):
+        new = vendored()
+        drop_key(new, "database.url")
+        chart = cd.ChartDiff("demo", [diff(vendored(), new)], "5.1.0", "5.1.0")
+        payload = json.loads(json.dumps(chart.as_json()))
+        self.assertEqual(payload["impact"], cd.MAJOR)
+        self.assertEqual(payload["version"], {
+            "old": "5.1.0",
+            "new": "5.1.0",
+            "bumped": False,
+            "suggested": "6.0.0",
+            "satisfied": False,
+        })
+        self.assertEqual([driver["subject"] for driver in payload["drivers"]], ["database.url"])
+        self.assertEqual(payload["contracts"][0]["status"], cd.STATUS_CHANGED)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/just/contracts.just
+++ b/just/contracts.just
@@ -190,4 +190,47 @@ explain chart='' pattern='' *flags:
     set -euo pipefail
     {{ resolve_python }}
     "$python" {{ scripts }}/explain-config.py '{{ chart }}' '{{ pattern }}' \
+
+# --------------------------------------------------------------------------------------------
+# The review aid — offline
+# --------------------------------------------------------------------------------------------
+
+# Report how a chart's vendored contracts changed against another revision, and what that costs.
+#
+# `contracts` runs inside the Renovate pull request that repins the digest, which is the design's
+# whole point and is also why the reviewer is looking at several hundred lines of reordered JSON.
+# The question they have is not in those lines: did the image gain a setting the chart has to
+# write, drop one the chart still writes, or move a default out from under it — and, given the
+# answer, what should this chart's own version be. This recipe is that answer.
+#
+# Severity is graded by what the loader does at boot rather than by the shape of the diff, which
+# is why a removed key and a changed dialect are the two most severe things here. Both rename
+# every spelling the chart emits while nothing in the rendered manifests looks different, and
+# `external.unknown` is `reject` across every contract in this repository — so the old spelling is
+# a container that will not start, not a key quietly ignored.
+#
+# The suggestion is shown with the findings that produced it and never written anywhere. Nothing
+# here edits `Chart.yaml`: the mapping from finding to bump is a defensible default, and only the
+# reviewer knows whether the chart actually writes the key that moved. A recipe that bumped the
+# version would be asserting it knows that, and would be wrong the first time a removed key was
+# one no template ever emitted.
+#
+# Reads no network — the other side comes from `git show`, exactly as every gate above reads the
+# committed file. Deliberately not part of `just check`: differences are the normal outcome of a
+# bump, so a gate that failed on them would be red on every pull request it exists to explain.
+# For a caller that needs the distinction as a status rather than as output, `--exit-code` gives
+# three: 0 identical, 1 error, 2 differences -- on top of which `just` prints its own "failed
+# with exit code 2", which is simply what any non-zero recipe looks like to it.
+#
+#   just contract-diff                            every chart, against origin/main
+#   just contract-diff tankovault                 one chart
+#   just contract-diff portfolio HEAD~1           against another revision
+#   just contract-diff '' origin/main --json      the machine-readable report
+[doc("Report how a chart's vendored contracts changed against another revision, and what it costs")]
+[group('contracts')]
+contract-diff chart='' ref='origin/main' *flags='':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    {{ resolve_python }}
+    "$python" {{ scripts }}/contract-diff.py {{ chart }} --ref '{{ ref }}' \
       --charts {{ charts }} {{ flags }}


### PR DESCRIPTION
Adds `just contract-diff [chart] [ref]` — compares the working tree's vendored contracts against another revision and reports what changed, how severe it is, and what the chart's version should probably be.

## Why

`just contracts` refreshes the vendored contract inside the same Renovate pull request that repins the digest — that is the design's whole point, and it is also why the reviewer is looking at several hundred lines of reordered JSON. The question they actually have is not in those lines: did the image gain a setting the chart has to write, drop one the chart still writes, or move a default out from under it.

## What it reports

- **Envelope**: image digest, `app.version`, `terrace_contract`, `schema_version`, all three dialect fields, `external.unknown`, `external.ignore`.
- **Loader variables**, **key declarations** field by field, and **`external.env`**.
- A suggested semver impact with the findings that produced it. Shown, never written — nothing here edits `Chart.yaml`, because only the reviewer knows whether the chart actually writes the key that moved.

Offline: the other side comes from `git show <ref>:<path>`. Deliberately not in `just check` — differences are the normal outcome of every bump, so a gate failing on them would be red on exactly the PRs it exists to explain.

## Severity rules that differ from the original spec

Five gaps found while implementing, each with a comment and a test:

1. **A newly added *required* key is major, not minor** — identical failure to a key becoming required.
2. **`text_form` leaving `text` is major.** The key is spelled the same and renders the same, and the Secret the chart mounts silently stops loading, because a file delivers text and the loader does not coerce it. Decided via `cc.file_supplyable`.
3. **`env` / `env_file` / `secrets_file` changes are graded as a dialect change** — should be unreachable, but if a producer changes the derivation the chart writes the wrong name with nothing to explain it.
4. **`schema.loader` changes are major.** These are the variables the chart sets to point at its ConfigMap and mounted Secret. Remove or re-role one and nothing fails: the chart keeps setting the old name, the pod starts, and none of the mounted configuration loads.
5. **A removed `external.env` entry is only minor when a surviving `ignore` pattern absorbs it** — decided by calling `cc.matches_ignore` rather than reimplementing the pattern language.

## Exit status

0 whether or not there are differences, 1 for "could not answer". `--exit-code` opts into three codes with **2** for differences — deliberately not git's 1-for-both, so a caller can tell them apart.

It also deliberately does **not** call `cc.check_envelope`. Every gate is right to refuse a document whose envelope version it does not recognise, but "the envelope version changed" is a finding this tool exists to report, so both sides are read defensively field by field. There is a test for `terrace_contract: 99`.

## Verification

`just test-contract-union` — 181 passing (135 pre-existing + 46 new), no new fixtures. No commit in history has ever *modified* a vendored contract, so the key-level path was exercised by mutating portfolio's contract in the working tree and reverting.

## Follow-up

The `--json` output is shaped for a CI step that comments the diff onto a Renovate PR. That step is deliberately not in this PR.