### PR TITLE
fix(tankovault): scope the migration initContainer's secrets to what it reads

### DIFF
--- a/charts/tankovault/Chart.yaml
+++ b/charts/tankovault/Chart.yaml
@@ -1,6 +1,6 @@
 name: tankovault
 description: This chart deploys the full TankoVault manga aggregator stack — frontend, api, control-plane, worker, notifier, sync, challenge-solver and render — hardened to the restricted Pod Security Standard, with file-backed configuration that reloads in place instead of restarting pods, optional bundled PostgreSQL, Valkey, NATS JetStream and TRAWL, and optional Prometheus metrics, alerting rules and Grafana dashboards.
-version: 5.2.0
+version: 5.2.1
 appVersion: 8.1.1
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts

--- a/charts/tankovault/README.md
+++ b/charts/tankovault/README.md
@@ -1,6 +1,6 @@
 # tankovault
 
-![Version: 5.2.0](https://img.shields.io/badge/Version-5.2.0-informational?style=flat-square) ![AppVersion: 8.1.1](https://img.shields.io/badge/AppVersion-8.1.1-informational?style=flat-square)
+![Version: 5.2.1](https://img.shields.io/badge/Version-5.2.1-informational?style=flat-square) ![AppVersion: 8.1.1](https://img.shields.io/badge/AppVersion-8.1.1-informational?style=flat-square)
 
 This chart deploys the full TankoVault manga aggregator stack — frontend, api, control-plane, worker, notifier, sync, challenge-solver and render — hardened to the restricted Pod Security Standard, with file-backed configuration that reloads in place instead of restarting pods, optional bundled PostgreSQL, Valkey, NATS JetStream and TRAWL, and optional Prometheus metrics, alerting rules and Grafana dashboards.
 

--- a/charts/tankovault/templates/_bootstrap.tpl
+++ b/charts/tankovault/templates/_bootstrap.tpl
@@ -30,6 +30,45 @@ never log in — a failure that looks like a wrong password rather than a miscon
 {{- end -}}
 
 {{/*
+The subset of those keys `seed-admin` alone reads.
+
+Both are credentials of the account that step creates, and no other subcommand opens either:
+the pepper is the hashing parameter and the password is the plaintext being hashed. Named here
+rather than inlined below so that `tankovault.bootstrapSecretKeys` stays the one list of what
+the image reads, and what follows is visibly a subtraction from it rather than a second copy
+free to drift alongside it.
+*/}}
+{{- define "tankovault.seedAdminSecretKeys" -}}
+- auth__password_pepper
+- seed_admin_password
+{{- end -}}
+
+{{/*
+The credential keys `bootstrap migrate` reads: applying a schema needs the database URL and
+nothing else.
+
+This exists because the migration is not always a pod of its own. As an initContainer it runs
+inside a service pod, and mounting that pod's own `secrets` volume would hand it every
+credential the service reads — on `api`, eight keys against the one this command opens. Same
+pod, so not a boundary crossing; but a different binary with a different attack surface,
+running at a different point in the pod's life, has no call for the token signing key, the MFA
+sealing key, the SMTP password or an internal caller token.
+
+That the pepper is not among them is not an inference: `control-plane`, `worker`, `notifier`
+and `sync` never project it, and the migration has always run on their pods.
+
+Args: ctx (root).
+*/}}
+{{- define "tankovault.migrateSecretKeys" -}}
+{{- $seedOnly := include "tankovault.seedAdminSecretKeys" . | fromYamlArray -}}
+{{- range $key := include "tankovault.bootstrapSecretKeys" . | fromYamlArray -}}
+{{- if not (has $key $seedOnly) }}
+- {{ $key }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 The values tree the bootstrap workloads render against — `.Values.defaults` with the bootstrap
 image, its own resources and no probes at all: these are one-shot commands with no listener,
 and `common.container` would otherwise attach the service probes and fail them immediately.
@@ -73,11 +112,17 @@ Used both as the migration initContainer on the service pods that need the schem
 body of the seed Jobs, so the two can never drift apart.
 
 The environment always names the secrets directory: `tankovault.bootstrapVolumeMounts` mounts
-that volume unconditionally, and both pods this container runs in provide one — the bootstrap
-Job through `tankovault.bootstrapVolumes`, and a service pod because the migration is attached
-only to services whose `needsDatabase` puts `database__url` in their own projection.
+a volume there unconditionally, and both pods this container runs in provide one — the
+bootstrap Job through `tankovault.bootstrapVolumes`, and a service pod through
+`tankovault.migrateVolumes`.
 
-Args: ctx (root), command (bootstrap subcommand), name (container name).
+`secretVolume` names which of them it is, because in a service pod it must not be the volume
+the service itself mounts: `secrets` there carries every credential that service reads, and
+the migration reads `database__url`. Defaults to `secrets`, the name a bootstrap Job's own pod
+gives it.
+
+Args: ctx (root), command (bootstrap subcommand), name (container name),
+      secretVolume (optional, the pod volume holding this command's credentials).
 */}}
 {{- define "tankovault.bootstrapContainer" -}}
 {{- $root := .ctx -}}
@@ -88,16 +133,23 @@ Args: ctx (root), command (bootstrap subcommand), name (container name).
       "name" .name
       "args" (list .command)
       "env" (include "tankovault.env" (dict "ctx" $root "secrets" true) | fromYamlArray)
-      "volumeMounts" (include "tankovault.bootstrapVolumeMounts" $root | fromYamlArray)
+      "volumeMounts" (include "tankovault.bootstrapVolumeMounts" (dict
+            "ctx" $root
+            "secretVolume" (.secretVolume | default "secrets")
+          ) | fromYamlArray)
     ) -}}
 {{- end -}}
 
