### PR TITLE
feat(scripts): inventory the credential surface and reconcile it against the charts

### DIFF
--- a/.github/scripts/config-secrets.py
+++ b/.github/scripts/config-secrets.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""The credential inventory, and the report reconciling it against what the charts deliver.
+
+Two questions nobody in this repository could answer before it existed, and one entry point for
+both because they are the same subject read at two removes — what the images declare secret, and
+whether anything actually supplies it.
+
+  python3 .github/scripts/config-secrets.py                        the inventory, as a table
+  python3 .github/scripts/config-secrets.py --json                 the same, for a machine
+  python3 .github/scripts/config-secrets.py --reconcile rendered   the report
+  python3 .github/scripts/config-secrets.py --reconcile rendered --json
+
+**The reconciliation exits 0 whatever it finds, and that is deliberate for now.** Its three
+questions are new and the first pass over an established repository is where a report earns its
+triage: a finding that turns out to be a considered design decision is a line in a document, not a
+red pipeline on a pull request that changed nothing. A follow-up promotes it once the findings
+here are triaged, and the promotion is the last line of `main` — the findings are already
+`config_report.Finding`s at the right level, so nothing else moves.
+
+The model lives in `config_secrets.py`; this file is the loop, the layout and the exit status,
+matching how `check-config.py` sits above the gates it composes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import config_contract as cc  # noqa: E402
+from config_declaration import DeclarationError  # noqa: E402
+from config_report import Report, error, warning  # noqa: E402
+from config_secrets import (  # noqa: E402
+    Credential,
+    Mount,
+    Reconciler,
+    Surface,
+    contracted_charts,
+    credentials,
+    declared_secrets,
+)
+
+CHARTS_DIR = Path("charts")
+
+
+# --------------------------------------------------------------------------------------------
+# The inventory
+# --------------------------------------------------------------------------------------------
+
+
+def print_inventory(charts: Path) -> int:
+    """One block per contracted chart; returns how many credentials were listed."""
+    total = 0
+    for chart_dir, declaration in contracted_charts(charts):
+        rows = credentials(declared_secrets(chart_dir, declaration))
+        total += len(rows)
+        print(f"==> {declaration.chart}")
+        if not rows:
+            print(
+                f"    no key of the {len(declaration.documents)} document(s) this chart declares "
+                "is marked secret"
+            )
+            print()
+            continue
+        _print_chart(chart_dir, declaration, rows)
+        print()
+
+    if total == 0:
+        print("no chart declares a configuration contract with a secret key")
+    else:
+        print(f"{total} credential(s) across {len(list(contracted_charts(charts)))} chart(s)")
+    return total
+
+
+def _print_chart(chart_dir: Path, declaration, rows: list[Credential]) -> None:
+    images = sorted({image for row in rows for image in row.images})
+    vendored = sum(len(document.images) for document in declaration.documents)
+    print(
+        f"    {len(rows)} credential(s), read by {len(images)} of the {vendored} image(s) this "
+        "chart vendors a contract for"
+    )
+
+    # The environment spellings are derived from the config path by the dialect, and stating the
+    # derivation once is both shorter and more useful than a column of values every one of which
+    # restates it. Checked rather than assumed: a credential whose contract spells it otherwise
+    # gets its literal spellings printed under its row, so the rule can never quietly become a
+    # lie the table tells.
+    exceptions = [row for row in rows if row.env_file != row.env + "_FILE"]
+    prefix = _common_prefix([row.env for row in rows])
+    if prefix:
+        print(
+            f"    environment: {prefix}<PATH>, with dots as `__` and upper-cased; the same "
+            "spelling with `_FILE` appended names a file whose contents supply it"
+        )
+
+    multi = len(images) > 1
+    widths = (
+        max(len(row.path) for row in rows),
+        max(len(row.secrets_file) for row in rows),
+    )
+    header = f"    {'config path':<{widths[0]}}  {'secrets file':<{widths[1]}}  required"
+    print()
+    print(header)
+    print("    " + "-" * (len(header) - 4))
+    for row in rows:
+        required = "yes" if row.required else "no"
+        print(
+            f"    {row.path:<{widths[0]}}  {row.secrets_file:<{widths[1]}}  {required}"
+        )
+        if multi:
+            print(f"        read by  {', '.join(row.images)}")
+        if row in exceptions or not prefix:
+            print(f"        env      {row.env}")
+            print(f"        _FILE    {row.env_file}")
+
+
+def _common_prefix(spellings: list[str]) -> str:
+    """The dialect prefix every environment spelling shares, or nothing when they differ."""
+    if not spellings:
+        return ""
+    head = spellings[0]
+    cut = len(head)
+    for spelling in spellings[1:]:
+        cut = min(cut, len(spelling))
+        while cut and spelling[:cut] != head[:cut]:
+            cut -= 1
+    return head[:cut]
+
+
+def inventory_json(charts: Path) -> dict:
+    payload = []
+    for chart_dir, declaration in contracted_charts(charts):
+        for row in credentials(declared_secrets(chart_dir, declaration)):
+            payload.append(asdict(row))
+    return {"credentials": payload}
+
+
+# --------------------------------------------------------------------------------------------
+# The reconciliation
+# --------------------------------------------------------------------------------------------
+
+
+def reconcile(charts: Path, rendered: Path) -> Surface:
+    if not rendered.is_dir():
+        raise DeclarationError(
+            f"{rendered}: no rendered manifests; run `just render {rendered}` first"
+        )
+    return Reconciler(charts, rendered).run()
+
+
+def report_of(surface: Surface) -> Report:
+    """Turn one scan into findings, at the level each conclusion has earned.
+
+    An error is reserved for a chart that has no channel for a credential at all, and for a
+    credential reaching a pod that cannot read it. A warning is for everything that is a gap in
+    what was *checked* rather than in what the chart does: a credential no `ci/` fixture exercises,
+    a chart policy being recorded, a document that could not be reconciled. That is the same
+    division `config_report.Finding` already documents, applied to a report rather than a gate.
+    """
+    report = Report()
+
+    for note in surface.notes:
+        report.add("not reconciled", warning(note))
+
+    for finding in surface.undeliverable:
+        row = finding.credential
+        channels = (
+            f"not as the file {row.secrets_file!r} in a secrets directory, not through "
+            f"{row.env_file}, not as {row.env}, and not by the rendered document"
+        )
+        summary = f" The contract says: {row.summary}" if row.summary else ""
+        if finding.named_by_chart:
+            report.add(
+                f"unsupplied: {row.chart}",
+                warning(
+                    f"{row.path} is declared secret by {', '.join(row.images)} and none of the "
+                    f"{len(finding.values_files)} `ci/` values file(s) supplies it: {channels}. "
+                    f"The chart does mention it, in {', '.join(finding.named_in)}, so it has "
+                    "heard of the credential: this is a fixture that never sets it, or a "
+                    "spelling the chart deliberately handles some other way, rather than a "
+                    f"credential nothing in the chart knows about.{summary}"
+                ),
+            )
+            continue
+        report.add(
+            f"undeliverable: {row.chart}",
+            error(
+                f"{row.path} is declared secret by {', '.join(row.images)}, no rendering of this "
+                f"chart supplies it ({channels}), and no file of the chart outside its vendored "
+                "contracts mentions any of those spellings. Nothing can supply this credential "
+                "and nobody reading the values file would learn it exists. Checked against all "
+                f"{len(finding.values_files)} `ci/` values file(s); "
+                f"{'required' if row.required else 'optional'} to the image.{summary}"
+            ),
+        )
+
+    for chart, workload, container, image, files, values_files in _by_container(surface.unclaimed):
+        report.add(
+            f"unclaimed: {chart}",
+            error(
+                f"{workload} container {container!r} mounts {', '.join(files)} from a Secret, and "
+                "no contract this chart vendors spells any of those names, as a key or as a leaf "
+                f"of a dynamic map. Under {', '.join(values_files)}. Gate 3 did not judge them: "
+                "it inspects a resolved secrets directory on a declared consumer, and these are "
+                "outside that reach."
+            ),
+        )
+
+    for chart, workload, container, image, files, values_files in _by_container(
+        surface.over_projected
+    ):
+        report.add(
+            f"over-projected: {chart}",
+            error(
+                f"{workload} container {container!r} runs the {image} image and is given "
+                f"{', '.join(files)}, none of which that image's own contract declares; a sibling "
+                "image's does. The pod holds credentials the binary inside it never reads. Under "
+                f"{', '.join(values_files)}. Gate 3 did not judge them: it inspects a resolved "
+                "secrets directory on a declared consumer, and this container is outside that "
+                "reach."
+            ),
+        )
+
+    for elevated in surface.elevated:
+        report.add(
+            f"elevated: {elevated.chart}",
+            warning(
+                f"{elevated.path} is `secret: false` in the contract and this chart delivers it "
+                f"as the Secret file {elevated.file_name!r} to {', '.join(elevated.containers)}. "
+                "Chart policy electing to treat a value as more sensitive than the image does; "
+                f"its text_form is {elevated.text_form!r}, so a file can supply it and gate 3 "
+                "permits it. Recorded, not counted against the chart."
+            ),
+        )
+
+    return report
+
+
+def _by_container(
+    mounts: list[Mount],
+) -> list[tuple[str, str, str, str, tuple[str, ...], tuple[str, ...]]]:
+    """One row per container rather than per file.
+
+    A container over-projected six credentials has one problem, not six, and six near-identical
+    lines is how a reader learns to skim a report. The values files stay in the row because which
+    fixture produced it is what somebody reproducing this needs.
+    """
+    grouped: dict[tuple[str, str, str, str], tuple[set[str], set[str]]] = {}
+    for mount in mounts:
+        identity = (mount.chart, mount.workload, mount.container, mount.image)
+        files, values_files = grouped.setdefault(identity, (set(), set()))
+        files.add(mount.file_name)
+        values_files.add(mount.values_file)
+
+    rows = []
+    for (chart, workload, container, image), (files, values_files) in sorted(grouped.items()):
+        rows.append(
+            (chart, workload, container, image, tuple(sorted(files)), tuple(sorted(values_files)))
+        )
+    return rows
+
+
+def print_reconciliation(surface: Surface, report: Report) -> None:
+    print(
+        "==> report only: this recipe exits 0 whatever it finds, so that its first pass over an "
+        "established repository can be triaged rather than merged as a red pipeline"
+    )
+    print(
+        f"    reconciled {len(surface.charts)} chart(s) against every `ci/` values file each one "
+        f"ships: {', '.join(surface.charts) or 'none'}"
+    )
+    print(
+        "    a credential delivered under any one of them is delivered; over-projection and "
+        "unclaimed names are per values file and name it"
+    )
+    print()
+    # The findings are split across the two streams the rest of this repository splits them
+    # across, so the promotion to a gate changes the exit status and nothing about the output.
+    # Flushed first, or the preamble lands after them in a terminal.
+    sys.stdout.flush()
+    report.print(sys.stdout, sys.stderr)
+    sys.stdout.flush()
+
+    undeliverable = [entry for entry in surface.undeliverable if not entry.named_by_chart]
+    unsupplied = len(surface.undeliverable) - len(undeliverable)
+    print(
+        f"\n{len(undeliverable)} undeliverable, {len(_by_container(surface.over_projected))} "
+        f"over-projected container(s), {len(_by_container(surface.unclaimed))} container(s) with "
+        f"unclaimed file(s), {unsupplied} unsupplied, {len(surface.elevated)} elevated"
+    )
+
+
+def surface_json(surface: Surface) -> dict:
+    return {
+        "charts": surface.charts,
+        "values_files": surface.values_files,
+        "undeliverable": [
+            {"credential": asdict(entry.credential), "values_files": list(entry.values_files)}
+            for entry in surface.undeliverable
+        ],
+        "unclaimed": [asdict(mount) for mount in surface.unclaimed],
+        "over_projected": [asdict(mount) for mount in surface.over_projected],
+        "elevated": [asdict(entry) for entry in surface.elevated],
+        "notes": surface.notes,
+    }
+
+
+# --------------------------------------------------------------------------------------------
+# Entry point
+# --------------------------------------------------------------------------------------------
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="The credential inventory, and what the charts deliver against it"
+    )
+    parser.add_argument(
+        "--reconcile",
+        metavar="RENDERED",
+        help="reconcile against the manifests in this directory instead of listing the inventory",
+    )
+    parser.add_argument("--charts", default=str(CHARTS_DIR))
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    args = parser.parse_args(argv)
+
+    charts = Path(args.charts)
+
+    try:
+        if args.reconcile:
+            surface = reconcile(charts, Path(args.reconcile))
+            if args.json:
+                json.dump(surface_json(surface), sys.stdout, indent=2, sort_keys=True)
+                print()
+            else:
+                print_reconciliation(surface, report_of(surface))
+        elif args.json:
+            json.dump(inventory_json(charts), sys.stdout, indent=2, sort_keys=True)
+            print()
+        else:
+            print_inventory(charts)
+    except (DeclarationError, cc.ContractError) as failure:
+        print(f"error: {failure}", file=sys.stderr)
+        return 1
+
+    # Report only. Promoting it to a gate is this line becoming `return 1 if report.errors else 0`
+    # once the findings above have been triaged, and nothing else.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/scripts/config_secrets.py
+++ b/.github/scripts/config_secrets.py
@@ -1,0 +1,767 @@
+#!/usr/bin/env python3
+"""The credential surface: what the images declare secret, and what the charts deliver.
+
+Forty-seven key declarations across this repository carry `secret: true`, and until this module
+existed no document anywhere said what they are, how each one reaches the process that reads it,
+or which pods end up holding it. That gap is not cosmetic. The gates in `config_gate_container.py`
+are structurally unable to close it: gate 3 asks whether every *delivered* file name is known to
+the contract, so it rejects a name nothing declares and is blind by construction to a declared key
+nothing supplies. A credential that no channel delivers renders cleanly, passes every gate, and
+fails at the first request that needs it.
+
+Two answers live here, and they are deliberately separate:
+
+**The inventory** is what the contracts say, and needs no render. It reads the vendored documents
+and nothing else, so it stays cheap enough to run while writing a values file. It deliberately
+skips the staleness interlock `config_declaration.bind` applies — a Renovate digest bump produces
+one run where the pinned digest and the vendored contract disagree, and refusing to print the
+inventory then would withhold the document at exactly the moment a reviewer is reading a
+credential change. Whether the vendored copy is current is `just check-contracts`' question.
+
+**The reconciliation** is what a rendered chart actually delivers, against that inventory. It does
+apply the interlock, because it reasons about which image a container runs and an answer derived
+from a contract that belongs to a different digest is worse than no answer.
+
+Three conclusions, and the scope of each is load-bearing:
+
+  undeliverable   a contract key no rendered configuration can supply through any channel. Judged
+                  across *every* `ci/` fixture the chart ships, because a credential delivered
+                  only under one fixture is delivered — the chart has a way to supply it.
+
+  unclaimed       a delivered Secret file name that no contract of the chart names, by neither an
+                  exact spelling nor a dynamic-map leaf. Scoped against every contract the chart
+                  vendors, which is what keeps it disjoint from over-projection below.
+
+  over-projected  a Secret file whose name a *sibling* image's contract claims and the container's
+                  own image's contract does not. A pod holding a credential its binary never reads
+                  is a least-privilege defect, and it is scoped per container against that one
+                  image's contract — never against the union, for the reason
+                  `config_gate_container.py`'s docstring gives at length.
+
+**Not duplicating gate 3.** Gate 3 already errors on a name unknown to the contract, but only for
+a file inside a *resolved* secrets directory on a container the declaration lists as a consumer of
+that document. Both halves of that condition are recorded per file here, and a file gate 3 would
+have judged is reported by neither `unclaimed` nor `over-projected` — it is already one line in
+`just check-config`, and a second line saying the same thing in a different report trains a reader
+to skim both. What remains is precisely gate 3's blind spot, and it is not hypothetical: several
+of this repository's Deployments run an init container that no `config-contract.yaml` names as a
+consumer, so nothing checks what it mounts.
+
+**Nothing here builds a union, and the word is worth avoiding.** `tankovault` declares nine
+documents, one per service, each with exactly one image — so `union_contracts` is the identity for
+every one of them and there is no shared namespace to merge. Every judgement below is made against
+one image's own contract, which is the only scope that can distinguish a key `notifier` reads from
+one `api` does. The single chart-wide structure is a digest-to-contract lookup, and it exists to
+*find* the right contract for a container rather than to widen one: an init container inside the
+`api` Deployment runs the `bootstrap` image, whose contract the `api` document never mentions.
+
+**Every container, not only the declared consumers.** The reconciliation walks every container of
+every rendered workload and identifies its image by digest, because the question "who can see this
+credential" is about the pod rather than about what the declaration chose to describe. A container
+whose image the chart does not pin a contract for is skipped: nothing here can say what it reads.
+
+**Aliases are deliberately not consulted.** A key may carry `env_aliases`, `env_file_aliases` and
+`secrets_file_aliases`; `config_contract.classify` and `Union.key_by` ignore them, and this module
+agrees with the normative reader rather than being independently cleverer than the gate whose
+findings it sits beside. No contract in this repository declares one today, so the two readings
+cannot yet diverge; if that changes, it changes in `config_contract.py` first.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+import config_contract as cc
+from config_declaration import Binding, Declaration, Document, bind, load_declaration
+from config_gate_container import ContainerView
+from config_gate_document import parse_document
+from config_manifests import containers_of, digest_of, load_manifests, pod_spec, select
+
+# The four ways a value can reach the loader, named as the report prints them. The rendered
+# document is among them and is not a mistake: a key written into the plaintext ConfigMap *is*
+# supplied, and leaving that channel out would report a key as undeliverable while a running pod
+# reads it. Whether a credential belongs in a ConfigMap is a different question from whether it
+# arrives.
+SECRETS_DIRECTORY = "the secrets directory"
+INDIRECTION = "`_FILE` indirection"
+ENVIRONMENT = "the environment"
+DOCUMENT = "the rendered document"
+
+# Files under a chart that describe what it *delivers*. The vendored contracts are excluded on
+# purpose: they are the other side of the comparison, and every credential is named in one of them
+# by definition.
+CHART_TEXT = ("*.yaml", "*.yml", "*.tpl", "*.json", "*.md", "*.txt")
+EXCLUDED_DIRS = ("contracts", "charts")
+
+
+# --------------------------------------------------------------------------------------------
+# The inventory — what the vendored contracts declare
+# --------------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Declared:
+    """One `secret: true` key, as one image's contract spells it."""
+
+    chart: str
+    document: str
+    # The vendored file as `config_declaration.bind` labels it — `<chart>/contracts/<name>.json`.
+    # The same spelling `cc.Union.sources` carries, so a declaration and the contract a rendered
+    # container was matched against are comparable without a second naming convention.
+    contract: str
+    image: str
+    path: str
+    secrets_file: str
+    env: str
+    env_file: str
+    text_form: str
+    required: bool
+    # The contract's own first line about the key. Carried into the report because it is what
+    # turns a triage question into an answered one: `internal.token` is undeliverable here and its
+    # own documentation says it is retired, which no amount of chart reading would have said.
+    summary: str
+
+
+@dataclass(frozen=True)
+class Credential:
+    """One credential of one chart: every declaration of it, merged.
+
+    Merged by spelling rather than by path alone. Two documents of one chart spelling one path
+    differently would be two different files on disk and two different variables, so they stay two
+    rows — the inventory's job is to name the artefacts an operator has to create, and collapsing
+    them would name one that does not exist.
+    """
+
+    chart: str
+    path: str
+    secrets_file: str
+    env: str
+    env_file: str
+    required: bool
+    summary: str
+    documents: tuple[str, ...]
+    images: tuple[str, ...]
+    contracts: tuple[str, ...]
+
+
+def contracted_charts(charts: Path) -> list[tuple[Path, Declaration]]:
+    """Every chart that declares at least one document, in directory order."""
+    found: list[tuple[Path, Declaration]] = []
+    for chart_dir in sorted(charts.iterdir()):
+        if not (chart_dir / "Chart.yaml").is_file():
+            continue
+        declaration = load_declaration(chart_dir)
+        if declaration is not None and declaration.documents:
+            found.append((chart_dir, declaration))
+    return found
+
+
+def declared_secrets(chart_dir: Path, declaration: Declaration) -> list[Declared]:
+    """Every `secret: true` key of every contract one chart vendors."""
+    found: list[Declared] = []
+    for document in declaration.documents:
+        for reference in document.images:
+            vendored = cc.load_vendored(chart_dir / reference.contract)
+            app = (vendored.contract.get("app") or {}).get("name") or vendored.image
+            for key in vendored.contract["schema"]["keys"]:
+                if not key.get("secret"):
+                    continue
+                found.append(
+                    Declared(
+                        chart=declaration.chart,
+                        document=document.name,
+                        contract=f"{declaration.chart}/{reference.contract}",
+                        image=str(app),
+                        path=str(key["path"]),
+                        secrets_file=str(key.get("secrets_file") or ""),
+                        env=str(key.get("env") or ""),
+                        env_file=str(key.get("env_file") or ""),
+                        text_form=str(key.get("text_form") or ""),
+                        required=bool(key.get("required")),
+                        summary=_first_line(key.get("docs")),
+                    )
+                )
+    return found
+
+
+def inventory(charts: Path) -> list[Declared]:
+    """Every secret declaration in the repository, chart by chart."""
+    found: list[Declared] = []
+    for chart_dir, declaration in contracted_charts(charts):
+        found.extend(declared_secrets(chart_dir, declaration))
+    return found
+
+
+def credentials(declared: Iterable[Declared]) -> list[Credential]:
+    """Collapse declarations into one row per credential, keeping every reader's name."""
+    merged: dict[tuple[str, str, str, str, str], list[Declared]] = {}
+    for entry in declared:
+        key = (entry.chart, entry.path, entry.secrets_file, entry.env, entry.env_file)
+        merged.setdefault(key, []).append(entry)
+
+    rows = []
+    for (chart, path, secrets_file, env, env_file), entries in merged.items():
+        rows.append(
+            Credential(
+                chart=chart,
+                path=path,
+                secrets_file=secrets_file,
+                env=env,
+                env_file=env_file,
+                # Unioned exactly as `config_contract` unions it: a key any reader requires is a
+                # key the deployment must carry.
+                required=any(entry.required for entry in entries),
+                # `config_contract._merge_entry` refuses two contracts that document one key
+                # differently, so every entry here carries the same line and the first will do.
+                summary=entries[0].summary,
+                documents=tuple(sorted({entry.document for entry in entries})),
+                images=tuple(sorted({entry.image for entry in entries})),
+                contracts=tuple(sorted({entry.contract for entry in entries})),
+            )
+        )
+    rows.sort(key=lambda row: (row.chart, row.path, row.secrets_file))
+    return rows
+
+
+# --------------------------------------------------------------------------------------------
+# What a rendered volume actually delivers
+# --------------------------------------------------------------------------------------------
+
+
+def secret_file_names(
+    manifests: list[dict[str, Any]], spec: dict[str, Any], volume_name: str
+) -> list[str]:
+    """The file names one volume presents *from Secret sources only*.
+
+    `config_manifests.projected_file_names` answers the neighbouring question and deliberately
+    merges Secret and ConfigMap sources, because gate 3 asks whether a name spells a key and that
+    does not depend on where the bytes came from. Here it does: the whole subject is a credential's
+    blast radius, and `config.toml` arriving from a ConfigMap in the same projected volume is not
+    one. Same walk, one source kind.
+    """
+    volume = next(
+        (entry for entry in spec.get("volumes") or [] if entry.get("name") == volume_name), None
+    )
+    if volume is None:
+        return []
+
+    sources: list[dict[str, Any]] = []
+    if "projected" in volume:
+        sources = volume["projected"].get("sources") or []
+    elif "secret" in volume:
+        sources = [{"secret": {**volume["secret"], "name": volume["secret"].get("secretName")}}]
+
+    names: list[str] = []
+    for source in sources:
+        body = source.get("secret")
+        if not isinstance(body, dict):
+            continue
+        if body.get("items"):
+            names.extend(str(item.get("path") or item.get("key")) for item in body["items"])
+            continue
+        # No `items` means every key of the object, which is the `existingSecret` case — the one a
+        # gate would otherwise have nothing to say about. Readable only when the chart renders the
+        # Secret itself; when it names one the operator supplies, there is nothing to read and the
+        # volume contributes no names.
+        for manifest in manifests:
+            metadata = manifest.get("metadata") or {}
+            if manifest.get("kind") == "Secret" and metadata.get("name") == body.get("name"):
+                names.extend(manifest.get("data") or {})
+                names.extend(manifest.get("stringData") or {})
+    return sorted(set(names))
+
+
+def document_paths(instance: Any, prefix: str = "") -> set[str]:
+    """Every dotted path the parsed configuration document sets, leaves and tables alike.
+
+    Tables are included so a `structured` key supplied as a whole table counts as supplied, which
+    is what the loader sees.
+    """
+    paths: set[str] = set()
+    if not isinstance(instance, dict):
+        return paths
+    for name, value in instance.items():
+        full = f"{prefix}.{name}" if prefix else str(name)
+        paths.add(full)
+        paths |= document_paths(value, full)
+    return paths
+
+
+# --------------------------------------------------------------------------------------------
+# The reconciliation
+# --------------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Mount:
+    """One Secret-sourced file, as one rendered container receives it."""
+
+    chart: str
+    values_file: str
+    workload: str
+    container: str
+    image: str
+    mount_path: str
+    file_name: str
+    # Whether gate 3 already judged this file: it inspects the contents of a *resolved* secrets
+    # directory on a container the declaration lists as a consumer, and nothing else.
+    judged_by_gate_three: bool
+
+
+@dataclass(frozen=True)
+class Undeliverable:
+    """A credential the chart declares and no rendering of it supplies.
+
+    `named_by_chart` separates the two very different reasons that happens, and it is the whole
+    difference between a defect and a coverage gap. A chart that names a credential somewhere in
+    its values, templates or documentation has a channel for it and simply no `ci/` fixture that
+    exercises one; a chart that names it nowhere has no channel at all, and an operator reading
+    the values file will never learn the credential exists.
+    """
+
+    credential: Credential
+    values_files: tuple[str, ...]
+    named_by_chart: bool
+    named_in: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Elevated:
+    """A key the contract calls ordinary configuration and the chart delivers as a Secret."""
+
+    chart: str
+    path: str
+    file_name: str
+    text_form: str
+    containers: tuple[str, ...]
+
+
+@dataclass
+class Ledger:
+    """What one chart's renders were found to deliver, accumulated across every values file.
+
+    The same shape `config_gate_container.Suppliers` takes one level down, and for the same
+    reason: neither question is answerable from a single container, so the answer has to outlive
+    the walk over one. Keyed by the vendored contract as well as the config path, because "who
+    supplies this" is a question about one image — two images declaring one path are two
+    credentials to deliver, and collapsing them would let either one cover for the other.
+    """
+
+    supplied: dict[tuple[str, str], set[str]] = field(default_factory=dict)
+    elevated: dict[tuple[str, str, str], set[str]] = field(default_factory=dict)
+
+    def supply(self, contract: str, path: str, channel: str) -> None:
+        self.supplied.setdefault((contract, path), set()).add(channel)
+
+    def supplies(self, contract: str, path: str) -> bool:
+        return (contract, path) in self.supplied
+
+    def elevate(self, key: dict[str, Any], file_name: str, container: str) -> None:
+        identity = (str(key["path"]), file_name, str(key.get("text_form") or ""))
+        self.elevated.setdefault(identity, set()).add(container)
+
+
+@dataclass
+class Surface:
+    """Everything one pass over the rendered manifests found."""
+
+    charts: list[str] = field(default_factory=list)
+    values_files: list[str] = field(default_factory=list)
+    undeliverable: list[Undeliverable] = field(default_factory=list)
+    unclaimed: list[Mount] = field(default_factory=list)
+    over_projected: list[Mount] = field(default_factory=list)
+    elevated: list[Elevated] = field(default_factory=list)
+    # Anything that stopped a chart being reconciled, rather than anything found wrong in one.
+    notes: list[str] = field(default_factory=list)
+
+
+class Reconciler:
+    """One chart at a time: bind its contracts, walk its renders, compare the two."""
+
+    def __init__(self, charts: Path, rendered: Path):
+        self.charts = charts
+        self.rendered = rendered
+        self.surface = Surface()
+
+    def run(self) -> Surface:
+        for chart_dir, declaration in contracted_charts(self.charts):
+            self.reconcile(chart_dir, declaration)
+        self.surface.charts.sort()
+        self.surface.values_files.sort()
+        return self.surface
+
+    # -- one chart ---------------------------------------------------------------------------
+
+    def reconcile(self, chart_dir: Path, declaration: Declaration) -> None:
+        values = _read_yaml(chart_dir / "values.yaml")
+        app_version = _read_yaml(chart_dir / "Chart.yaml").get("appVersion")
+
+        bindings: dict[str, Binding] = {}
+        for document in declaration.documents:
+            binding, problems = bind(chart_dir, document, values, app_version)
+            if binding is None:
+                for problem in problems:
+                    self.surface.notes.append(
+                        f"{declaration.chart}: {document.name}: not reconciled: {problem}"
+                    )
+                continue
+            bindings[document.name] = binding
+
+        if not bindings:
+            return
+
+        # Which contract describes the image a container runs, chart-wide rather than per
+        # document. An init container inside the `api` Deployment may run the `bootstrap` image,
+        # and the `api` document's binding has never heard of it — which is exactly the case the
+        # over-projection check exists to see.
+        by_digest: dict[str, cc.Union] = {}
+        for binding in bindings.values():
+            by_digest.update(binding.by_digest)
+
+        contracts = [
+            (label, union)
+            for binding in bindings.values()
+            for label, union in _labelled(binding).items()
+        ]
+
+        renders = sorted(self.rendered.glob(f"{declaration.chart}--*.yaml"))
+        if not renders:
+            self.surface.notes.append(
+                f"{declaration.chart}: no rendered manifests; nothing to reconcile against"
+            )
+            return
+
+        self.surface.charts.append(declaration.chart)
+        ledger = Ledger()
+        seen_values: list[str] = []
+
+        for render in renders:
+            values_file = render.name.split("--", 1)[1]
+            seen_values.append(values_file)
+            if values_file not in self.surface.values_files:
+                self.surface.values_files.append(values_file)
+            manifests = load_manifests(render)
+            self.scan_render(
+                declaration, bindings, by_digest, contracts, manifests, values_file, ledger
+            )
+
+        self.collect(chart_dir, declaration, ledger, tuple(seen_values))
+
+    def scan_render(
+        self,
+        declaration: Declaration,
+        bindings: dict[str, Binding],
+        by_digest: dict[str, cc.Union],
+        contracts: list[tuple[str, cc.Union]],
+        manifests: list[dict[str, Any]],
+        values_file: str,
+        ledger: Ledger,
+    ) -> None:
+        judged = self.gate_three_reach(declaration, manifests)
+
+        for document in declaration.documents:
+            binding = bindings.get(document.name)
+            if binding is not None:
+                self.scan_document(document, binding, manifests, ledger)
+
+        # Every workload, found by shape rather than by a list of kinds: anything carrying a pod
+        # template has containers, and anything else yields none. A kind list here would need
+        # editing the first time a chart grew a workload nobody thought of.
+        for manifest in manifests:
+            spec = pod_spec(manifest)
+            found = containers_of(spec)
+            if not found:
+                continue
+            workload = (
+                f"{manifest.get('kind')} "
+                f"{(manifest.get('metadata') or {}).get('name', '?')}"
+            )
+            for name, container in sorted(found.items()):
+                mine = by_digest.get(digest_of(str(container.get("image") or "")) or "")
+                if mine is None:
+                    continue
+                self.scan_container(
+                    declaration, contracts, manifests, spec, mine, values_file, workload,
+                    name, container, judged, ledger,
+                )
+
+    def scan_document(
+        self,
+        document: Document,
+        binding: Binding,
+        manifests: list[dict[str, Any]],
+        ledger: Ledger,
+    ) -> None:
+        """Record the keys the rendered plaintext document sets, as one delivery channel."""
+        matched = select(manifests, document.source.kind, document.source.selector)
+        if len(matched) != 1:
+            return
+        text = (matched[0].get("data") or {}).get(document.source.key)
+        if not isinstance(text, str):
+            return
+        try:
+            instance = parse_document(text, document.source.format)
+        except Exception:  # noqa: BLE001 — an unparseable document is gate 1's finding, not ours
+            return
+
+        present = document_paths(instance)
+        for label, union in _labelled(binding).items():
+            for path in union.keys:
+                if path in present:
+                    ledger.supply(label, path, DOCUMENT)
+
+    def scan_container(
+        self,
+        declaration: Declaration,
+        contracts: list[tuple[str, cc.Union]],
+        manifests: list[dict[str, Any]],
+        spec: dict[str, Any],
+        mine: cc.Union,
+        values_file: str,
+        workload: str,
+        name: str,
+        container: dict[str, Any],
+        judged: set[tuple[str, str]],
+        ledger: Ledger,
+    ) -> None:
+        label = mine.sources[0]
+        view = ContainerView.read(container, mine)
+        secrets_dir = view.secrets_dir.rstrip("/") if view.secrets_dir else None
+
+        for variable in sorted(view.values):
+            decision = cc.classify(mine, variable)
+            entry = decision.entry or {}
+            if decision.kind == cc.KEY_ENV:
+                ledger.supply(label, entry["path"], ENVIRONMENT)
+            elif decision.kind == cc.KEY_ENV_FILE:
+                ledger.supply(label, entry["path"], INDIRECTION)
+
+        for mount in container.get("volumeMounts") or []:
+            volume = str(mount.get("name") or "")
+            path = str(mount.get("mountPath") or "").rstrip("/")
+            if not volume:
+                continue
+            for file_name in secret_file_names(manifests, spec, volume):
+                self.scan_file(
+                    declaration, contracts, mine, label, view, secrets_dir, values_file,
+                    workload, name, path, file_name, judged, ledger,
+                )
+
+    def scan_file(
+        self,
+        declaration: Declaration,
+        contracts: list[tuple[str, cc.Union]],
+        mine: cc.Union,
+        label: str,
+        view: ContainerView,
+        secrets_dir: str | None,
+        values_file: str,
+        workload: str,
+        container: str,
+        mount_path: str,
+        file_name: str,
+        judged: set[tuple[str, str]],
+        ledger: Ledger,
+    ) -> None:
+        in_secrets_dir = secrets_dir is not None and mount_path == secrets_dir
+        by_indirection = f"{mount_path}/{file_name}" in view.indirect
+
+        key = mine.key_by("secrets_file", file_name)
+        dynamic = mine.container_of("secrets_file", file_name) if key is None else None
+
+        if key is not None or dynamic is not None:
+            owned = key if key is not None else dynamic
+            if in_secrets_dir:
+                ledger.supply(label, owned["path"], SECRETS_DIRECTORY)
+            elif by_indirection:
+                ledger.supply(label, owned["path"], INDIRECTION)
+            # A file whose exact key the contract calls ordinary configuration, delivered as a
+            # Secret anyway. Legitimate — chart policy may treat a value as more sensitive than
+            # the image does, and gate 3 permits it for any `text` key — so it is stated and never
+            # counted against the chart. Only an exact match is judged: a dynamic map's leaves
+            # have no sensitivity of their own for the contract to state. And only a
+            # file-supplyable key, because the same mount of a key of any other form is gate 3's
+            # error rather than a policy choice, and it already says so at length.
+            if key is not None and not key.get("secret") and cc.file_supplyable(key):
+                ledger.elevate(key, file_name, f"{container} ({_short(label)})")
+            return
+
+        mount = Mount(
+            chart=declaration.chart,
+            values_file=values_file,
+            workload=workload,
+            container=container,
+            image=_short(label),
+            mount_path=mount_path,
+            file_name=file_name,
+            judged_by_gate_three=in_secrets_dir and (workload, container) in judged,
+        )
+        if mount.judged_by_gate_three:
+            return
+
+        if _named_anywhere(contracts, file_name):
+            self.surface.over_projected.append(mount)
+        else:
+            self.surface.unclaimed.append(mount)
+
+    # -- gate 3's reach ----------------------------------------------------------------------
+
+    def gate_three_reach(
+        self, declaration: Declaration, manifests: list[dict[str, Any]]
+    ) -> set[tuple[str, str]]:
+        """The `(workload, container)` pairs `just check-config` already inspects the mounts of.
+
+        `check-config.py` walks the consumers a `config-contract.yaml` declares and the containers
+        each one names, so a container absent from that list — an init container, a sidecar, a
+        workload whose selector matches nothing — is a container gate 3 never opens. Recomputing
+        the same selection here is what lets this report stay silent about files gate 3 has
+        already reported and speak about the ones it cannot see.
+        """
+        reach: set[tuple[str, str]] = set()
+        for document in declaration.documents:
+            for consumer in document.consumers:
+                for workload in select(manifests, consumer.kind, consumer.selector):
+                    identity = (
+                        f"{workload.get('kind')} "
+                        f"{(workload.get('metadata') or {}).get('name', '?')}"
+                    )
+                    present = containers_of(pod_spec(workload))
+                    for name in consumer.containers:
+                        if name in present:
+                            reach.add((identity, name))
+        return reach
+
+    # -- turning the scan into findings ------------------------------------------------------
+
+    def collect(
+        self,
+        chart_dir: Path,
+        declaration: Declaration,
+        ledger: Ledger,
+        values_files: tuple[str, ...],
+    ) -> None:
+        for credential in credentials(declared_secrets(chart_dir, declaration)):
+            # Delivered by any one of the images that declare it is delivered: the credential is
+            # one artefact an operator creates, and the report is about that artefact existing.
+            # Which image reads it where is the over-projection question, one report down.
+            if any(
+                ledger.supplies(contract, credential.path) for contract in credential.contracts
+            ):
+                continue
+            named_in = names_credential(chart_dir, credential)
+            self.surface.undeliverable.append(
+                Undeliverable(
+                    credential=credential,
+                    values_files=values_files,
+                    named_by_chart=bool(named_in),
+                    named_in=named_in,
+                )
+            )
+
+        for (path, file_name, text_form), containers in sorted(ledger.elevated.items()):
+            self.surface.elevated.append(
+                Elevated(
+                    chart=declaration.chart,
+                    path=path,
+                    file_name=file_name,
+                    text_form=text_form,
+                    containers=tuple(sorted(containers)),
+                )
+            )
+
+
+def _labelled(binding: Binding) -> dict[str, cc.Union]:
+    """One image's contract by the label that names its vendored file."""
+    return {union.sources[0]: union for union in binding.by_digest.values()}
+
+
+def _named_anywhere(contracts: list[tuple[str, cc.Union]], file_name: str) -> bool:
+    """Whether any contract this chart vendors claims the file name, exactly or as a map leaf.
+
+    Deliberately not `cc.union_contracts`: unioning nine contracts is a merge that can fail on a
+    disagreement between two of them, and a report that refuses to run because two images document
+    one key differently has traded the answer for a check `just check-config` already makes.
+    """
+    for _, union in contracts:
+        if union.key_by("secrets_file", file_name) is not None:
+            return True
+        if union.container_of("secrets_file", file_name) is not None:
+            return True
+    return False
+
+
+def names_credential(chart_dir: Path, credential: Credential) -> tuple[str, ...]:
+    """The chart's own files that mention any spelling of one credential.
+
+    Answers the question no fixed set of renders can: could *some* values file supply this? A
+    chart that writes `telemetry.sentry_dsn` into its document when an operator sets a value names
+    the key in a template and in `values.yaml`, and the only thing missing is a `ci/` fixture that
+    sets it. A chart that names it nowhere has no channel at all.
+
+    Matched with boundaries rather than as a substring, because the spellings nest: this
+    repository's `internal__tokens__api` contains `internal__token`, and a substring search would
+    report the retired tier-wide key as deliverable on the strength of an unrelated one. The
+    boundary is "not another character the spelling could continue with", which is what makes
+    those two distinguishable at all.
+
+    A heuristic, and deliberately one that only chooses between two reports rather than producing
+    one: a chart that assembled a file name by concatenation would name no spelling and be read as
+    having no channel. Every finding is still grounded in what the render did — this decides how
+    loudly to say it, never whether there is anything to say.
+    """
+    spellings = [
+        spelling
+        for spelling in (
+            credential.path,
+            credential.secrets_file,
+            credential.env,
+            credential.env_file,
+        )
+        if spelling
+    ]
+    pattern = re.compile(
+        "|".join(rf"(?<![\w.]){re.escape(spelling)}(?![\w])" for spelling in spellings)
+    )
+
+    found: list[str] = []
+    for path in sorted(_chart_files(chart_dir)):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if pattern.search(text):
+            found.append(path.relative_to(chart_dir).as_posix())
+    return tuple(found)
+
+
+def _chart_files(chart_dir: Path) -> Iterable[Path]:
+    """Everything under a chart that describes what it delivers, dependencies excluded."""
+    for pattern in CHART_TEXT:
+        for path in chart_dir.rglob(pattern):
+            relative = path.relative_to(chart_dir).parts
+            if relative and relative[0] in EXCLUDED_DIRS:
+                continue
+            yield path
+
+
+def _first_line(docs: Any) -> str:
+    if not isinstance(docs, str):
+        return ""
+    for line in docs.splitlines():
+        if line.strip():
+            return line.strip()
+    return ""
+
+
+def _short(label: str) -> str:
+    """`tankovault/contracts/api.json` as `api` — the vendored file, without the path around it."""
+    return Path(label).stem
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}

