### PR TITLE
feat(scripts): select a shared-key document and probe the layer that wins

### DIFF
--- a/.github/scripts/config_testgen.py
+++ b/.github/scripts/config_testgen.py
@@ -15,7 +15,8 @@ contract says the key will accept. `check-config.py` supplies the reading half o
 `generate-contract-tests.py` supplies the walking and the writing; this is the model, and it is
 a pure function of a contract key so every rule below is testable by calling it.
 
-Five rules here are normative rather than convenient:
+Seven rules here are normative rather than convenient. The first four are about the probe, and
+the last three about the shape of the chart it is written into:
 
 **A probe must differ from the key's default.** A case that sets a key to the value it already
 has passes whether or not the chart delivers anything, which is worse than no case at all: it
@@ -46,17 +47,45 @@ backslash — `re.escape` escapes `-`, `&`, `~`, `#` and the space, and Go's par
 obliged to accept every one of those. So only the characters that are metacharacters in both
 are escaped, and everything else is passed through as the literal it already is.
 
-**A render prerequisite may never be written into the configuration tree.** Several charts here
-refuse their own default render — no target base, no webhook URL, no bucket entry — so a suite
-for one of them needs values supplied before any of its cases renders at all, the case that only
-checks the document's identity included. Those are the chart's own first-class values, and a
-prerequisite is therefore carried by every case without exception rather than dropped on a
+**A document is selected by the key it carries, and by its labels only where the key is not
+enough.** `check-config.py` reads a document out of the key its declaration names, so selecting
+on that same fact is what ties the two gates to one object — where a label selector on its own
+matches the Deployment and the Service as well, which was measured rather than assumed. A chart
+that renders the same key into several documents breaks that: TankoVault's nine services each
+write their own `config.toml`, so the key identifies all nine and none of them. There the labels
+the declaration already selects the document on are added to the key, and the two facts go into
+one JSONPath filter rather than into two matchers, because helm-unittest's `documentSelector`
+carries exactly one `path` and one `value` — measured against plugin 1.1.2, whose selector is a
+single `yamlpath` expression evaluated per rendered manifest. The narrowing is applied only where
+a key is shared, since a filter over labels that distinguish nothing would be longer without
+proving more.
+
+**Which values path a probe is written to is the chart's decision, not this module's.** Every
+chart here merges its operator-facing configuration tree *over* whatever it derives, so a probe
+written into that tree arrives in the document. One does the opposite: TankoVault merges
+`.Values.config`, then the chart-derived wiring, then `services.<name>.config`, so a probe
+written into the root tree is overwritten by the chart before it reaches the file and the case
+fails for a reason that is not a defect. The root is therefore per document and stated in the
+chart's enrolment rather than guessed at — the values key is `services.controlPlane.config` where
+the document is named `control-plane`, so there is nothing to derive it from — and a document's
+baseline is read under the same root, because the check that stops a baseline from supplying the
+very value a case is probing is a comparison of the two paths as strings.
+
+**A render prerequisite may never be written into the tree the probes are written to.** Several
+charts here refuse their own default render — no target base, no webhook URL, no bucket entry —
+so a suite for one of them needs values supplied before any of its cases renders at all, the case
+that only checks the document's identity included. Those are the chart's own first-class values,
+and a prerequisite is therefore carried by every case without exception rather than dropped on a
 collision the way a baseline is. That is exactly why the collision has to be made unreachable
-instead: a prerequisite writing under `config` would sit in the same tree every case probes, free
-to supply the very value a case exists to prove the chart delivered, and the suite would report a
-proof it had not earned. So the refusal lives here, in the model, and not only in the loader that
-reads the enrolment file — the rule belongs to the suite, and a caller reaching past the loader
-would otherwise reach past the rule with it.
+instead: a prerequisite writing under the probe root would sit in the same tree every case probes,
+free to supply the very value a case exists to prove the chart delivered, and the suite would
+report a proof it had not earned. The rule is stated against that root rather than against the
+literal `config`, because the root is what the rule above made movable, and a refusal naming the
+default would stop guarding the one chart that does not use it. A prerequisite the root nests
+*inside* is refused for the neighbouring reason: it and the probe would be two entries of one
+`set` mapping, one enclosing the other, and a `set` mapping has no order. So the refusal lives
+here, in the model, and not only in the loader that reads the enrolment file — the rule belongs to
+the suite, and a caller reaching past the loader would otherwise reach past the rule with it.
 
 One limit is deliberate and cannot be closed from here. The probe is chosen to differ from the
 *contract's* default, which is the image's compiled-in value; a chart is free to render some
@@ -66,13 +95,14 @@ overlap is unreachable in practice; for a boolean there are only two values and 
 real. Closing it would mean rendering the chart, which would make generation depend on helm and
 on a values file — and the staleness gate would stop being a pure comparison of committed bytes.
 
-A second limit belongs to the rule above and is stated rather than papered over. Refusing `config`
-makes a prerequisite unable to reach a probed key *directly*; a first-class chart value that the
-chart derives a probed key from is a longer path to the same place, and no mapping from one to
-the other exists in the contract for this module to consult. What closes it is the layer order
-every chart enrolled so far shares — `.Values.config` is merged over the derived tree, so the
-probe wins whatever a prerequisite set — and that is a property of the chart rather than of the
-generator. The enrolment's mandatory `reason` is where a chart says so.
+A second limit belongs to the prerequisite rule and is stated rather than papered over. Refusing
+the probe root makes a prerequisite unable to reach a probed key *directly*; a first-class chart
+value that the chart derives a probed key from is a longer path to the same place, and no mapping
+from one to the other exists in the contract for this module to consult. What closes it is what
+the probe root is chosen to be — the layer that wins, whether that is `.Values.config` merged over
+the derived tree or the per-document layer merged over both — so the probe outranks whatever a
+prerequisite set. That is a property of the chart rather than of the generator, and the
+enrolment's mandatory `reason` is where a chart says so.
 """
 
 from __future__ import annotations
@@ -89,7 +119,15 @@ import config_contract as cc
 # chart-agnostic generator possible: every contract key is reachable as `config.<path>` whether
 # or not the chart also spells it as a camelCase value of its own. A chart without one cannot be
 # probed this way and is reported rather than guessed at.
+#
+# The default rather than the rule: a chart whose derived wiring outranks this tree names a
+# higher-precedence one per document in its enrolment. See the module header.
 VALUES_ROOT = "config"
+
+# A values path a probe may be written under: dotted, and nothing else. The path is used twice —
+# as a `set` prefix in the generated suite and as a walk into the chart's `values.yaml` — and the
+# two agree on dotted segments and on nothing beyond them.
+VALUES_PATH = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*(\.[A-Za-z_][A-Za-z0-9_-]*)*$")
 
 # Text probes are built from this stem so a value appearing in a rendered document is
 # unmistakably a test fixture and never a plausible setting somebody meant.
@@ -138,16 +176,23 @@ SECRET_REASON = (
     "value in a test file is a credential"
 )
 
-# Why a render prerequisite naming this path may not be written. Stated as a constant because two
-# callers refuse it — the loader that reads the enrolment file, which can name the file, and the
-# model below, which cannot but must refuse it anyway. See the module header.
-PREREQUISITE_IN_CONFIG = (
-    f"writes under `{VALUES_ROOT}`, which is the tree every case probes: a prerequisite there "
-    f"could supply the value a case exists to prove the chart delivered. A render prerequisite "
-    f"states the chart's own values, and nothing under `{VALUES_ROOT}` is one"
+# Why a render prerequisite may not be written. Stated here because two callers refuse it — the
+# loader that reads the enrolment file, which can name the file, and the model below, which
+# cannot but must refuse it anyway. The two that name a tree are built from the probe root rather
+# than from `VALUES_ROOT`, because the root is what a chart's enrolment may move.
+PREREQUISITE_EMPTY = "is empty, so it names no value at all"
+
+PREREQUISITE_INSIDE_PROBES = (
+    "writes under `{root}`, which is the tree every case probes: a prerequisite there could "
+    "supply the value a case exists to prove the chart delivered. A render prerequisite states "
+    "the chart's own values, and nothing under `{root}` is one"
 )
 
-PREREQUISITE_EMPTY = "is empty, so it names no value at all"
+PREREQUISITE_AROUND_PROBES = (
+    "encloses `{root}`, the tree every case probes: the prerequisite and the probe would be two "
+    "entries of one `set` mapping with the second nested inside the first, and a `set` mapping "
+    "has no order, so which of them survives is stated nowhere"
+)
 
 
 class TestGenError(Exception):
@@ -433,6 +478,47 @@ def document_pattern(path: str, text: str) -> str:
 
 
 # --------------------------------------------------------------------------------------------
+# Spelling the document selector
+# --------------------------------------------------------------------------------------------
+
+
+def jsonpath_string(text: str) -> str:
+    """One string literal inside a JSONPath expression, double-quoted.
+
+    Double quotes rather than single ones so the whole expression survives the single-quoted YAML
+    scalar it is written into without every quote in it being doubled. A label or a key carrying
+    a double quote or a backslash is refused instead of escaped: `yamlpath`'s lexer is not this
+    repository's to reason about, and no object in it has ever carried one — a guess here would
+    produce a selector that silently matches nothing.
+    """
+    if '"' in text or "\\" in text:
+        raise TestGenError(
+            f"{text!r} cannot be written into a document selector: a JSONPath string literal "
+            "here carries neither a double quote nor a backslash"
+        )
+    return f'"{text}"'
+
+
+def selector_path(key: str, discriminator: Sequence[tuple[str, str]]) -> str:
+    """The `documentSelector` path for one document: its key, narrowed by labels where needed.
+
+    helm-unittest evaluates this as a `yamlpath` expression against each rendered manifest and
+    selects the manifest when it resolves to anything at all, so putting the labels into a filter
+    over the document root and the key into the step after it is what makes one selector out of
+    two facts. Its `documentSelector` has room for exactly one `path` and one `value`, which is
+    why they are not spelled as two matchers.
+    """
+    if not discriminator:
+        return f"data[{jsonpath_string(key)}]"
+
+    predicate = " && ".join(
+        f"@.metadata.labels[{jsonpath_string(label)}]=={jsonpath_string(value)}"
+        for label, value in discriminator
+    )
+    return f"$[?({predicate})].data[{jsonpath_string(key)}]"
+
+
+# --------------------------------------------------------------------------------------------
 # The suite
 # --------------------------------------------------------------------------------------------
 
@@ -462,23 +548,32 @@ class Plan:
     skipped: list[Skipped]
 
 
-def values_path(path: str) -> str:
+def values_path(path: str, root: str = VALUES_ROOT) -> str:
     """Where an operator writes one contract key, as a helm-unittest `set` path."""
-    return f"{VALUES_ROOT}.{path}"
+    return f"{root}.{path}"
 
 
-def prerequisite_conflict(path: str) -> str | None:
+def prerequisite_conflict(path: str, root: str = VALUES_ROOT) -> str | None:
     """Why one render prerequisite may not be written, or `None` when it may be.
 