+{{/*
+Args: ctx (root), secretVolume (the pod volume this command's credentials are projected into).
+*/}}
 {{- define "tankovault.bootstrapVolumeMounts" -}}
+{{- $ctx := .ctx -}}
 - name: config
-  mountPath: {{ .Values.configReload.configDir | quote }}
+  mountPath: {{ $ctx.Values.configReload.configDir | quote }}
   readOnly: true
-- name: secrets
-  mountPath: {{ .Values.configReload.secretsDir | quote }}
+- name: {{ .secretVolume }}
+  mountPath: {{ $ctx.Values.configReload.secretsDir | quote }}
   readOnly: true
 {{- end -}}
 
@@ -113,6 +165,30 @@ Args: ctx (root), command (bootstrap subcommand), name (container name).
       {{- include "tankovault.secretSources" (dict
             "ctx" $ctx
             "keys" (include "tankovault.bootstrapSecretKeys" $ctx | fromYamlArray)
+          ) | nindent 6 }}
+{{- end -}}
+
+{{/*
+The extra volume a service pod carries for the migration initContainer.
+
+A second projection rather than a narrower view of the pod's `secrets` volume: a projected
+volume is mounted whole, so projecting the keys twice is the only way to give one container in
+a pod fewer of them than another. Built by `tankovault.secretSources` like every other
+projection in this chart, so the file the migration reads is byte for byte the one the service
+reads — same Secret, same path, same 0400, and the same `externalDatabase.existingSecret`
+redirection.
+
+Args: ctx (root).
+*/}}
+{{- define "tankovault.migrateVolumes" -}}
+{{- $ctx := . -}}
+- name: migrate-secrets
+  projected:
+    defaultMode: 0400
+    sources:
+      {{- include "tankovault.secretSources" (dict
+            "ctx" $ctx
+            "keys" (include "tankovault.migrateSecretKeys" $ctx | fromYamlArray)
           ) | nindent 6 }}
 {{- end -}}
 

--- a/charts/tankovault/templates/_workload.tpl
+++ b/charts/tankovault/templates/_workload.tpl
@@ -128,12 +128,12 @@ affinity and the pod spec all come from the same helpers every other chart in th
 uses — just resolved per service instead of per chart.
 
 In `initContainer` migrate mode the migration is attached only to the pods of services that
-use the database. Those are exactly the pods that carry `database__url`: a pod projects only
-its own `secretKeys`, so on `frontend` — which has none — the shared bootstrap volumeMounts
-would name a `secrets` volume the pod does not define and the API server rejects the
-Deployment outright, while on `render` and `challenge-solver` the volume exists but holds no
-database URL and the migration could only fail. Migrating from the pods that actually need the
-schema also keeps the ordering guarantee intact.
+use the database, and it brings its own `migrate-secrets` projection rather than mounting the
+service's — see `tankovault.migrateSecretKeys`. `needsDatabase` gates both: on `frontend`,
+`render` and `challenge-solver` the migration would run against no database URL at all and
+could only fail, and a projection carrying the one credential they have no business holding is
+not worth adding to pods that will never use it. Migrating from the pods that actually need
+the schema also keeps the ordering guarantee intact.
 */}}
 {{- define "tankovault.deployment" -}}
 {{- $root := .ctx -}}
@@ -143,6 +143,10 @@ schema also keeps the ordering guarantee intact.
 {{- $ctx := dict "Values" $values "Chart" $root.Chart "Release" $root.Release "Capabilities" $root.Capabilities "Template" $root.Template "Files" $root.Files -}}
 {{- $volumes := include "tankovault.volumes" (dict "ctx" $root "service" $service) | fromYamlArray -}}
 {{- $mounts := include "tankovault.volumeMounts" (dict "ctx" $root "service" $service) | fromYamlArray -}}