--- a/.github/scripts/tests/test_contract_secrets.py
+++ b/.github/scripts/tests/test_contract_secrets.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""The credential surface, over hand-built volumes and contracts rather than over a render.
+
+Every rule in `config_secrets.py` is a decision about *which* report a fact belongs in, and each
+of them has a plausible-looking wrong answer that a run against this repository would not expose:
+the charts here happen to be clean of unclaimed names, so a test that only ran the reconciler over
+`rendered/` would pass whether the unclaimed branch worked or not.
+
+Four rules are worth stating as tests, because getting any of them wrong turns the report into
+noise nobody reads:
+
+  the Secret-only read      `config.toml` arrives from a ConfigMap in the same projected volume,
+                            and counting it as a credential would make every pod look wrong
+
+  the boundary match        `internal__tokens__api` contains `internal__token`, so a substring
+                            search calls the retired tier-wide key deliverable on the strength of
+                            an unrelated one, and downgrades the only finding that mattered
+
+  gate 3's reach            a file that gate 3 already judged must produce no second line here,
+                            and the condition is both halves: a resolved secrets directory *and*
+                            a container the declaration lists as a consumer
+
+  own contract, not union   a file a sibling image declares is over-projection; a file nobody
+                            declares is unclaimed. Scoring both against the union would collapse
+                            the distinction the whole report rests on
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from dataclasses import replace
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+
+import config_contract as cc  # noqa: E402
+from config_declaration import Consumer, Declaration, Document, Source  # noqa: E402
+from config_gate_container import ContainerView  # noqa: E402
+from config_secrets import (  # noqa: E402
+    Declared,
+    Ledger,
+    Reconciler,
+    credentials,
+    document_paths,
+    names_credential,
+    secret_file_names,
+)
+
+FIXTURES = SCRIPTS.parent / "testdata" / "contracts"
+
+
+def _load(name: str, filename: str):
+    """Import a hyphenated entry point, the way `test_contract_refresh` already does."""
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+entry = _load("config_secrets_entry", "config-secrets.py")
+
+
+def fixture(name: str) -> dict:
+    return json.loads((FIXTURES / f"{name}.json").read_text(encoding="utf-8"))
+
+
+def union(name: str, contract: dict | None = None) -> cc.Union:
+    return cc.union_contracts([(name, contract if contract is not None else fixture(name))])
+
+
+def with_plain_text_key(name: str = "api") -> dict:
+    """The `api` fixture plus one `text` key the image does *not* consider secret.
+
+    No fixture on disk carries that combination, and it is the exact shape of the two keys this
+    repository's `tankovault` chart elevates — a value the image treats as ordinary configuration
+    and the chart delivers as a Secret file anyway.
+    """
+    contract = copy.deepcopy(fixture(name))
+    contract["schema"]["keys"].append(
+        {
+            "path": "email.username",
+            "env": "FIXTURE_EMAIL__USERNAME",
+            "env_file": "FIXTURE_EMAIL__USERNAME_FILE",
+            "secrets_file": "email__username",
+            "docs": "The mailbox login.",
+            "ty": "String",
+            "values": [],
+            "constraint": {"type": "string"},
+            "text_constraint": None,
+            "text_form": "text",
+            "aliases": [],
+            "default": None,
+            "default_value": None,
+            "note": None,
+            "required": False,
+            "secret": False,
+            "reserved": False,
+        }
+    )
+    return contract
+
+
+def declaration(chart: str = "fixture") -> Declaration:
+    return Declaration(chart=chart, path=Path(chart), documents=[], reason=None, unconfigured=[])
+
+
+def container(name: str = "app", env: dict | None = None, mounts: list | None = None) -> dict:
+    return {
+        "name": name,
+        "image": "example/app:v1@sha256:" + "0" * 64,
+        "env": [{"name": key, "value": value} for key, value in (env or {}).items()],
+        "volumeMounts": list(mounts or []),
+    }
+
+
+# --------------------------------------------------------------------------------------------
+# What a volume delivers
+# --------------------------------------------------------------------------------------------
+
+
+class TestSecretFileNames(unittest.TestCase):
+    def test_a_projected_volume_reports_only_its_secret_sources(self):
+        spec = {
+            "volumes": [
+                {
+                    "name": "config",
+                    "projected": {
+                        "sources": [
+                            {"configMap": {"name": "cm", "items": [{"key": "config.toml"}]}},
+                            {"secret": {"name": "s", "items": [{"key": "k", "path": "db__url"}]}},
+                        ]
+                    },
+                }
+            ]
+        }
+        self.assertEqual(secret_file_names([], spec, "config"), ["db__url"])
+
+    def test_a_source_without_items_presents_every_key_of_the_rendered_secret(self):
+        spec = {"volumes": [{"name": "creds", "secret": {"secretName": "existing"}}]}
+        manifests = [
+            {
+                "kind": "Secret",
+                "metadata": {"name": "existing"},
+                "data": {"database__url": "eA=="},
+                "stringData": {"auth__jwt_secret": "x"},
+            }
+        ]
+        self.assertEqual(
+            secret_file_names(manifests, spec, "creds"), ["auth__jwt_secret", "database__url"]
+        )
+
+    def test_a_secret_the_operator_supplies_contributes_no_names(self):
+        spec = {"volumes": [{"name": "creds", "secret": {"secretName": "not-rendered"}}]}
+        self.assertEqual(secret_file_names([], spec, "creds"), [])
+
+    def test_a_volume_the_pod_does_not_have_is_not_an_error(self):
+        self.assertEqual(secret_file_names([], {"volumes": []}, "missing"), [])
+
+
+class TestDocumentPaths(unittest.TestCase):
+    def test_every_table_and_every_leaf_is_a_path(self):
+        paths = document_paths({"auth": {"jwt_secret": "x"}, "port": 8080})
+        self.assertEqual(paths, {"auth", "auth.jwt_secret", "port"})
+
+
+# --------------------------------------------------------------------------------------------
+# The inventory
+# --------------------------------------------------------------------------------------------
+
+
+def declared(chart="c", document="d", contract="c/contracts/a.json", image="a", required=False):
+    return Declared(
+        chart=chart,
+        document=document,
+        contract=contract,
+        image=image,
+        path="database.url",
+        secrets_file="database__url",
+        env="FIXTURE_DATABASE__URL",
+        env_file="FIXTURE_DATABASE__URL_FILE",
+        text_form="text",
+        required=required,
+        summary="The connection string.",
+    )
+
+
+class TestCredentials(unittest.TestCase):
+    def test_two_images_reading_one_key_are_one_row_naming_both(self):
+        rows = credentials(
+            [
+                declared(document="api", contract="c/contracts/api.json", image="api"),
+                declared(document="worker", contract="c/contracts/worker.json", image="worker"),
+            ]
+        )
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].images, ("api", "worker"))
+        self.assertEqual(rows[0].documents, ("api", "worker"))
+
+    def test_required_unions_the_way_the_contract_model_unions_it(self):
+        rows = credentials([declared(image="a"), declared(image="b", required=True)])
+        self.assertEqual(len(rows), 1)
+        self.assertTrue(rows[0].required)
+
+    def test_two_spellings_of_one_path_stay_two_rows(self):
+        renamed = replace(declared(image="b"), secrets_file="db__url")
+        rows = credentials([declared(image="a"), renamed])
+        self.assertEqual(len(rows), 2)
+
+
+class TestNamesCredential(unittest.TestCase):
+    """The boundary match, which is what keeps a nested spelling from masking its own prefix."""
+
+    def setUp(self):
+        self.work = tempfile.TemporaryDirectory()
+        self.chart = Path(self.work.name)
+        self.addCleanup(self.work.cleanup)
+        (self.chart / "contracts").mkdir()
+        (self.chart / "templates").mkdir()
+
+    def credential(self, path="internal.token", secrets_file="internal__token"):
+        rows = credentials(
+            [
+                Declared(
+                    chart="c",
+                    document="d",
+                    contract="c/contracts/a.json",
+                    image="a",
+                    path=path,
+                    secrets_file=secrets_file,
+                    env="TANKOVAULT_INTERNAL__TOKEN",
+                    env_file="TANKOVAULT_INTERNAL__TOKEN_FILE",
+                    text_form="text",
+                    required=False,
+                    summary="",
+                )
+            ]
+        )
+        return rows[0]
+
+    def test_a_longer_spelling_that_contains_the_shorter_one_does_not_name_it(self):
+        (self.chart / "templates" / "_secrets.tpl").write_text(
+            'key: {{ printf "internal__tokens__%s" . }}\n{{ .Values.internal.tokens }}\n',
+            encoding="utf-8",
+        )
+        self.assertEqual(names_credential(self.chart, self.credential()), ())
+
+    def test_the_spelling_itself_names_it(self):
+        (self.chart / "values.yaml").write_text("# internal.token is gone\n", encoding="utf-8")
+        self.assertEqual(names_credential(self.chart, self.credential()), ("values.yaml",))
+
+    def test_the_vendored_contracts_are_not_evidence_that_the_chart_delivers_it(self):
+        (self.chart / "contracts" / "a.json").write_text(
+            '{"secrets_file": "internal__token"}', encoding="utf-8"
+        )
+        self.assertEqual(names_credential(self.chart, self.credential()), ())
+
+
+# --------------------------------------------------------------------------------------------
+# The reconciliation
+# --------------------------------------------------------------------------------------------
+
+
+class TestScanFile(unittest.TestCase):
+    """One mounted file at a time, which is where every one of the three reports is decided."""
+
+    def setUp(self):
+        self.mine = union("worker")
+        self.sibling = union("api")
+        self.contracts = [("worker", self.mine), ("api", self.sibling)]
+        self.reconciler = Reconciler(Path("charts"), Path("rendered"))
+        self.ledger = Ledger()
+
+    def scan(
+        self,
+        file_name: str,
+        mount_path: str = "/secrets",
+        secrets_dir: str | None = "/secrets",
+        judged: set | None = None,
+        mine: cc.Union | None = None,
+        env: dict | None = None,
+    ) -> None:
+        chosen = mine or self.mine
+        view = ContainerView.read(container(env=env or {}), chosen)
+        self.reconciler.scan_file(
+            declaration(),
+            self.contracts,
+            chosen,
+            chosen.sources[0],
+            view,
+            secrets_dir,
+            "default.yaml",
+            "Deployment app",
+            "app",
+            mount_path,
+            file_name,
+            judged if judged is not None else set(),
+            self.ledger,
+        )
+
+    def test_a_key_the_container_reads_is_recorded_as_supplied_and_reported_nowhere(self):
+        self.scan("database__url")
+        self.assertEqual(
+            self.ledger.supplied, {("worker", "database.url"): {"the secrets directory"}}
+        )
+        self.assertEqual(self.reconciler.surface.unclaimed, [])
+        self.assertEqual(self.reconciler.surface.over_projected, [])
+
+    def test_a_file_outside_the_secrets_directory_supplies_nothing_without_indirection(self):
+        self.scan("database__url", mount_path="/elsewhere")
+        self.assertEqual(self.ledger.supplied, {})
+
+    def test_a_file_named_by_a_file_variable_supplies_its_key_wherever_it_is_mounted(self):
+        self.scan(
+            "database__url",
+            mount_path="/elsewhere",
+            env={"FIXTURE_DATABASE__URL_FILE": "/elsewhere/database__url"},
+        )
+        self.assertEqual(
+            self.ledger.supplied, {("worker", "database.url"): {"`_FILE` indirection"}}
+        )
+
+    def test_a_sibling_images_key_is_over_projection_rather_than_an_unknown_name(self):
+        self.scan("auth__session_ttl", secrets_dir="/other")
+        self.assertEqual(self.reconciler.surface.unclaimed, [])
+        self.assertEqual(len(self.reconciler.surface.over_projected), 1)
+        self.assertEqual(self.reconciler.surface.over_projected[0].file_name, "auth__session_ttl")
+
+    def test_a_name_no_contract_of_the_chart_spells_is_unclaimed(self):
+        self.scan("nothing__spells_this", secrets_dir="/other")
+        self.assertEqual(self.reconciler.surface.over_projected, [])
+        self.assertEqual(len(self.reconciler.surface.unclaimed), 1)
+
+    def test_a_file_gate_three_already_judged_produces_no_second_line(self):
+        self.scan("nothing__spells_this", judged={("Deployment app", "app")})
+        self.assertEqual(self.reconciler.surface.unclaimed, [])
+        self.assertEqual(self.reconciler.surface.over_projected, [])
+
+    def test_gate_three_needs_both_halves_before_it_owns_the_verdict(self):
+        # The declaration lists the container, but the file is outside the secrets directory that
+        # gate 3 resolves — so gate 3 never inspected it and this report must still speak.
+        self.scan(
+            "nothing__spells_this",
+            mount_path="/elsewhere",
+            judged={("Deployment app", "app")},
+        )
+        self.assertEqual(len(self.reconciler.surface.unclaimed), 1)
+
+    def test_a_non_secret_text_key_delivered_as_a_secret_is_recorded_as_policy(self):
+        mine = union("api", with_plain_text_key())
+        self.contracts = [("api", mine)]
+        self.scan("email__username", mine=mine)
+        self.assertEqual(
+            list(self.ledger.elevated), [("email.username", "email__username", "text")]
+        )
+        self.assertEqual(self.reconciler.surface.over_projected, [])
+
+    def test_a_non_secret_key_no_file_can_supply_is_left_to_gate_three(self):
+        # `worker.concurrency` is an integer, and gate 3 already refuses the mount at length.
+        self.scan("worker__concurrency")
+        self.assertEqual(self.ledger.elevated, {})
+
+
+class TestGateThreeReach(unittest.TestCase):
+    """Which containers `just check-config` already opens, recomputed from the declaration."""
+
+    def setUp(self):
+        self.reconciler = Reconciler(Path("charts"), Path("rendered"))
+        self.manifests = [
+            {
+                "kind": "Deployment",
+                "metadata": {"name": "app", "labels": {"app.kubernetes.io/component": "api"}},
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "initContainers": [{"name": "migrate"}],
+                            "containers": [{"name": "api"}],
+                        }
+                    }
+                },
+            }
+        ]
+
+    def declaration_naming(self, *containers: str) -> Declaration:
+        document = Document(
+            name="api",
+            source=Source(kind="ConfigMap", selector={}, key="config.toml", format="toml"),
+            images=[],
+            consumers=[
+                Consumer(
+                    kind="Deployment",
+                    selector={"app.kubernetes.io/component": "api"},
+                    containers=list(containers),
+                )
+            ],
+            exempt=[],
+        )
+        return Declaration(
+            chart="c", path=Path("c"), documents=[document], reason=None, unconfigured=[]
+        )
+
+    def test_a_declared_container_is_within_reach(self):
+        reach = self.reconciler.gate_three_reach(self.declaration_naming("api"), self.manifests)
+        self.assertEqual(reach, {("Deployment app", "api")})
+
+    def test_an_init_container_no_declaration_names_is_not(self):
+        reach = self.reconciler.gate_three_reach(self.declaration_naming("api"), self.manifests)
+        self.assertNotIn(("Deployment app", "migrate"), reach)
+
+
+# --------------------------------------------------------------------------------------------
+# The rendering
+# --------------------------------------------------------------------------------------------
+
+
+class TestGrouping(unittest.TestCase):
+    def test_one_container_over_projecting_several_files_is_one_row(self):
+        from config_secrets import Mount
+
+        def mount(file_name: str, values_file: str) -> Mount:
+            return Mount(
+                chart="c",
+                values_file=values_file,
+                workload="Deployment app",
+                container="migrate",
+                image="bootstrap",
+                mount_path="/secrets",
+                file_name=file_name,
+                judged_by_gate_three=False,
+            )
+
+        rows = entry._by_container(
+            [mount("a", "one.yaml"), mount("b", "one.yaml"), mount("a", "two.yaml")]
+        )
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][4], ("a", "b"))
+        self.assertEqual(rows[0][5], ("one.yaml", "two.yaml"))
+
+
+class TestCommonPrefix(unittest.TestCase):
+    def test_the_dialect_prefix_is_what_every_spelling_shares(self):
+        self.assertEqual(entry._common_prefix(["FIXTURE_A__B", "FIXTURE_C__D"]), "FIXTURE_")
+
+    def test_nothing_shared_is_no_prefix(self):
+        self.assertEqual(entry._common_prefix(["A_ONE", "B_TWO"]), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/just/contracts.just
+++ b/just/contracts.just
@@ -191,3 +191,70 @@ explain chart='' pattern='' *flags:
     {{ resolve_python }}
     "$python" {{ scripts }}/explain-config.py '{{ chart }}' '{{ pattern }}' \
       --charts {{ charts }} {{ flags }}
+
+# --------------------------------------------------------------------------------------------
+# The credential surface
+# --------------------------------------------------------------------------------------------
+
+# List every credential the images in this repository declare secret, and how each one is spelt.
+#
+# Forty-seven key declarations across the tree carry `secret: true`, and until this recipe existed
+# no document anywhere said what they are. Somebody writing a values file has to know which
+# credentials a chart needs, what to name the keys of the Secret that carries them, which
+# environment spelling and which `_FILE` spelling address the same value, and — for a chart whose
+# services run different binaries — which of them actually reads each one. Every part of that
+# answer was already published by the images and readable only by opening nine JSON documents by
+# hand.
+#
+# Reads the committed contracts and nothing else: no render, no cluster, no network. Cheap enough
+# to run while writing the values file it exists to help with, which is the only time it is
+# wanted.
+#
+# Deliberately skips the staleness interlock the gates apply. A Renovate digest bump produces one
+# run in which the pinned digest and the vendored contract disagree, and withholding the inventory
+# then would remove the document at exactly the moment a reviewer is reading a credential change.
+# Whether the vendored copy is current is `just check-contracts`' question, and it answers it in
+# one line rather than by refusing to describe anything.
+#
+# `--json` for a machine; the table is the answer for a person.
+[doc("List every credential the images declare secret, and how each one is spelt")]
+[group('contracts')]
+config-secrets *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    {{ resolve_python }}
+    "$python" {{ scripts }}/config-secrets.py --charts {{ charts }} {{ args }}
+
+# Report what the charts deliver against the credentials the images declare. Report only.
+#
+# The gates in `check-config` are structurally unable to ask this. Gate 3 checks that every secret
+# file a pod is *given* is a name the contract knows, so it refuses a name nothing declares and is
+# blind by construction to the opposite defect: a credential the image declares and no channel
+# supplies. That one renders cleanly, passes every gate, starts, reports healthy, and fails at the
+# first request that needs it. Gate 3 is also scoped to the containers a `config-contract.yaml`
+# names as consumers, so an init container or a sidecar sharing the pod is a container no gate
+# opens — and several Deployments here run one that mounts the whole per-service credential set
+# while running a different image entirely.
+#
+# Reuses `just render`, so the manifests read here are the ones every other gate reads: one
+# render, one set of facts. Reconciled against every `ci/` values file each chart ships, because a
+# credential delivered under one fixture is delivered — the chart has a channel for it — while
+# over-projection is a property of the fixture that produced it and is reported naming that file.
+#
+# **Exits 0 whatever it finds, and that is the point of the first pass.** Its three questions are
+# new, and a report over an established repository is where they earn their triage: a finding that
+# turns out to be a considered design decision belongs in a document, not in a red pipeline on a
+# pull request that changed nothing. A follow-up promotes it once these findings are triaged, and
+# the promotion is one line of `config-secrets.py` — the findings are already `Finding`s at the
+# level each has earned, so nothing else moves.
+#
+# Deliberately not in `just check` for the same reason: an aggregate a contributor is expected to
+# run before pushing must not be a place where advisory output accumulates.
+[doc("Report what the charts deliver against the credentials the images declare (report only)")]
+[group('contracts')]
+check-config-secrets out='rendered' *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    {{ resolve_python }}
+    just render '{{ out }}'
+    "$python" {{ scripts }}/config-secrets.py --reconcile '{{ out }}' --charts {{ charts }} {{ args }}


### PR DESCRIPTION
Adds `just config-secrets` (inventory) and `just check-config-secrets` (reconciliation, report-only, exits 0).

## Why

23 distinct keys across six charts are declared `secret: true` by the images that read them, and no document states what they are, how each is delivered, or which pods can see them. The existing gates are structurally blind to a *missing* one: gate 3 checks that every mounted secret file name is **known** to the contract, so it rejects an unknown name and cannot see a contract key nothing supplies.

## What it reports

- **Inventory** — every secret declaration with its `secrets_file`, environment spelling, required flag and readers. No render, no network.
- **Undeliverable** — a contract secret key no rendering can supply through any channel.
- **Over-projection** — a secret file mounted into a container whose own image's contract does not declare that key.
- **Unclaimed** / **elevated** — context, and chart policy treating a `secret: false` key as sensitive.

Scoped **per document, per image** — never chart-wide. Each judgement is made against a single-contract binding, so a key only `notifier` reads stays genuinely unknown to `api`; collapsing them would mask the over-projection this exists to find.

## It found a real least-privilege defect

The `migrate` init container inside the service Deployments runs the `tankovault-bootstrap` image but mounts the **host service's** secrets volume in full. Rendering `tankovault-api` with `ci/minimal-values.yaml`, that volume projects eight keys:

```
auth__jwt_secret, auth__mfa_encryption_key, auth__password_pepper, database__url,
email__password, email__username, internal__caller__token, redis__url
```

The bootstrap binary reads three, and the chart already says which — `tankovault.bootstrapSecretKeys` lists `database__url`, `auth__password_pepper`, `seed_admin_password`. The migration step can therefore read the JWT signing key, the MFA encryption key, the SMTP password and the inter-service token. Same shape on `control-plane`, `notifier`, `sync` and `worker`.

Nothing catches it because gate 3 only opens containers a `config-contract.yaml` names as consumers. The service documents list `containers: [api]`; the `bootstrap` document's consumer selects a **Job**, not a Deployment. The identically-named init container inside a Deployment is examined by nothing.

Weighed honestly: the init container shares a pod with the service container that legitimately holds these credentials, so this is not a cross-boundary exposure. It is still a different binary with a different attack surface at a different lifecycle stage. Fixed separately, not here.

Also found: `email__url` is declared secret by two images and supplied nowhere in the chart (deliberate — the chart surfaces the decomposed `email__host`/`port`/`username`/`password` form — but unrecorded).

## Report-only, on purpose

Exits 0 regardless of findings, and is not in `just check`. Promotion to a gate is one line; doing it here would mean fixing or exempting the findings under cover of a tooling change.

## Verification

`just test-contract-union` — 160 passing (135 pre-existing + 25 new). `just check-config` still green. No chart file touched.

## Review notes

- The undeliverable category is split into error and warning by a **boundary-matched textual search** of the chart. That is a heuristic inside an otherwise structural tool. Its defence is that `internal__tokens__api` contains `internal__token`, so a naive substring search would silently downgrade the retired key on the strength of an unrelated one — and it only chooses how loudly to speak, never whether there is a finding. Softest part of the PR; worth reading closest.
- The inventory counts 23 distinct paths. Counting *declarations* across contracts gives 47, since `database__url` is declared by six TankoVault images. Header wording should make the unit unambiguous.