-    The whole of the guarantee named in the module header, in one comparison of one string, so
+    The whole of the guarantee named in the module header, in two comparisons of one string, so
     that a reader checks it by eye rather than by reasoning about how two trees merge. A caller
     that reports the conflict wraps this in whatever names the file it came from; `plan` below
     raises on it, because a suite built past this rule is a suite that proves less than it says.
+
+    `root` is the values path the probes are written under, which the enrolment may move off
+    `VALUES_ROOT` per document. Comparing against the root rather than against the default is the
+    whole point: the rule exists to keep a prerequisite out of the tree the cases probe, and on a
+    chart that probes `services.api.config` the tree to stay out of is that one. Both directions
+    are refused, because either nesting puts two entries of one unordered `set` mapping inside
+    each other.
     """
     if not path:
         return PREREQUISITE_EMPTY
-    if path == VALUES_ROOT or path.startswith(f"{VALUES_ROOT}."):
-        return PREREQUISITE_IN_CONFIG
+    if path == root or path.startswith(f"{root}."):
+        return PREREQUISITE_INSIDE_PROBES.format(root=root)
+    if root.startswith(f"{path}."):
+        return PREREQUISITE_AROUND_PROBES.format(root=root)
     return None
 
 
@@ -486,6 +581,7 @@ def plan(
     keys: Iterable[dict[str, Any]],
     baseline: Sequence[tuple[str, Any]],
     prerequisites: Sequence[tuple[str, Any]] = (),
+    root: str = VALUES_ROOT,
 ) -> Plan:
     """Turn a union's keys into the cases and the skips of one suite.
 