+{{- $migrates := and (eq (include "tankovault.migrateMode" $root) "initContainer") $spec.needsDatabase -}}
+{{- if $migrates -}}
+{{- $volumes = concat $volumes (include "tankovault.migrateVolumes" $root | fromYamlArray) -}}
+{{- end -}}
 {{- if eq $service "render" -}}
 {{- $volumes = concat $volumes (include "tankovault.renderVolumes" $root | fromYamlArray) -}}
 {{- $mounts = concat $mounts (include "tankovault.renderVolumeMounts" $root | fromYamlArray) -}}
@@ -206,9 +210,13 @@ spec:
         `just check-config` can only require the switch.
       */}}
       enableServiceLinks: false
-      {{- if and (eq (include "tankovault.migrateMode" $root) "initContainer") $spec.needsDatabase }}
+      {{- if $migrates }}
       initContainers:
-        {{- include "tankovault.bootstrapContainer" (dict "ctx" $root "command" "migrate" "name" "migrate") | nindent 8 }}
+        {{- include "tankovault.bootstrapContainer" (dict
+              "ctx" $root
+              "command" "migrate"
+              "name" "migrate"
+              "secretVolume" "migrate-secrets") | nindent 8 }}
       {{- end }}
       containers:
         {{- include "common.container" (dict

--- a/charts/tankovault/tests/bootstrap_test.yaml
+++ b/charts/tankovault/tests/bootstrap_test.yaml
@@ -73,9 +73,8 @@ tests:
           value: [migrate]
 
   - it: leaves pods that never touch the database without a migration initContainer
-    # A pod projects only its own `secretKeys`. `frontend` has none, so the shared bootstrap
-    # volumeMounts would name a `secrets` volume the pod does not define and the API server
-    # rejects the whole Deployment.
+    # `frontend` reads no credential at all and has no database to migrate, so it gets neither
+    # the initContainer nor a projection for it.
     template: deployment.yaml
     set:
       postgresql.enabled: true
@@ -92,6 +91,116 @@ tests:
           any: true
           content:
             name: secrets
+      - notContains:
+          path: spec.template.spec.volumes
+          any: true
+          content:
+            name: migrate-secrets
+
+  - it: gives the migration initContainer a projection of its own rather than the service's
+    # The service container and the initContainer are different binaries with different attack
+    # surfaces, and a projected volume is mounted whole — so the only way to give the migration
+    # fewer keys than the pod it runs in is to project them twice. On `api` that is one key
+    # against eight: the token signing key, the MFA sealing key, the SMTP credentials and the
+    # internal caller token are all read by the service and none of them by `bootstrap migrate`.
+    template: deployment.yaml
+    set:
+      postgresql.enabled: true
+      postgresql.auth.password: test-password
+      externalDatabase.url: ""
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-tankovault-api
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: migrate-secrets
+            mountPath: /etc/tankovault/secrets
+            readOnly: true
+      - notContains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          any: true
+          content:
+            name: secrets
+      - equal:
+          path: spec.template.spec.volumes[?(@.name=="migrate-secrets")].projected.sources[0].secret.items
+          value:
+            - key: database__url
+              path: database__url
+      # The service itself keeps every key it had.
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: secrets
+            mountPath: /etc/tankovault/secrets
+            readOnly: true
+
+  - it: keeps the seed credentials out of the migration's projection
+    # `tankovault.bootstrapSecretKeys` carries `auth__password_pepper` and `seed_admin_password`
+    # for `seed-admin`, which hashes the initial password. Applying a schema reads neither, and
+    # `worker`, `notifier`, `sync` and `control-plane` have always run the migration on pods
+    # that project no pepper at all.
+    template: deployment.yaml
+    set:
+      postgresql.enabled: true
+      postgresql.auth.password: test-password
+      externalDatabase.url: ""
+      bootstrap.seedAdmin.enabled: true
+      bootstrap.seedAdmin.password: seed-password
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-tankovault-api
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes[?(@.name=="migrate-secrets")].projected.sources[0].secret.items
+          content:
+            key: auth__password_pepper
+            path: auth__password_pepper
+      - notContains:
+          path: spec.template.spec.volumes[?(@.name=="migrate-secrets")].projected.sources[0].secret.items
+          content:
+            key: seed_admin_password
+            path: seed_admin_password
+
+  - it: follows an external database Secret into the migration's projection
+    # `tankovault.secretSources` builds it like every other projection in the chart, so
+    # `externalDatabase.existingSecret` redirects the one key the migration reads and the
+    # release-owned Secret drops out of the volume entirely.
+    template: deployment.yaml
+    set:
+      postgresql.enabled: false
+      bootstrap.migrate.mode: initContainer
+      externalDatabase.url: ""
+      externalDatabase.existingSecret: db-credentials
+      externalDatabase.urlKey: dsn
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-tankovault-api
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[?(@.name=="migrate-secrets")].projected.sources
+          value:
+            - secret:
+                name: db-credentials
+                items:
+                  - key: dsn
+                    path: database__url
+
+  - it: leaves the bootstrap Jobs projecting every key their steps read
+    # The Job form is a pod of its own running nothing else, so narrowing it buys nothing — and
+    # the same three Jobs run `seed-admin`, which needs all three keys.
+    template: job-migrate.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[?(@.name=="secrets")].projected.sources[0].secret.items
+          value:
+            - key: database__url
+              path: database__url
+            - key: auth__password_pepper
+              path: auth__password_pepper
+            - key: seed_admin_password
+              path: seed_admin_password
 
   - it: backs the bootstrap container's /tmp mount with a volume of its own
     # `common.container` adds the /tmp mount whenever the root filesystem is read-only, and only


### PR DESCRIPTION
## What

The `migrate` initContainer on the service Deployments runs the `tankovault-bootstrap` image but mounted the **host service's** `secrets` projected volume in full. On `tankovault-api` that is eight credentials:

```
auth__jwt_secret  auth__mfa_encryption_key  auth__password_pepper  database__url
email__password   email__username           internal__caller__token  redis__url
```

`bootstrap migrate` applies a schema. It reads `database__url`.

It now gets a `migrate-secrets` projection of its own, so the initContainer and the service container in the same pod no longer see the same key set.

Rendered key counts for the `migrate` initContainer, before → after:

| Deployment | before | after |
|---|---|---|
| `api` | 8 | 1 |
| `control-plane` | 3 | 1 |
| `notifier` | 5 | 1 |
| `sync` | 5 | 1 |
| `worker` | 3 | 1 |

`frontend`, `render` and `challenge-solver` never carry the migration and are unchanged.

## How

- `tankovault.migrateSecretKeys` derives the list from `tankovault.bootstrapSecretKeys`, subtracting the new `tankovault.seedAdminSecretKeys` — `auth__password_pepper` and `seed_admin_password`, which that helper's own comment already attributes to `seed-admin`. The subtraction keeps one list of what the image reads rather than a second copy free to drift.
- `tankovault.migrateVolumes` builds the projection through `tankovault.secretSources`, so the file the migration reads is byte for byte the one the service reads: same Secret, same path, same `0400`, and the same `externalDatabase.existingSecret` redirection.
- `tankovault.bootstrapContainer` takes an optional `secretVolume`, defaulting to `secrets` so the bootstrap Jobs render exactly as before.

That the pepper is not needed is not an inference: `control-plane`, `worker`, `notifier` and `sync` have never projected it, and the migration has always run on their pods.

## Scope

The bootstrap Jobs are deliberately untouched. They are pods of their own running nothing else, so narrowing them buys nothing, and the same pod shape carries `seed-admin`, which needs all three keys. A test pins that.

This is not a cross-boundary exposure — the initContainer shares a pod with a service container that legitimately holds these credentials. It is a different binary with a different attack surface at a different lifecycle stage, and the correct key list already existed in the chart.

## Why no gate caught it

Gate 3 in `config_gate_container.py` only opens containers a `config-contract.yaml` document names as a consumer. The service documents list `containers: [api]` and so on; the `bootstrap` document's consumer is a `Job` selected by `app.kubernetes.io/component: bootstrap`. This initContainer is named by neither. Adding it as a consumer is not a free change — it would then be checked against `contracts/bootstrap.json` while mounting the *service's* `config` ConfigMap (see below), so it is left out of this PR.

## Verification

- `just deps && just test-unit tankovault` — 221 passed, including five new assertions on the projection, the mount, the seed-key exclusion, the `externalDatabase.existingSecret` redirection and the unchanged Job.
- `just check-config` — exit 0.
- `just validate-manifests` — 819 resources valid.
- `just lint-policy` — no lint errors.
- Re-rendered `ci/minimal-values.yaml` and `ci/default.yaml` with every service enabled and confirmed each Deployment's `migrate-secrets` volume projects `database__url` alone, and that `ci/*` renders are otherwise byte-identical.

`charts/tankovault/Chart.yaml` bumped 5.2.0 → 5.2.1.

## Noted, not fixed

The same initContainer mounts the volume named `config`, which in a service pod is that service's ConfigMap — `tankovault-api-config`, not `tankovault-bootstrap-config`. `configmap-bootstrap.yaml`'s own comment says the bootstrap ConfigMap "is mounted by the migration initContainer on every service pod", so intent and render disagree. Same shape as this defect, but it changes what the migration is configured with rather than what it can read, so it belongs in its own change.