@@ -499,12 +595,19 @@ def plan(
     `prerequisites` is carried by every case with no exception at all, because it is what makes
     the chart render in the first place: a chart whose `validateValues` refuses its own defaults
     has no case that can do without one. So the collision the baseline is protected from by being
-    dropped is instead made unreachable — a prerequisite path under the configuration tree is
+    dropped is instead made unreachable — a prerequisite path inside the probes' own tree is
     refused here rather than accommodated. The two fields are different things and this is the
     line between them.
+
+    `root` is the values path a probe is written under: the chart's operator-facing configuration
+    tree, or its higher-precedence per-document layer where that tree is outranked by what the
+    chart derives. It is what the baseline and the prerequisites are both read against — the
+    enrolment states the baseline under it, so the collision check stays a comparison of two
+    strings, and the prerequisite refusal is measured against it, so moving the root moves the
+    tree a prerequisite has to stay out of.
     """
     for name, _ in prerequisites:
-        conflict = prerequisite_conflict(name)
+        conflict = prerequisite_conflict(name, root)
         if conflict is not None:
             raise TestGenError(f"the render prerequisite {name!r} {conflict}")
 
@@ -518,7 +621,7 @@ def plan(
             skipped.append(Skipped(path=path, reason=reason or "no reason given"))
             continue
 
-        target = values_path(path)
+        target = values_path(path, root)
         set_values = list(prerequisites)
         set_values.extend((name, value) for name, value in baseline if name != target)
         set_values.append((target, probe.value))
@@ -548,6 +651,11 @@ PLAIN_SCALAR = re.compile(r"^[A-Za-z_][A-Za-z0-9_./-]*$")
 # Where a wrapped comment line stops. Matches the width the rest of this repository's Python and
 # `just` files are written to.
 COMMENT_WIDTH = 96
+
+# A selector path YAML reads back unchanged as a plain scalar. `data["config.toml"]` is one by
+# YAML's block-context rules; the filter form opens with `$[?(` and carries `&&`, and quoting that
+# is cheaper than making every reader confirm none of it is an indicator.
+PLAIN_SELECTOR = re.compile(r'^[A-Za-z_][A-Za-z0-9_."\[\]/-]*$')
 
 
 def yaml_scalar(value: Any) -> str:
@@ -590,7 +698,14 @@ def comment(lines: Iterable[str], indent: str = "") -> list[str]:
 
 @dataclass(frozen=True)
 class Target:
-    """The document a suite is written for, as the declaration describes it."""
+    """The document a suite is written for, as the declaration and the enrolment describe it.
+
+    The last two fields carry defaults because they are what every chart but one looks like: a
+    document whose key identifies it on its own, probed through the configuration tree the chart
+    merges over its derived wiring. Stating them as defaults rather than as required arguments is
+    also what keeps a suite for such a chart byte-identical to the one generated before either
+    field existed.
+    """
 
     chart: str
     name: str
@@ -600,12 +715,19 @@ class Target:
     declaration: str
     contracts: tuple[str, ...]
 
+    # Labels that tell this document from its siblings, empty when the key already does. See
+    # `selector_path` and the module header.
+    discriminator: tuple[tuple[str, str], ...] = ()
+
+    # The values path a probe is written under. See the module header.
+    root: str = VALUES_ROOT
+
 
 def render_suite(
     target: Target,
     plan: Plan,
     baseline: Sequence[tuple[str, Any]],
-    baseline_reason: str | None,
+    reason: str | None,
     prerequisites: Sequence[tuple[str, Any]] = (),
     prerequisite_reason: str | None = None,
 ) -> str:
@@ -616,6 +738,10 @@ def render_suite(
     version — written into the file at all. That is what lets the staleness gate be a comparison
     of bytes, and it is what keeps a Renovate digest bump that changes no key from producing a
     diff here.
+
+    `reason` is the enrolment's explanation for whatever it made non-default about this document
+    — a baseline, a probe root, or both — and is rendered once beside them. The prerequisites
+    carry their own, because they are a different field explaining a different thing.
     """
     lines = comment(_preamble(target, plan))
     lines.append("")
@@ -626,17 +752,18 @@ def render_suite(
     lines.append(f"  name: {yaml_scalar(target.chart)}")
     lines.append("")
     if prerequisites:
-        lines.extend(comment(_prerequisite_note(prerequisite_reason)))
+        lines.extend(comment(_prerequisite_note(target.root, prerequisite_reason)))
     lines.append("tests:")
     lines.extend(_identity_case(target, prerequisites))
 
-    if baseline:
+    notes = _case_notes(target, baseline, reason)
+    if notes:
         lines.append("")
-        lines.extend(comment(_baseline_note(baseline_reason), indent="  "))
+        lines.extend(comment(notes, indent="  "))
 
     for case in plan.cases:
         lines.append("")
-        lines.extend(_probe_case(case, target.key))
+        lines.extend(_probe_case(case, target))
 
     if plan.skipped:
         lines.append("")
@@ -652,7 +779,7 @@ def _preamble(target: Target, plan: Plan) -> list[str]:
         BANNER,
         "",
         *_wrap(
-            f"Every case below writes one setting into `{VALUES_ROOT}` and asserts that it "
+            f"Every case below writes one setting into `{target.root}` and asserts that it "
             f"arrives in `{target.key}`, under the table its contract path names. That is the "
             "round trip no other gate can see: `just check-config` proves the rendered document "
             "satisfies the contract, and a document missing a setting entirely satisfies it "
@@ -686,19 +813,9 @@ def _release_note() -> list[str]:
 
 def _identity_case(target: Target, prerequisites: Sequence[tuple[str, Any]]) -> list[str]:
     lines = [
-        *comment(
-            _wrap(
-                "Every case below selects its document by the key it carries, which is what "
-                "`check-config.py` reads it from — a label would match the Deployment and the "
-                "Service too. This case is what ties that selection back to the declaration: "
-                f"the object holding `{target.key}` has to be the {target.kind} the declaration "
-                "names, carrying the labels the declaration selects on.",
-                COMMENT_WIDTH - 4,
-            ),
-            indent="  ",
-        ),
+        *comment(_wrap(_selection_note(target), COMMENT_WIDTH - 4), indent="  "),
         f"  - it: renders {target.key} on the {target.kind} the declaration selects",
-        *_selector(target.key),
+        *_selector(target),
         # This case sets nothing of its own, and still carries the prerequisites: without them
         # the chart's guard refuses the render, and a case asserting on a document that was never
         # produced fails for a reason that has nothing to do with what it checks.
@@ -718,9 +835,35 @@ def _identity_case(target: Target, prerequisites: Sequence[tuple[str, Any]]) -> 
     return lines
 
 
-def _selector(key: str) -> list[str]:
+def _selector(target: Target) -> list[str]:
     """The document selector, matching on the key existing rather than on its contents."""
-    return ["    documentSelector:", f'      path: data["{key}"]']
+    path = selector_path(target.key, target.discriminator)
+    scalar = path if PLAIN_SELECTOR.match(path) else yaml_quoted(path)
+    return ["    documentSelector:", f"      path: {scalar}"]
+
+
+def _selection_note(target: Target) -> str:
+    """Why every case below selects the document it does, in whichever form actually applies."""
+    if not target.discriminator:
+        return (
+            "Every case below selects its document by the key it carries, which is what "
+            "`check-config.py` reads it from — a label would match the Deployment and the "
+            "Service too. This case is what ties that selection back to the declaration: the "
+            f"object holding `{target.key}` has to be the {target.kind} the declaration names, "
+            "carrying the labels the declaration selects on."
+        )
+
+    labels = ", ".join(f"`{label}: {value}`" for label, value in target.discriminator)
+    return (
+        f"Every case below selects its document by the key it carries and by {labels}, because "
+        f"this chart renders `{target.key}` into more than one document and the key on its own "
+        "identifies all of them at once. The labels on their own would not do it either — they "
+        "are on the workload and its Service as well — so the two are spelled as one JSONPath "
+        "filter, which is what helm-unittest's single-matcher selector has room for. This case "
+        f"is what ties that selection back to the declaration: the object holding `{target.key}` "
+        f"has to be the {target.kind} the declaration names, carrying the labels the declaration "
+        "selects on."
+    )
 
 
 def _set_block(values: Sequence[tuple[str, Any]]) -> list[str]:
@@ -733,28 +876,63 @@ def _set_block(values: Sequence[tuple[str, Any]]) -> list[str]:
     return lines
 
 
-def _baseline_note(reason: str | None) -> list[str]:
-    lines = _wrap(
-        "Every case below also carries the chart's baseline values, minus whichever of them the "
-        "case is itself probing — a baseline that supplied the probed value would make the "
-        "assertion pass whether or not the chart delivered anything. The baseline exists because "
-        "a chart may refuse to render a combination the contract considers legal, and a probe "
-        "that walked into one would fail for a reason that has nothing to do with the round trip.",
-        COMMENT_WIDTH - 4,
+_BASELINE_NOTE = (
+    "Every case below also carries the chart's baseline values, minus whichever of them the case "
+    "is itself probing — a baseline that supplied the probed value would make the assertion pass "
+    "whether or not the chart delivered anything. The baseline exists because a chart may refuse "
+    "to render a combination the contract considers legal, and a probe that walked into one "
+    "would fail for a reason that has nothing to do with the round trip."
+)
+
+
+def _root_note(root: str) -> str:
+    return (
+        f"Every case below writes its probe into `{root}` rather than into `{VALUES_ROOT}`, "
+        "which the chart's enrolment states because this chart merges its derived wiring *over* "
+        f"`{VALUES_ROOT}` rather than under it. A probe written into `{VALUES_ROOT}` for a key "
+        "the chart derives would be overwritten before it reached the document, and the case "
+        f"would fail on a chart that is behaving correctly. What that costs is real: `{root}` is "
+        f"the layer these cases prove, and nothing here proves `{VALUES_ROOT}` still reaches a "
+        "key the chart does not derive."
     )
+
+
+def _case_notes(
+    target: Target, baseline: Sequence[tuple[str, Any]], reason: str | None
+) -> list[str]:
+    """Whatever the enrolment made non-default about these cases, and the reason it gives.
+
+    One block carrying one reason rather than a note per field: the document entry states a
+    single `reason` for its baseline and its probe root alike, and a reader who sees the same
+    paragraph twice stops reading it. The render prerequisites are not here — they are a separate
+    field with a separate reason, and their note sits above `tests:` because the identity case
+    carries them too.
+    """
+    paragraphs: list[list[str]] = []
+    if baseline:
+        paragraphs.append(_wrap(_BASELINE_NOTE, COMMENT_WIDTH - 4))
+    if target.root != VALUES_ROOT:
+        paragraphs.append(_wrap(_root_note(target.root), COMMENT_WIDTH - 4))
+    if not paragraphs:
+        return []
     if reason:
-        lines.append("")
-        lines.extend(_wrap(reason.strip(), COMMENT_WIDTH - 4))
+        paragraphs.append(_wrap(reason.strip(), COMMENT_WIDTH - 4))
+
+    lines: list[str] = []
+    for paragraph in paragraphs:
+        if lines:
+            lines.append("")
+        lines.extend(paragraph)
     return lines
 
 
-def _prerequisite_note(reason: str | None) -> list[str]:
+def _prerequisite_note(root: str, reason: str | None) -> list[str]:
     lines = _wrap(
         "Every case below carries this chart's render prerequisites, the identity case included: "
         "chart values its own `validateValues` insists on before it will render anything at all. "
         "They are first-class chart values rather than configuration, and none of them may be "
-        f"written under `{VALUES_ROOT}` — a prerequisite there would sit in the tree every case "
-        "probes, free to supply the value the case exists to prove the chart delivered. Unlike a "
+        f"written under `{root}` — a prerequisite there would sit in the tree every case probes, "
+        "free to supply the value the case exists to prove the chart delivered. Unlike a "
         "baseline, a prerequisite is never dropped for the case it would collide with, because a "
         "case without it does not render at all; the refusal is what takes that dropping's place.",
         COMMENT_WIDTH - 2,
@@ -765,17 +943,17 @@ def _prerequisite_note(reason: str | None) -> list[str]:
     return lines
 
 
-def _probe_case(case: Case, key: str) -> list[str]:
+def _probe_case(case: Case, target: Target) -> list[str]:
     lines = [
-        f"  - it: delivers {case.path} into {key}",
-        *_selector(key),
+        f"  - it: delivers {case.path} into {target.key}",
+        *_selector(target),
         *_set_block(case.set_values),
     ]
     lines.extend(
         [
             "    asserts:",
             "      - matchRegex:",
-            f'          path: data["{key}"]',
+            f'          path: data["{target.key}"]',
             f"          pattern: {yaml_quoted(case.pattern)}",
         ]
     )

--- a/.github/scripts/generate-contract-tests.py
+++ b/.github/scripts/generate-contract-tests.py
@@ -17,17 +17,24 @@ choosing a probe, refusing to invent one, and spelling the assertion — lives i
 `charts/<chart>/contract-tests.yaml`, exactly as `config-contract.yaml` is what enrols it in
 `just check-config`. That is what makes the phased rollout a property of the tree rather than of
 a constant somebody has to remember to edit, and it is also where a chart says which values every
-generated case has to carry before it will render at all.
+generated case has to carry before it will render at all, and — where the operator-facing
+configuration tree is not the layer that wins — which values path a probe is to be written to.
 
 **A baseline and a render prerequisite are two different fields because they are two different
-things.** A `baseline` states configuration — flat dotted paths under `config` — and is dropped
-from the one case probing the key it sets, because a baseline supplying the probed value would
-make that case pass whether or not the chart delivered anything. A `prerequisites` block states
-the chart's own first-class values, the ones a `validateValues` guard refuses to render without,
-and is carried by every case including the identity one, because a case that does not render
-proves nothing either. Being undroppable is exactly why it may not name a path under `config`:
-that is refused here with the file's name on it, and refused again by `config_testgen.plan`, so
-the guarantee does not depend on this loader having been the caller.
+things.** A `baseline` states configuration — flat dotted paths under the document's probe root —
+and is dropped from the one case probing the key it sets, because a baseline supplying the probed
+value would make that case pass whether or not the chart delivered anything. A `prerequisites`
+block states the chart's own first-class values, the ones a `validateValues` guard refuses to
+render without, and is carried by every case including the identity one, because a case that does
+not render proves nothing either. Being undroppable is exactly why it may not name a path inside
+that same probe root: that is refused here with the file's name on it, and refused again by
+`config_testgen.plan`, so the guarantee does not depend on this loader having been the caller.
+
+**How a document is told from its siblings is derived, not declared.** A suite finds its document
+by the key the declaration names; a chart rendering that key into several documents needs the
+labels as well, and `config-contract.yaml` already carries them per document. Asking the
+enrolment to repeat them would let the two disagree, and the gate reading the first would then be
+validating an object the suite never selects.
 
 **The vendored contracts are read directly rather than through `config_declaration.bind`.** The
 binding exists to refuse validating a document against a contract for some other digest, and it
@@ -64,6 +71,7 @@ from config_declaration import (  # noqa: E402
     Declaration,
     DeclarationError,
     Document,
+    dig,
     load_declaration,
     reject_unknown,
 )
@@ -73,7 +81,7 @@ from config_declaration import (  # noqa: E402
 # and for the same reason.
 ENROLMENT = "contract-tests.yaml"
 ENROLMENT_KEYS = {"documents"}
-ENROLMENT_DOCUMENT_KEYS = {"name", "baseline", "reason", "prerequisites"}
+ENROLMENT_DOCUMENT_KEYS = {"name", "baseline", "probe", "reason", "prerequisites"}
 ENROLMENT_PREREQUISITE_KEYS = {"values", "reason"}
 
 # Where a generated suite goes, and the name that identifies one. The prefix is what lets the
@@ -108,8 +116,13 @@ class Baseline:
     same cause `config-contract.yaml` demands one for an exemption: an unexplained hole is
     indistinguishable from an oversight.
 
-    Deliberately confined to paths under the configuration tree. What a chart needs *outside* it
-    is a render prerequisite, which is `Prerequisites` below and not this.
+    Deliberately confined to paths under the document's probe root — the configuration tree by
+    default, and whatever higher-precedence layer the enrolment names where the chart merges its
+    derived wiring over that tree. Read under the same root the probes are, because the collision
+    check that drops a baseline entry compares the two paths as strings: a baseline one layer off
+    would never compare equal to a probe, and would quietly supply the value the case exists to
+    prove the chart delivered. What a chart needs *outside* that root altogether is a render
+    prerequisite, which is `Prerequisites` below and not this.
     """
 
     values: list[tuple[str, Any]] = field(default_factory=list)
@@ -130,8 +143,8 @@ class Prerequisites:
     Held as flat dotted paths with whatever shape the leaf has, rather than as a nested block, for
     three reasons. A helm-unittest `set` mapping *is* flat dotted paths, so what the enrolment
     states is what the generated file carries and there is no translation between the two to go
-    wrong in silence. The refusal that keeps a prerequisite out of the configuration tree is then
-    a prefix test on one string — the same rule `Baseline` is read under, checkable by eye —
+    wrong in silence. The refusal that keeps a prerequisite out of the tree the cases probe is
+    then a prefix test on one string — the same rule `Baseline` is read under, checkable by eye —
     where a nested block would spell it as a walk over two trees. And the leaves are free to be
     structures because `bucket.entries` is a map of maps keyed by request path: splitting it into
     `bucket.entries.docs/handbook.bucket` would put a `/` inside a dotted path and read worse than
@@ -144,8 +157,8 @@ class Prerequisites:
     that needs it rather than in the harness — is followed exactly.
 
     A prerequisite carries a mandatory `reason` for the cause a baseline does, and one more: the
-    reason is where a chart states that its `.Values.config` layer still wins over anything these
-    values derive, which is the half of the guarantee no path comparison can make.
+    reason is where a chart states that its probe root still wins over anything these values
+    derive, which is the half of the guarantee no path comparison can make.
     """
 
     values: list[tuple[str, Any]] = field(default_factory=list)
@@ -154,10 +167,26 @@ class Prerequisites:
 
 @dataclass(frozen=True)
 class Enrolment:
-    """What one chart's `contract-tests.yaml` says about one of its documents."""
+    """What one chart's `contract-tests.yaml` says about one of its documents.
+
+    `probe` is the values path every case for this document writes into, defaulting to the
+    operator-facing configuration tree every chart here exposes. It exists because that tree is
+    not always the layer that wins: `tankovault.configToml` merges `.Values.config`, then the
+    chart-derived wiring, then `services.<name>.config`, so a probe written into the root tree
+    for a key the chart derives is overwritten before it reaches the document. Declared rather
+    than derived — the document named `control-plane` is configured at
+    `services.controlPlane.config`, and there is nothing in the declaration that spells the
+    second from the first — and per document rather than per chart, because tankovault's own
+    `bootstrap` document has no such layer at all.
+
+    It sits here rather than on `Baseline` because it governs all three fields at once: the
+    probes are written under it, the baseline is read under it, and the prerequisites are
+    refused from it.
+    """
 
     baseline: Baseline = field(default_factory=Baseline)
     prerequisites: Prerequisites = field(default_factory=Prerequisites)
+    probe: str = tg.VALUES_ROOT
 
 
 def load_enrolment(chart_dir: Path) -> dict[str, Enrolment] | None:
@@ -187,41 +216,60 @@ def load_enrolment(chart_dir: Path) -> dict[str, Enrolment] | None:
         if name in enrolments:
             raise DeclarationError(f"{path}: `{name}` is declared twice")
 
+        probe = _load_probe(path, name, entry.get("probe"))
         baseline = Baseline(
-            values=_load_baseline(path, name, entry.get("baseline") or {}),
+            values=_load_baseline(path, name, entry.get("baseline") or {}, probe),
             reason=entry.get("reason"),
         )
-        if baseline.values and not baseline.reason:
+        if (baseline.values or probe != tg.VALUES_ROOT) and not baseline.reason:
             raise DeclarationError(
-                f"{path}: the baseline for `{name}` has no `reason`; it narrows what every "
-                "generated case proves, and an unexplained hole in a gate is indistinguishable "
-                "from an oversight"
+                f"{path}: the entry for `{name}` sets a baseline or a probe path and has no "
+                "`reason`; either narrows what every generated case proves, and an unexplained "
+                "hole in a gate is indistinguishable from an oversight"
             )
 
         enrolments[name] = Enrolment(
             baseline=baseline,
-            prerequisites=_load_prerequisites(path, name, entry.get("prerequisites")),
+            prerequisites=_load_prerequisites(path, name, entry.get("prerequisites"), probe),
+            probe=probe,
         )
 
     return enrolments
 
 
-def _load_baseline(path: Path, name: str, baseline: Any) -> list[tuple[str, Any]]:
+def _load_probe(path: Path, name: str, probe: Any) -> str:
+    """The values path this document's cases write into, defaulting to the configuration tree."""
+    if probe is None:
+        return tg.VALUES_ROOT
+    if not isinstance(probe, str) or not tg.VALUES_PATH.match(probe):
+        raise DeclarationError(
+            f"{path}: {name}: `probe` {probe!r} is not a dotted values path; it is used both as "
+            "a `set` prefix and as a walk into the chart's values, and neither reads anything "
+            "else"
+        )
+    return probe
+
+
+def _load_baseline(path: Path, name: str, baseline: Any, probe: str) -> list[tuple[str, Any]]:
     """One baseline, as sorted `set` path / value pairs.
 
     Flat dotted paths rather than a nested tree, because the generator has to be able to tell
     whether an entry collides with the key a case is probing — and comparing one string is a rule
-    a reader can check by eye, where walking two trees is not.
+    a reader can check by eye, where walking two trees is not. Read under the document's own
+    probe path for the same cause: a baseline written one layer below the probes would never
+    compare equal to one, so the collision it exists to be dropped for would go unnoticed and
+    the baseline would quietly supply the value a case is meant to prove the chart delivered.
     """
     if not isinstance(baseline, dict):
         raise DeclarationError(f"{path}: {name}: `baseline` must be a mapping")
 
     values: list[tuple[str, Any]] = []
     for key, value in sorted(baseline.items()):
-        if not isinstance(key, str) or not key.startswith(f"{tg.VALUES_ROOT}."):
+        if not isinstance(key, str) or not key.startswith(f"{probe}."):
             raise DeclarationError(
-                f"{path}: {name}: the baseline entry {key!r} is not a path under "
-                f"`{tg.VALUES_ROOT}`; a baseline states configuration, not chart values"
+                f"{path}: {name}: the baseline entry {key!r} is not a path under `{probe}`; a "
+                "baseline states configuration at the layer the probes are written to, not "
+                "chart values"
             )
         if isinstance(value, (dict, list)):
             raise DeclarationError(
@@ -232,14 +280,18 @@ def _load_baseline(path: Path, name: str, baseline: Any) -> list[tuple[str, Any]
     return values
 
 
-def _load_prerequisites(path: Path, name: str, block: Any) -> Prerequisites:
+def _load_prerequisites(path: Path, name: str, block: Any, probe: str) -> Prerequisites:
     """One document's render prerequisites, as sorted `set` path / value pairs and their reason.
 
     Every refusal below is loud rather than lenient, and the first of them is the one the whole
-    field turns on: a prerequisite under the configuration tree is undroppable *and* in the tree
-    every case probes, which is the one combination that lets a generated suite pass without
-    having proven anything. `config_testgen.prerequisite_conflict` owns the rule so the message
-    is the same one the model raises; what this adds is the name of the file to fix.
+    field turns on: a prerequisite inside the tree the cases probe is undroppable *and* able to
+    supply what they assert, which is the one combination that lets a generated suite pass
+    without having proven anything. That tree is the document's `probe` root rather than the
+    default configuration tree, which is why the root is read before this is called: on a chart
+    probing `services.api.config`, a prerequisite under `config` is harmless and one under
+    `services.api.config` is not, and a rule spelled against the default would have had it
+    exactly backwards. `config_testgen.prerequisite_conflict` owns the rule so the message is
+    the same one the model raises; what this adds is the name of the file to fix.
     """
     if block is None:
         return Prerequisites()
@@ -260,7 +312,7 @@ def _load_prerequisites(path: Path, name: str, block: Any) -> Prerequisites:
             raise DeclarationError(
                 f"{path}: {name}: the render prerequisite {key!r} is not a values path"
             )
-        conflict = tg.prerequisite_conflict(key)
+        conflict = tg.prerequisite_conflict(key, probe)
         if conflict is not None:
             raise DeclarationError(f"{path}: {name}: the render prerequisite {key!r} {conflict}")
         values.append((key, value))
@@ -300,22 +352,63 @@ def _load_prerequisites(path: Path, name: str, block: Any) -> Prerequisites:
 # --------------------------------------------------------------------------------------------
 
 
-def raw_config_tree(chart_dir: Path) -> None:
-    """Refuse a chart whose values expose no raw configuration tree.
+def probe_tree(chart_dir: Path, values: dict, name: str, probe: str) -> None:
+    """Refuse a document whose probe path is not a configuration tree in the chart's values.
 
-    Every contract key is reachable as `config.<path>` only because each of these charts merges
-    an operator-supplied tree over whatever it derives from its own first-class values. A chart
-    without one can still be probed — through whichever camelCase value happens to spell each
-    key — but not by a generator that knows nothing about it, and guessing would produce a suite
-    that silently asserts nothing.
+    Every contract key is reachable as `<probe>.<path>` only because each of these charts
+    exposes an operator-supplied tree that some layer of its render merges. A chart without one
+    can still be probed — through whichever camelCase value happens to spell each key — but not
+    by a generator that knows nothing about it, and guessing would produce a suite that silently
+    asserts nothing. The same check catches the likelier mistake by far: an enrolment naming a
+    `probe` path this chart does not have, which would otherwise generate a whole suite of cases
+    setting values nothing reads.
     """
-    path = chart_dir / "values.yaml"
-    values = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    if not isinstance(values.get(tg.VALUES_ROOT), dict):
+    if not isinstance(dig(values, probe), dict):
         raise DeclarationError(
-            f"{path}: has no `{tg.VALUES_ROOT}` mapping, so a contract key cannot be written "
-            "into this chart's values by its contract path alone"
+            f"{chart_dir / 'values.yaml'}: {name}: has no `{probe}` mapping, so a contract key "
+            "cannot be written into this chart's values by its contract path alone"
         )
+
+
+def discriminator_for(
+    declaration: Declaration, document: Document
+) -> tuple[tuple[str, str], ...]:
+    """The labels a document's selector needs beyond its key, empty where the key suffices.
+
+    A generated suite finds its document by the key the declaration names, which is what
+    `check-config.py` reads it from. That stops identifying anything the moment a chart renders
+    the same key into several documents — tankovault's nine services each write their own
+    `config.toml` — so where a key is shared the declaration's own `source.selector` is added to
+    it. Derived here rather than declared in the enrolment because the declaration already
+    states it: a second copy could disagree with the first, and the gate reading the first would
+    then be validating an object the suite never selects.
+    """
+    shared = [
+        other
+        for other in declaration.documents
+        if other.name != document.name and other.source.key == document.source.key
+    ]
+    if not shared:
+        return ()
+
+    if not document.source.selector:
+        raise DeclarationError(
+            f"{declaration.path}: `{document.name}` shares the key `{document.source.key}` "
+            f"with {', '.join(sorted(other.name for other in shared))} and carries no "
+            "`source.selector`, so nothing in this declaration tells the documents apart"
+        )
+
+    twins = sorted(
+        other.name for other in shared if other.source.selector == document.source.selector
+    )
+    if twins:
+        raise DeclarationError(
+            f"{declaration.path}: `{document.name}` shares both the key `{document.source.key}` "
+            f"and its `source.selector` with {', '.join(twins)}, so nothing in this "
+            "declaration tells the documents apart"
+        )
+
+    return tuple(sorted(document.source.selector.items()))
 
 
 def union_for(chart_dir: Path, document: Document) -> cc.Union:
@@ -352,11 +445,13 @@ def build(chart_dir: Path, declaration: Declaration, enrolments: dict[str, Enrol
             f"{declaration.path} does not declare"
         )
 
-    raw_config_tree(chart_dir)
+    values = yaml.safe_load((chart_dir / "values.yaml").read_text(encoding="utf-8")) or {}
 
     suites: dict[Path, str] = {}
     for document in declaration.documents:
         enrolment = enrolments.get(document.name, Enrolment())
+        probe_tree(chart_dir, values, document.name, enrolment.probe)
+
         union = union_for(chart_dir, document)
         target = tg.Target(
             chart=chart_dir.name,
@@ -368,9 +463,14 @@ def build(chart_dir: Path, declaration: Declaration, enrolments: dict[str, Enrol
             contracts=tuple(
                 repository_path(chart_dir, reference.contract) for reference in document.images
             ),
+            discriminator=discriminator_for(declaration, document),
+            root=enrolment.probe,
         )
         plan = tg.plan(
-            union.keys.values(), enrolment.baseline.values, enrolment.prerequisites.values
+            union.keys.values(),
+            enrolment.baseline.values,
+            enrolment.prerequisites.values,
+            enrolment.probe,
         )
         suites[suite_path(chart_dir, document)] = tg.render_suite(
             target,

--- a/.github/scripts/tests/test_contract_testgen.py
+++ b/.github/scripts/tests/test_contract_testgen.py
@@ -10,13 +10,23 @@ anything. So they are asserted here, key by key, alongside the refusals: a probe
 invented for a secret, for a `structured` key or for an `unknown` one, and the generated file has
 to say which of the three applied.
 
-A third way of losing the property arrived with render prerequisites, and it is the quietest of
-the three. A prerequisite is carried by every case and dropped from none — a case that does not
-render proves nothing — so one written into the configuration tree would supply the value a case
-exists to prove the chart delivered, and every case it touched would pass on the enrolment file's
-own contents. That is asserted twice below, once against the loader that reads the enrolment and
-once against the model, because the guarantee is worth nothing if it holds only for the callers
-that went through the loader.
+Two more ways of losing it are just as quiet and belong to the shape of the chart rather than to
+the key. A selector that matches several documents fails loudly, but one that matches the *wrong*
+single document asserts a key against a file that was never meant to carry it — so the selector
+is asserted to narrow exactly as far as the declaration gives it grounds to and no further. And a
+probe written into a values layer the chart overwrites produces a case that fails on a chart
+behaving perfectly, which is worse than no case at all: the probe root is therefore asserted to
+be the one the enrolment names, and the baseline to be read under that same root, since the check
+that stops a baseline from supplying a probed value compares the two paths as strings.
+
+A last way arrived with render prerequisites, and it is the quietest of them all. A prerequisite
+is carried by every case and dropped from none — a case that does not render proves nothing — so
+one written into the tree the cases probe would supply the value a case exists to prove the chart
+delivered, and every case it touched would pass on the enrolment file's own contents. That is
+asserted twice below, once against the loader that reads the enrolment and once against the
+model, because the guarantee is worth nothing if it holds only for the callers that went through
+the loader — and asserted again against a moved probe root, because the tree to stay out of is
+the one the probes are written to and not the one that happens to be the default.
 
 The rest is determinism. The staleness gate is a comparison of bytes, so a generator that sorted
 by dictionary order or wrote a timestamp into the header would fail a pull request that changed
@@ -46,7 +56,13 @@ sys.path.insert(0, str(SCRIPTS))
 
 import config_contract as cc  # noqa: E402
 import config_testgen as tg  # noqa: E402
-from config_declaration import DeclarationError  # noqa: E402
+from config_declaration import (  # noqa: E402
+    Declaration,
+    DeclarationError,
+    Document,
+    ImageRef,
+    Source,
+)
 
 
 def load_entry_point():
@@ -83,6 +99,28 @@ def key(path: str, **overrides: Any) -> dict[str, Any]:
     }
     entry.update(overrides)
     return entry
+
+
+def declaration(*documents: tuple[str, str, dict[str, str]]) -> Declaration:
+    """One chart's declaration, as `(document name, source key, source selector)` triples."""
+    return Declaration(
+        chart="chart",
+        path=Path("charts/chart/config-contract.yaml"),
+        documents=[
+            Document(
+                name=name,
+                source=Source(
+                    kind="ConfigMap", selector=selector, key=source_key, format="toml"
+                ),
+                images=[ImageRef(values="image", contract="contracts/one.json")],
+                consumers=[],
+                exempt=[],
+            )
+            for name, source_key, selector in documents
+        ],
+        reason=None,
+        unconfigured=[],
+    )
 
 
 class TestProbeSynthesis(unittest.TestCase):
@@ -284,6 +322,65 @@ class TestAssertionSpelling(unittest.TestCase):
         self.assertFalse(re.search(pattern, '[isr]\nlevel = "info"\n'))
 
 
+class TestDocumentSelection(unittest.TestCase):
+    """Which document a case reads, for a chart whose documents do not differ by their key."""
+
+    def test_a_key_that_identifies_its_document_selects_on_the_key_alone(self):
+        self.assertEqual(tg.selector_path("config.toml", ()), 'data["config.toml"]')
+
+    def test_a_shared_key_is_narrowed_by_the_labels_the_declaration_selects_on(self):
+        self.assertEqual(
+            tg.selector_path("config.toml", (("app.kubernetes.io/component", "api"),)),
+            '$[?(@.metadata.labels["app.kubernetes.io/component"]=="api")].data["config.toml"]',
+        )
+
+    def test_several_labels_become_one_filter(self):
+        """helm-unittest's `documentSelector` carries one `path` and one `value`, and no more."""
+        self.assertEqual(
+            tg.selector_path("config.toml", (("a", "1"), ("b", "2"))),
+            '$[?(@.metadata.labels["a"]=="1" && @.metadata.labels["b"]=="2")]'
+            '.data["config.toml"]',
+        )
+
+    def test_a_label_no_string_literal_can_carry_is_refused_rather_than_escaped(self):
+        for offender in ('quo"te', "back\\slash"):
+            with self.subTest(offender=offender):
+                with self.assertRaises(tg.TestGenError):
+                    tg.selector_path("config.toml", (("app.kubernetes.io/component", offender),))
+
+    def test_the_key_is_derived_to_be_enough_when_no_sibling_shares_it(self):
+        declared = declaration(
+            ("server", "config.toml", {"app.kubernetes.io/instance": "portfolio"}),
+            ("agent", "agent.toml", {"app.kubernetes.io/instance": "portfolio"}),
+        )
+        for document in declared.documents:
+            with self.subTest(document=document.name):
+                self.assertEqual(generator.discriminator_for(declared, document), ())
+
+    def test_a_shared_key_derives_the_labels_from_the_declaration(self):
+        declared = declaration(
+            ("api", "config.toml", {"app.kubernetes.io/component": "api"}),
+            ("worker", "config.toml", {"app.kubernetes.io/component": "worker"}),
+        )
+        self.assertEqual(
+            generator.discriminator_for(declared, declared.documents[0]),
+            (("app.kubernetes.io/component", "api"),),
+        )
+
+    def test_a_shared_key_with_no_selector_is_refused(self):
+        declared = declaration(("api", "config.toml", {}), ("worker", "config.toml", {}))
+        with self.assertRaises(DeclarationError) as raised:
+            generator.discriminator_for(declared, declared.documents[0])
+        self.assertIn("tells the documents apart", str(raised.exception))
+
+    def test_a_shared_key_and_a_shared_selector_are_refused(self):
+        """Deriving them anyway would emit a selector that matches both and fails at run time."""
+        shared = {"app.kubernetes.io/instance": "chart"}
+        declared = declaration(("api", "config.toml", shared), ("worker", "config.toml", shared))
+        with self.assertRaises(DeclarationError):
+            generator.discriminator_for(declared, declared.documents[0])
+
+
 class TestPlanning(unittest.TestCase):
     KEYS = [
         key("isr.ttl_secs", text_form="integer", constraint={"type": "integer", "minimum": 0},
@@ -316,6 +413,38 @@ class TestPlanning(unittest.TestCase):
         self.assertEqual(case.set_values[0][1], tg.DISTINCTIVE_INTEGER)
 
 
+class TestProbeTarget(unittest.TestCase):
+    """Where a probe is written, when a chart's derived wiring outranks its configuration tree."""
+
+    ROOT = "services.api.config"
+
+    def test_a_case_writes_its_key_under_the_root_the_enrolment_names(self):
+        plan = tg.plan(TestPlanning.KEYS, [], root=self.ROOT)
+        case = next(case for case in plan.cases if case.path == "isr.ttl_secs")
+        self.assertEqual(
+            case.set_values[-1], (f"{self.ROOT}.isr.ttl_secs", tg.DISTINCTIVE_INTEGER)
+        )
+
+    def test_the_baseline_collision_is_still_caught_under_a_moved_root(self):
+        """A baseline one layer off the probes would silently supply the value under test."""
+        probed = tg.values_path("isr.ttl_secs", self.ROOT)
+        plan = tg.plan(TestPlanning.KEYS, [(probed, 99)], root=self.ROOT)
+        case = next(case for case in plan.cases if case.path == "isr.ttl_secs")
+        self.assertEqual([name for name, _ in case.set_values], [probed])
+
+    def test_the_default_root_is_the_configuration_tree(self):
+        self.assertEqual(tg.values_path("isr.ttl_secs"), "config.isr.ttl_secs")
+
+    def test_a_probe_path_the_chart_does_not_expose_is_refused(self):
+        with tempfile.TemporaryDirectory() as directory:
+            values = {"config": {}, "services": {"api": {"config": {}}}}
+            generator.probe_tree(Path(directory), values, "api", self.ROOT)
+            for missing in ("services.worker.config", "nothing"):
+                with self.subTest(probe=missing):
+                    with self.assertRaises(DeclarationError):
+                        generator.probe_tree(Path(directory), values, "api", missing)
+
+
 class TestSuiteRendering(unittest.TestCase):
     TARGET = tg.Target(
         chart="portfolio",
@@ -327,8 +456,28 @@ class TestSuiteRendering(unittest.TestCase):
         contracts=("charts/portfolio/contracts/server.json",),
     )
 
+    # The other shape a chart can have: nine documents sharing one key, probed through the layer
+    # that outranks the configuration tree rather than through the tree itself.
+    SHARED = tg.Target(
+        chart="tankovault",
+        name="api",
+        kind="ConfigMap",
+        selector={"app.kubernetes.io/component": "api"},
+        key="config.toml",
+        declaration="charts/tankovault/config-contract.yaml",
+        contracts=("charts/tankovault/contracts/api.json",),
+        discriminator=(("app.kubernetes.io/component", "api"),),
+        root="services.api.config",
+    )
+
     def render(self, keys, baseline=(), reason=None) -> str:
         return tg.render_suite(self.TARGET, tg.plan(keys, baseline), baseline, reason)
+
+    def render_shared(self, keys, baseline=(), reason="because") -> str:
+        root = self.SHARED.root
+        return tg.render_suite(
+            self.SHARED, tg.plan(keys, baseline, root=root), baseline, reason
+        )
 
     def test_the_suite_is_valid_yaml_shaped_like_a_helm_unittest_suite(self):
         suite = yaml.safe_load(self.render(TestPlanning.KEYS))
@@ -367,11 +516,49 @@ class TestSuiteRendering(unittest.TestCase):
         self.assertNotIn("sha256", rendered)
         self.assertNotRegex(rendered, r"\d{4}-\d{2}-\d{2}T")
 
+    def test_every_case_of_a_shared_key_selects_through_the_same_filter(self):
+        """A case reading a sibling's document would assert a key against the wrong file."""
+        suite = yaml.safe_load(self.render_shared(TestPlanning.KEYS))
+        expected = tg.selector_path(self.SHARED.key, self.SHARED.discriminator)
+        for test in suite["tests"]:
+            with self.subTest(case=test["it"]):
+                self.assertEqual(test["documentSelector"], {"path": expected})
+
+    def test_a_shared_key_still_asserts_its_document_against_the_declaration(self):
+        suite = yaml.safe_load(self.render_shared(TestPlanning.KEYS))
+        self.assertEqual(
+            suite["tests"][0]["asserts"],
+            [
+                {"isKind": {"of": "ConfigMap"}},
+                {
+                    "equal": {
+                        "path": 'metadata.labels["app.kubernetes.io/component"]',
+                        "value": "api",
+                    }
+                },
+            ],
+        )
+
+    def test_a_moved_probe_root_reaches_the_header_the_set_paths_and_the_note(self):
+        rendered = self.render_shared(TestPlanning.KEYS, reason="the derived wiring outranks it")
+        self.assertIn("writes one setting into `services.api.config`", rendered)
+        self.assertIn("services.api.config.isr.ttl_secs:", rendered)
+        self.assertIn("rather than into `config`", rendered)
+        self.assertIn("the derived wiring outranks it", rendered)
+
+    def test_a_document_with_neither_a_baseline_nor_a_moved_root_carries_no_note(self):
+        """The reason belongs to what the enrolment changed; with nothing changed it is noise."""
+        self.assertNotIn("Every case below also carries", self.render(TestPlanning.KEYS))
+        self.assertNotIn("rather than into", self.render(TestPlanning.KEYS))
+
 
 class TestRenderPrerequisites(unittest.TestCase):
     """Values that make the chart render at all, and the rule that keeps them out of the proof."""
 
     PREREQUISITES = [("bucket.entries", {"link": {"bucket": "b", "object": "o"}})]
+
+    # A probe root off the default, which is what the last four cases below turn on.
+    ROOT = "services.api.config"
 
     def test_every_case_carries_the_prerequisites(self):
         plan = tg.plan(TestPlanning.KEYS, [], self.PREREQUISITES)
@@ -398,6 +585,56 @@ class TestRenderPrerequisites(unittest.TestCase):
     def test_a_values_path_that_merely_starts_with_the_tree_s_name_is_allowed(self):
         """The refusal is on the tree, not on the six letters: `configMount` is another value."""
         self.assertIsNone(tg.prerequisite_conflict("configMount.rolloutOnChange"))
+
+    def test_the_refusal_follows_the_probe_root_rather_than_the_default_tree(self):
+        """The one place the two enrolment fields actually meet.
+
+        On a chart probing `services.api.config`, `config` is the *lowest*-precedence layer and
+        a prerequisite there cannot reach a probed key; the layer that can is the probe root.
+        A rule spelled against the default would refuse the harmless path and admit the
+        dangerous one, which is exactly backwards.
+        """
+        self.assertIsNone(tg.prerequisite_conflict(tg.VALUES_ROOT, self.ROOT))
+        self.assertIsNone(tg.prerequisite_conflict(f"{tg.VALUES_ROOT}.isr.ttl_secs", self.ROOT))
+        self.assertIsNotNone(tg.prerequisite_conflict(self.ROOT, self.ROOT))
+        self.assertIsNotNone(tg.prerequisite_conflict(f"{self.ROOT}.isr.ttl_secs", self.ROOT))
+
+    def test_a_prerequisite_the_probe_root_nests_inside_is_refused(self):
+        """Two entries of one `set` mapping, one enclosing the other, and no order between."""
+        conflict = tg.prerequisite_conflict("services.api", self.ROOT)
+        self.assertIsNotNone(conflict)
+        self.assertIn("no order", conflict)
+        self.assertIsNone(tg.prerequisite_conflict("services.worker.replicaCount", self.ROOT))
+
+    def test_the_model_refuses_a_moved_root_s_own_tree(self):
+        """`plan` raises on it, so a caller reaching past the loader reaches past nothing."""
+        with self.assertRaises(tg.TestGenError) as raised:
+            tg.plan(
+                TestPlanning.KEYS, [], [(f"{self.ROOT}.isr.ttl_secs", 1)], root=self.ROOT
+            )
+        self.assertIn(self.ROOT, str(raised.exception))
+        tg.plan(TestPlanning.KEYS, [], [(tg.VALUES_ROOT, {})], root=self.ROOT)
+
+    def test_a_prerequisite_and_a_moved_probe_root_compose_in_one_suite(self):
+        """Prerequisites on every case including the identity one, probes under the moved root."""
+        target = TestSuiteRendering.SHARED
+        suite = yaml.safe_load(
+            tg.render_suite(
+                target,
+                tg.plan(TestPlanning.KEYS, [], self.PREREQUISITES, target.root),
+                [],
+                "the derived wiring outranks it",
+                self.PREREQUISITES,
+                "because the guard insists",
+            )
+        )
+        for test in suite["tests"]:
+            with self.subTest(case=test["it"]):
+                self.assertEqual(test["set"]["bucket.entries"], self.PREREQUISITES[0][1])
+        probe = next(
+            test for test in suite["tests"] if "isr.ttl_secs" in test["it"]
+        )
+        self.assertIn(f"{target.root}.isr.ttl_secs", probe["set"])
 
     def test_an_empty_prerequisite_path_is_refused(self):
         self.assertIsNotNone(tg.prerequisite_conflict(""))
@@ -497,6 +734,52 @@ class TestEnrolment(unittest.TestCase):
                 "    reason: because\n"
             )
 
+    def test_a_document_with_no_probe_is_probed_through_the_configuration_tree(self):
+        enrolled = self.enrolment("documents:\n  - name: server\n")
+        self.assertEqual(enrolled["server"].probe, tg.VALUES_ROOT)
+
+    def test_a_probe_path_is_read_as_the_root_every_case_writes_under(self):
+        enrolled = self.enrolment(
+            "documents:\n  - name: api\n    probe: services.api.config\n    reason: because\n"
+        )
+        self.assertEqual(enrolled["api"].probe, "services.api.config")
+
+    def test_a_probe_that_is_not_a_dotted_values_path_is_refused(self):
+        for offender in ('services["api"].config', "services..config", ".config", "", 7):
+            with self.subTest(probe=offender):
+                with self.assertRaises(DeclarationError):
+                    self.enrolment(
+                        f"documents:\n  - name: api\n    probe: {offender!r}\n"
+                        "    reason: because\n"
+                    )
+
+    def test_a_probe_without_a_reason_is_refused(self):
+        """It narrows the suite to one layer, which is the same hole a baseline opens."""
+        with self.assertRaises(DeclarationError) as raised:
+            self.enrolment("documents:\n  - name: api\n    probe: services.api.config\n")
+        self.assertIn("reason", str(raised.exception))
+
+    def test_a_baseline_is_read_under_the_probe_root_rather_than_under_the_default(self):
+        enrolled = self.enrolment(
+            "documents:\n"
+            "  - name: api\n"
+            "    probe: services.api.config\n"
+            "    baseline:\n"
+            "      services.api.config.a: false\n"
+            "    reason: because\n"
+        )
+        self.assertEqual(enrolled["api"].baseline.values, [("services.api.config.a", False)])
+
+        with self.assertRaises(DeclarationError):
+            self.enrolment(
+                "documents:\n"
+                "  - name: api\n"
+                "    probe: services.api.config\n"
+                "    baseline:\n"
+                "      config.a: false\n"
+                "    reason: because\n"
+            )
+
     def test_an_unknown_key_is_refused_rather_than_ignored(self):
         with self.assertRaises(DeclarationError):
             self.enrolment("documents: []\nreason: stray")
@@ -571,6 +854,35 @@ class TestEnrolment(unittest.TestCase):
                 "documents:\n  - name: server\n    prerequisites:\n      value: {a: 1}\n"
                 "      reason: because\n"
             )
+
+    def test_a_moved_probe_root_moves_which_prerequisite_the_loader_refuses(self):
+        """The loader reads the root first, so its refusal is the model's under a moved root."""
+        enrolled = self.enrolment(
+            "documents:\n"
+            "  - name: api\n"
+            "    probe: services.api.config\n"
+            "    reason: the derived wiring outranks it\n"
+            "    prerequisites:\n"
+            "      values:\n"
+            "        config.profile: development\n"
+            "      reason: because the guard insists\n"
+        )
+        self.assertEqual(
+            enrolled["api"].prerequisites.values, [("config.profile", "development")]
+        )
+
+        with self.assertRaises(DeclarationError) as raised:
+            self.enrolment(
+                "documents:\n"
+                "  - name: api\n"
+                "    probe: services.api.config\n"
+                "    reason: the derived wiring outranks it\n"
+                "    prerequisites:\n"
+                "      values:\n"
+                "        services.api.config.profile: development\n"
+                "      reason: because the guard insists\n"
+            )
+        self.assertIn("services.api.config", str(raised.exception))
 
     def test_a_document_may_carry_a_baseline_and_prerequisites_at_once(self):
         enrolments = self.enrolment(


### PR DESCRIPTION
**Stacked on #461 → #460 → #458.** Merge those first.

Delivers the two capabilities TankoVault needs that no other chart does. **Does not enrol TankoVault** — that also needs render prerequisites and belongs in its own PR, so this diff is confined to `.github/scripts/`.

## 1. Disambiguating nine documents that share a key

TankoVault declares nine documents, each a per-component ConfigMap keyed `config.toml`. The existing selector matched all nine.

Measured against helm-unittest 1.1.2, reading the plugin source: `DocumentSelector` is `{SkipEmptyTemplates, MatchMany, Path, Value}` — **exactly one path and one value; matchers cannot be combined.** `templates:` does narrow the manifest set, but the generator cannot learn a chart's template filenames from the declaration.

So both facts go into one JSONPath expression, since `Path` is evaluated by `yamlpath` and supports filters:

```
$[?(@.metadata.labels["app.kubernetes.io/component"]=="api")].data["config.toml"]
```

| selector | result |
|---|---|
| `data["config.toml"]` | `multiple indexes found` |
| label filter + key, `component: api` | one document, `tankovault-api-config` |
| a component that does not exist | `document not found` — fails loudly |

The label set is **derived from the declaration's `source.selector`**, not restated in the enrolment, so it cannot disagree with what `check-config.py` reads. It is applied **only when a sibling document shares the key**, which is what keeps `portfolio` and `mp-stats-legacy-viewer` byte-identical. Two new hard refusals: a shared key with no selector, and a shared key with an identical selector.

## 2. Probing the layer that actually wins

Every other chart merges `.Values.config` **over** its derived tree. TankoVault is the opposite — `config` is its lowest layer. Measured:

- `config.rate_limit.backend: memory` → document renders `backend = "redis"`. The derived layer wins. **Fails.**
- `services.api.config.rate_limit.backend: memory` → arrives. **Passes.**

Adds a `probe` field, a dotted values path defaulting to `config`, per **document** rather than per chart — `bootstrap` has no per-service layer at all. It could not be derived: the document named `control-plane` is configured at `services.controlPlane.config`, and nothing in the declaration spells that camelCase from the slug.

The baseline is read under the same root, and that is load-bearing rather than cosmetic: `plan()` drops the baseline entry colliding with the probe target by string comparison, so a baseline at `config.x` against a probe at `services.api.config.x` would never compare equal and would quietly supply the value under test.

## The design collision this rebase surfaced

#461's `prerequisite_conflict()` refused `config` and anything beneath it — written when the probe root *was* `config`. Under a movable root that is exactly backwards:

- On a chart probing `services.api.config`, `config` is the **lowest**-precedence layer. A prerequisite there cannot supply a probed value, so refusing it blocks a harmless and sometimes necessary path.
- `services.api.config.*` **can** supply a probed value, and the old rule waved it straight through.

Now measured against the root, and both nesting directions are refused — a prerequisite at `services.api` *encloses* the probe's own `set` path. Two entries of one unordered `set` mapping, one inside the other; the same reasoning #461 already applied between two prerequisites, extended to prerequisite-versus-probe. Five new tests, including one at the loader.

## Verification

- `just test-contract-union` — **348 tests**, green.
- `just check-contract-tests` — 5 suites in step, all byte-identical. This was the main regression risk.
- `just test-unit` — portfolio 93, mp-stats 82, cloudflare 97, netcup 73, s3 87. All pass, no `.snap` touched.
- **TankoVault re-measured on the merged code**: enrolled temporarily → **9 suites, 385 tests, all passing**. Nine filter selectors each resolving to exactly one ConfigMap; 376 of 454 keys delivering. Removed; `git status` clean.

## Carried forward for whoever enrols TankoVault

`bootstrap` has no per-service layer, so it is probed through `config`. If `bootstrap.seedAdmin.enabled` is set, the chart's derived layer overwrites `seed_admin_username` and `seed_admin_email` and no values path can win. Leave it off, or exempt those two keys.

The 78 keys carrying no case are all existing refusals: 39 secret, 22 structured, 17 `unknown`.

`just/contracts.just` still describes TankoVault as blocked by the two capabilities this PR delivers. That paragraph belongs to the enrolment PR; left alone here to keep the diff inside `.github/scripts/`.