### PR TITLE
feat(scripts): state which contract key each chart value feeds, and gate it

### DIFF
--- a/.github/scripts/check-config-bindings.py
+++ b/.github/scripts/check-config-bindings.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+"""Hold every `# @config` marker in a chart's values.yaml against the contract it names.
+
+`just check-contract-coverage` answers a chart-level question — does this chart carry a
+`config-contract.yaml` at all — and its `unconfigured` escape hatch lists *images*. So the
+repository's documented recurring failure is invisible to it: an image release adds a setting, the
+automated bump repins the digest and omits everything else, and no gate anywhere notices that the
+new key has no chart value. `check-config` will not catch it either, because a key nothing renders
+is not a key rendered wrongly.
+
+This is the key-level half. It reads the markers described in `config_bindings.py`, resolves each
+one against the vendored contract, and fails when a marker is wrong or when a key is reached by
+nothing and explained by nothing.
+
+Five rules, and every one of them is a way for a marker to be worse than no marker at all:
+
+1. **A marker's target exists.** A typo binds a value to a key that is not there while looking
+   like coverage, so it is a hard failure with a `did you mean` — the same courtesy every other
+   gate in this group extends.
+2. **The class matches the key.** `structured` must name a key the contract calls `structured`,
+   and `projection` must not: a scalar written where a map belongs is a defect the marker is in a
+   position to state and therefore has to be held to.
+3. **A `when` clause names a values path that exists.** A gate value that was renamed leaves the
+   marker asserting a condition nothing evaluates.
+4. **One key is bound by one value — except under `composed`.** That exception is the entire
+   reason `composed` is a class: `mp-stats`' `server.bind_addr` is `printf "%s:%v" host port`, so
+   two values legitimately feed one key, and both must say so. The converse rule this used to
+   carry — a lone `composed` is really a projection — was **removed, because `tankovault`
+   falsifies it**: `metrics.listen` is `printf "0.0.0.0:%v" .Values.metrics.port`, one value and a
+   literal the chart supplies, whose text is not the value's text. `composed` now says "an input",
+   and the arity is counted here rather than asserted by the class.
+5. **Every key of a bound chart is bound, or `unbound` with a reason.** This is the rule the whole
+   file exists for; the other four keep it from being satisfied by fiction.
+
+The converse of rule 4 — one value binds one key — is enforced by `parse_values` rather than here,
+and it is a rule rather than a property of the grammar. An earlier draft put the marker on the
+value line, where a line has exactly one trailing comment and a value carrying two markers is
+unwriteable; the marker now sits inside the value's `@schema` block, which can hold as many lines
+as someone types, so the parser refuses a second one. Stated here because this is where a reader
+looks for the rules, and "the grammar makes it impossible" is no longer the answer.
+
+**Enrolment is opt-in and declared, by `bindings: true` in `config-contract.yaml`.** A gate that
+failed unenrolled charts would be red for work nobody has scheduled and would end up disabled,
+which is worse than absent. A chart that does not set the switch is not checked and not reported.
+All five charts that map values onto a contract set it today: `portfolio`, `netcup-offer-bot`,
+`s3-bucket-perma-link`, `mp-stats-legacy-viewer` and `tankovault`.
+
+**What a nine-document chart changed about all of this.** The format was designed against two
+single-document charts, and `tankovault` — nine documents, 167 distinct key paths in 454
+declarations — falsified four of its rules at once. Recorded here because each rule read as
+obviously right until a chart of that shape was actually put through it:
+
+1. **A value that feeds several documents could not say so.** 77 of those 167 paths are declared
+   by several documents at once, eight of them by eight documents each — `metrics.enabled`,
+   `metrics.listen`, `bind_addr`, `telemetry.*`. One template line writes each into every service.
+   The first draft refused an unqualified target that resolved in more than one document and asked
+   for a qualifier, which made the case inexpressible: a value carries one marker, and a qualified
+   marker covers one document and leaves the rest owing. An unscoped marker now binds **every**
+   document declaring the key, and a scope narrows it where the chart really does write the key
+   for only some of them.
+2. **`unbound` was per document.** Only 40 of the 167 paths are written by any rendered document
+   at all; the other 127 are settings the image reads and this chart does not surface. Per
+   document that was 345 entries repeating a handful of sentences, so `unbound` moved to the chart
+   and takes a list of keys against one reason. Still one key per line, and still no patterns.
+3. **A lone `composed` was refused.** See rule 4: `metrics.listen` is one value and a literal.
+4. **One value could bind only one key.** `internal.tls.certDir` is the directory
+   `internal.tls.cert`, `internal.tls.key` and `internal.tls.ca` are each built from, by three
+   `printf`s in one template. A value carries a run of markers now — see `config_bindings.py`.
+
+The measurement forced all four. What the chart ended up with: 38 markers resolving to 99
+bindings, and 144 keys written off in six `unbound` entries — eleven the chart derives from its
+own topology, fifteen delivered through the secrets directory, and the rest settings the image
+reads that this chart offers no value for.
+
+Inferring enrolment from "the chart carries at least one marker" is the obvious alternative, and
+it was measured to fail in the direction that matters. Feeding this gate a `portfolio` whose ten
+markers had been rewritten into a spelling the parser does not recognise produced exit 0 and a
+report the chart had simply vanished from — no error, no mention, and the coverage rule it was
+enrolled for silently not run. The same happens to a chart whose markers are deleted. With the
+switch in the declaration, both disagreements are errors: markers without `bindings: true`, and
+`bindings: true` without markers.
+
+Enrolment is per *chart*, not per document, and that is deliberate for a chart like `tankovault`
+that declares nine. A coverage figure over some of a chart's documents is not a coverage figure —
+the keys the reader cares about are exactly the ones nobody got to yet. Setting the switch commits
+the chart to all nine at once, which is a real cost and is meant to be one.
+
+**No staleness interlock, unlike `check-config`.** `bind()` refuses to validate when the vendored
+contract is not for the digest the chart pins, because reporting a pass it cannot justify is worse
+than reporting nothing. That reasoning does not carry here: this gate compares two committed files
+— `values.yaml` and `contracts/*.json` — and whether the second is current is
+`just check-contracts`' question, answered in one line. Refusing to run during the single CI run
+where a bump holds a new digest and the old contract would also remove this report from the exact
+pull request it was written for. Same posture, and the same paragraph, as `config-secrets.py`.
+
+Offline and render-free: two committed files per chart, no cluster, no network, no `helm template`.
+
+Usage: python3 .github/scripts/check-config-bindings.py
+       python3 .github/scripts/check-config-bindings.py --charts charts
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import config_bindings as cb  # noqa: E402
+import config_contract as cc  # noqa: E402
+from config_declaration import Declaration, DeclarationError, Document  # noqa: E402
+from config_declaration import load_declaration  # noqa: E402
+from config_report import Report  # noqa: E402
+
+CHARTS_DIR = Path("charts")
+
+
+class Bound:
+    """One chart's documents, resolved to the contracts that describe them.
+
+    Built without the staleness interlock `config_declaration.bind` applies — see the module
+    docstring — so this is deliberately not that function and does not pretend to be.
+    """
+
+    def __init__(self, chart_dir: Path, declaration: Declaration):
+        self.chart = declaration.chart
+        self.declaration = declaration
+        self.documents: dict[str, Document] = {}
+        self.unions: dict[str, cc.Union] = {}
+
+        for document in declaration.documents:
+            contracts = []
+            for reference in document.images:
+                vendored = cc.load_vendored(chart_dir / reference.contract)
+                contracts.append((f"{chart_dir.name}/{reference.contract}", vendored.contract))
+            self.documents[document.name] = document
+            self.unions[document.name] = cc.union_contracts(contracts)
+
+    def namespace(self, name: str, cls: str) -> dict[str, dict[str, Any]]:
+        """The half of one document's contract a marker of this class may name."""
+        union = self.unions[name]
+        return union.keys if cls in cb.KEY_CLASSES else union.external_env
+
+
+class Gate:
+    """The five rules, over one chart at a time."""
+
+    def __init__(self, report: Report):
+        self.report = report
+
+    def check_chart(self, chart_dir: Path) -> tuple[int, int] | None:
+        """Check one chart; `None` when its declaration does not enrol it.
+
+        Enrolment is read from `config-contract.yaml`, and both disagreements between the switch
+        and the file are failures — see the module docstring for the drift that inferring it let
+        through.
+        """
+        values_path = chart_dir / "values.yaml"
+        if not values_path.is_file():
+            return None
+
+        markers = cb.parse_values(values_path, chart_dir.name)
+        where = f"{chart_dir.name}: values.yaml"
+        declaration = load_declaration(chart_dir)
+
+        if declaration is None or not declaration.bindings:
+            if markers:
+                self.report.fail(
+                    where,
+                    f"carries {len(markers)} `{cb.MARKER}` marker(s), and its "
+                    + (
+                        "config-contract.yaml does not declare `bindings: true`"
+                        if declaration is not None
+                        else "chart has no config-contract.yaml to declare `bindings: true` in"
+                    )
+                    + ". Enrolment is declared rather than inferred, so that a chart which loses "
+                    "its markers goes red instead of quietly leaving the report",
+                )
+                return 0, 0
+            return None
+
+        if not declaration.documents:
+            self.report.fail(
+                where,
+                f"declares `bindings: true` but no configuration contract, so there is nothing to "
+                f"hold a `{cb.MARKER}` marker against; declare a document, or drop the switch",
+            )
+            return 0, 0
+
+        if not markers:
+            self.report.fail(
+                where,
+                f"declares `bindings: true` and carries no `{cb.MARKER}` marker. Either the "
+                "markers were lost — which is the drift this switch exists to catch — or the "
+                "chart was never bound and the switch should not be set",
+            )
+            return 0, 0
+
+        bound = Bound(chart_dir, declaration)
+        values = yaml.safe_load(values_path.read_text(encoding="utf-8")) or {}
+
+        resolved = self.resolve(bound, markers, values)
+        self.check_uniqueness(resolved)
+        self.check_write_offs(bound)
+        self.check_coverage(bound, resolved)
+
+        keys = sum(1 for marker, _ in resolved if marker.cls in cb.KEY_CLASSES)
+        return keys, len(resolved) - keys
+
+    # ------------------------------------------------------------------------------------
+    # Rules 1 to 3 — one marker at a time
+    # ------------------------------------------------------------------------------------
+
+    def resolve(
+        self, bound: Bound, markers: list[cb.Marker], values: dict[str, Any]
+    ) -> list[tuple[cb.Marker, str]]:
+        """Every marker that named something real, once per document it binds the key in."""
+        resolved: list[tuple[cb.Marker, str]] = []
+
+        for marker in markers:
+            documents = self.resolve_documents(bound, marker)
+            if not documents:
+                continue
+            if not self.check_shape(bound, marker, documents):
+                continue
+            self.check_condition(marker, values)
+            resolved.extend((marker, document) for document in documents)
+
+        return resolved
+
+    def resolve_documents(self, bound: Bound, marker: cb.Marker) -> list[str]:
+        """Which documents the marker binds its target in; empty when it named nothing real.
+
+        An unscoped marker binds **every** document whose contract declares the target, which is
+        what a chart does — `tankovault` writes `metrics.enabled` into all eight of its services
+        from one template line, and eight of its key paths are declared by eight documents each.
+        An earlier draft refused that case and asked for a qualifier, which made a value feeding
+        several documents inexpressible: a value carries one marker, and a qualified marker covers
+        one document and leaves the rest owing.
+
+        A scope narrows it, for the case the default over-claims: the chart writes the key for
+        some of the documents that declare it and not others. Naming a document that does not
+        declare the target is refused rather than ignored, because that is how a scope goes stale.
+        """
+        if marker.documents is not None:
+            unknown = [name for name in marker.documents if name not in bound.documents]
+            if unknown:
+                self.report.fail(
+                    marker.where,
+                    f"is scoped to {', '.join(repr(name) for name in unknown)}, which this chart "
+                    f"does not declare (declared: {', '.join(sorted(bound.documents))})",
+                )
+                return []
+            candidates = list(marker.documents)
+        else:
+            candidates = sorted(bound.documents)
+
+        matched = [
+            name for name in candidates if marker.target in bound.namespace(name, marker.cls)
+        ]
+        if matched and marker.documents is not None and len(matched) != len(candidates):
+            missing = sorted(set(candidates) - set(matched))
+            self.report.fail(
+                marker.where,
+                f"is scoped to {', '.join(missing)}, whose contract does not declare "
+                f"{marker.target!r}; a scope that names a document the key is absent from is a "
+                "scope nobody has re-read since the contract changed",
+            )
+            return []
+        if matched:
+            return matched
+
+        namespace = "external.env variable" if marker.cls == cb.EXTERNAL else "contract key"
+        known: list[str] = []
+        for name in candidates:
+            known.extend(bound.namespace(name, marker.cls))
+        scope = (
+            f"the document(s) {', '.join(marker.documents)} do not declare"
+            if marker.documents
+            else "no contract this chart declares carries"
+        )
+        self.report.fail(
+            marker.where,
+            f"binds the value {marker.values_path!r} to the {namespace} {marker.target!r}, which "
+            f"{scope}{cc.suggest(marker.target, known)}",
+        )
+        return []
+
+    def check_shape(self, bound: Bound, marker: cb.Marker, documents: list[str]) -> bool:
+        """Rule 2. A `structured` key holds a map the operator names; a scalar key does not.
+
+        Checked against every document the marker binds, and those documents are first required to
+        agree with each other. Two contracts declaring one path in two different shapes are two
+        different settings that happen to share a name, and binding both from one value would be
+        the marker asserting something no reader could have meant.
+        """
+        forms = {
+            document: bound.namespace(document, marker.cls)[marker.target].get("text_form")
+            for document in documents
+        }
+        if len(set(forms.values())) > 1:
+            spelt = ", ".join(f"{document}: {form}" for document, form in sorted(forms.items()))
+            self.report.fail(
+                marker.where,
+                f"binds {marker.target!r} in documents that do not agree what it is ({spelt}); "
+                "one path in two shapes is two settings, so scope the marker to the one this "
+                "value feeds",
+            )
+            return False
+
+        structured = next(iter(forms.values())) == "structured"
+
+        if marker.cls == cb.STRUCTURED and not structured:
+            self.report.fail(
+                marker.where,
+                f"is `{cb.STRUCTURED}`, but the contract calls {marker.target!r} a scalar "
+                f"({next(iter(forms.values()))}); a scalar key takes `{cb.PROJECTION}`",
+            )
+            return False
+
+        if marker.cls == cb.PROJECTION and structured:
+            self.report.fail(
+                marker.where,
+                f"is `{cb.PROJECTION}`, but the contract calls {marker.target!r} structured "
+                "— the keys underneath it are the operator's own names, which is what "
+                f"`{cb.STRUCTURED}` says",
+            )
+            return False
+
+        return True
+
+    def check_condition(self, marker: cb.Marker, values: dict[str, Any]) -> None:
+        """Rule 3. The gate value has to still be spelt the way the marker says it is."""
+        if marker.condition is None:
+            return
+        if not cb.has_path(values, marker.condition):
+            self.report.fail(
+                marker.where,
+                f"is written only `when {marker.condition}`, and this chart has no value at that "
+                "path; a condition nothing evaluates is a subtree nobody can predict",
+            )
+
+    # ------------------------------------------------------------------------------------
+    # Rule 4 — markers against each other
+    # ------------------------------------------------------------------------------------
+
+    def check_uniqueness(self, resolved: list[tuple[cb.Marker, str]]) -> None:
+        """One key, one value — unless every value binding it says `composed`.
+
+        Only this direction is checked here. The other one — a value binding two keys — is
+        `parse_values`' business, because two markers in one `@schema` block never reach this far.
+        """
+        by_target: dict[tuple[str, str], list[cb.Marker]] = {}
+        for marker, document in resolved:
+            # Keyed by the document the target *resolved* to rather than by how it was written,
+            # so a qualified and an unqualified marker naming one key collide as they should.
+            by_target.setdefault((document, marker.target), []).append(marker)
+
+        for (document, target), markers in sorted(by_target.items()):
+            composed = [marker for marker in markers if marker.cls == cb.COMPOSED]
+
+            if len(markers) > 1 and len(composed) != len(markers):
+                self.report.fail(
+                    markers[0].where,
+                    f"{document}: {target!r} is bound by {len(markers)} values "
+                    f"({', '.join(marker.values_path for marker in markers)}); only "
+                    f"`{cb.COMPOSED}` admits several, and then every one of them must say so",
+                )
+
+    # ------------------------------------------------------------------------------------
+    # Rule 5 — the coverage rule
+    # ------------------------------------------------------------------------------------
+
+    def check_write_offs(self, bound: Bound) -> None:
+        """Every `unbound` key names something some contract in its scope declares.
+
+        A chart-level question rather than a per-document one, and the distinction is the whole
+        reason this is its own pass. An unscoped entry writes a key off *wherever it is declared*,
+        so a document that does not declare it is not an error — it is the ordinary case for a
+        chart whose nine services share a configuration crate and read different halves of it. An
+        entry no document at all recognises is a different thing: a key that was renamed or
+        removed upstream, still written off here, quietly covering nothing.
+        """
+        declared: dict[str, set[str]] = {}
+        for name in bound.documents:
+            for key in bound.unions[name].keys:
+                declared.setdefault(key, set()).add(name)
+
+        where = f"{bound.chart}: config-contract.yaml"
+        for entry in bound.declaration.unbound:
+            scope = set(entry.documents) if entry.documents else set(bound.documents)
+            for key in entry.keys:
+                holders = declared.get(key, set()) & scope
+                if holders:
+                    continue
+                if entry.documents:
+                    self.report.fail(
+                        where,
+                        f"`unbound` writes off {key!r} in {', '.join(sorted(scope))}, whose "
+                        "contracts do not declare it"
+                        + cc.suggest(key, sorted(declared)),
+                    )
+                else:
+                    self.report.fail(
+                        where,
+                        f"`unbound` writes off {key!r}, which no contract this chart declares "
+                        f"carries{cc.suggest(key, sorted(declared))}",
+                    )
+
+    def check_coverage(self, bound: Bound, resolved: list[tuple[cb.Marker, str]]) -> None:
+        """Every contract key of an enrolled chart is bound, or written off with a reason.
+
+        Over `schema.keys` only. `external.env` is a namespace the loader does not own — `PORT`
+        belongs to the Dioxus toolchain and `RUST_LOG` to `tracing` — so a chart that offers no
+        value for one of them has declined to expose somebody else's variable, which is not the
+        omission this gate is looking for.
+        """
+        for name in sorted(bound.documents):
+            union = bound.unions[name]
+            where = f"{bound.chart}: {name}"
+
+            bound_here = {
+                marker.target
+                for marker, in_document in resolved
+                if in_document == name and marker.cls in cb.KEY_CLASSES
+            }
+            written_off = written_off_in(bound.declaration, name)
+
+            for key in sorted(written_off & set(union.keys) & bound_here):
+                self.report.fail(
+                    f"{where}: config-contract.yaml",
+                    f"`unbound` names {key!r} while a marker binds it; one of the two is out "
+                    "of date, and the reason recorded here is the one that will be believed",
+                )
+
+            for key in sorted(set(union.keys) - bound_here - written_off):
+                entry = union.keys[key]
+                self.report.fail(
+                    where,
+                    f"the contract declares {key!r} and no chart value binds it. Add a "
+                    f"`# # {cb.MARKER} ...` marker to the `@schema` block of the value that feeds "
+                    "it, or an `unbound` entry with a reason in config-contract.yaml"
+                    + (" (it is a credential; `just check-config-secrets` is what checks how "
+                       "those are delivered)" if entry.get("secret") else ""),
+                )
+
+
+def written_off_in(declaration: Declaration, document: str) -> set[str]:
+    """The keys `unbound` writes off in one document.
+
+    An entry without a `documents` scope writes its keys off wherever they are declared, which is
+    what "no chart value surfaces this" means for a chart whose services share a configuration
+    crate. A scoped entry writes them off only in the documents it names.
+    """
+    keys: set[str] = set()
+    for entry in declaration.unbound:
+        if entry.documents is None or document in entry.documents:
+            keys.update(entry.keys)
+    return keys
+
+
+def run(charts: Path, report: Report) -> list[tuple[str, int, int]]:
+    """Check every enrolled chart; returns one `(chart, keys, external)` row per enrolment.
+
+    Returns rather than prints, so a test can assert what was enrolled without reading stdout and
+    so the caller decides what a run looks like — the same separation `config_report` already
+    draws between finding something and saying it.
+    """
+    gate = Gate(report)
+    enrolled: list[tuple[str, int, int]] = []
+
+    for chart_dir in sorted(charts.iterdir()):
+        if not (chart_dir / "Chart.yaml").is_file():
+            continue
+
+        counted = gate.check_chart(chart_dir)
+        if counted is None:
+            continue
+
+        enrolled.append((chart_dir.name, counted[0], counted[1]))
+
+    return enrolled
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Check configuration binding markers against the contracts they name"
+    )
+    parser.add_argument("--charts", default=str(CHARTS_DIR))
+    args = parser.parse_args(argv)
+
+    report = Report()
+    try:
+        enrolled = run(Path(args.charts), report)
+    except (cb.BindingError, DeclarationError, cc.ContractError) as failure:
+        print(f"error: {failure}", file=sys.stderr)
+        return 1
+
+    for chart, keys, external in enrolled:
+        print(
+            f"bound: {chart} ({keys} contract key(s), "
+            f"{external} declared external variable(s))"
+        )
+    if not enrolled:
+        print(f"==> no chart carries a `{cb.MARKER}` marker; nothing to check")
+
+    report.print(sys.stdout, sys.stderr)
+
+    if report.errors:
+        print(f"\n{len(report.errors)} configuration binding violation(s)", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/scripts/config_bindings.py
+++ b/.github/scripts/config_bindings.py
@@ -1,0 +1,616 @@
+#!/usr/bin/env python3
+"""Configuration binding markers: which contract key a chart value feeds, stated in `values.yaml`.
+
+A contract says what the image reads. `config-contract.yaml` says which contract describes which
+rendered document. Neither says which *chart value* an operator sets to move a given setting, and
+that is the fact this file gives a name to:
+
+    # @schema
+    # # @config projection telemetry.sentry_dsn optional
+    # type: string
+    # @schema
+    # -- Sentry DSN (`telemetry.sentry_dsn`). Empty disables Sentry entirely.
+    sentryDsn: ""
+
+One line inside the value's `@schema` block, naming the contract key that value feeds and how it
+gets there. Nothing generates these — they are written by whoever maps the chart onto the image,
+and `check-config-bindings.py` is the gate that holds them against the vendored contract. Why that
+line and not the value's own is the longest section below, because it was measured rather than
+chosen and the obvious answers are all wrong.
+
+Why the fact is worth writing down at all, in the order the payoffs arrive:
+
+**1. Key-level coverage — the only one this file serves today.**
+`just check-contract-coverage` is chart-level: it reports whether a chart carries a
+`config-contract.yaml`, and its `unconfigured` escape hatch lists *images*. Nothing in this
+repository notices when an image release adds a setting that no chart value reaches. That is the
+documented recurring failure here — an automated bump repins the digest and silently omits
+everything else — and a marker per value is what turns "the chart has a contract" into "every key
+of that contract has an operator-facing value, or a written reason why it has none".
+
+**2. Retargeting the generated round-trip probes — later, and an addition rather than a rewrite.**
+The generated suites write their probes into the raw `config` escape hatch, so they pass whether
+or not the chart's hand-written camelCase-to-snake_case mapping is right. `Marker.values_path` is
+the dotted path of the chart value itself, so a probe can be written *there* instead and finally
+exercise the mapping. `condition` and `optional` are carried for the same reason: a probe on a
+gated value has to switch its gate on first, and a probe on an optional one has to assert the key
+is *absent* when the value is empty rather than present and empty. Nothing here uses either field;
+both are recorded because a generator that had to re-derive them would have to re-parse the
+templates.
+
+**3. Carrying contract prose into `values.schema.json` — later, likewise an addition.**
+`keys[].docs` and a value's schema `description` carry the same sentences today, written twice.
+A marker is the join: the description of the value at `Marker.values_path` is the `docs` of the key
+at `Marker.target`.
+
+So the model is deliberately (values_path -> target) plus enough about *how* to reproduce the
+mapping, and not a list of covered keys. A coverage-only model would have to be replaced for both
+later payoffs; this one is read by them.
+
+--------------------------------------------------------------------------------------------
+The grammar
+--------------------------------------------------------------------------------------------
+
+    # @schema
+    # # @config <class> <target> [optional] [when <values-path>]
+    # <the rest of the schema, untouched>
+    # @schema
+    # -- <the description helm-docs already reads>
+    <key>: <value>
+
+`class` is one of four shapes, `target` is `[<scope>:]<name>`, and the two suffixes are
+conditions. In fixed order, and with exactly one spelling of everything: a format whose parser
+accepts several orderings is a format two charts write differently. The same rule fixes the
+marker's line — first inside the opening `# @schema`, never second and never last — so a reader
+looking for a value's binding looks in one place.
+
+| Class        | What it asserts                                                          |
+|--------------|---------------------------------------------------------------------------|
+| `projection` | the value is written to the key, one to one, as a scalar                   |
+| `structured` | the value is a map or list written *under* the key; inside is the operator's |
+| `composed`   | the key's text is built from this value and something else                 |
+| `external`   | the value reaches the image as a declared `external.env` variable          |
+
+`<scope>` is one document name, or several separated by commas, and is left off in the ordinary
+case — a bare `<name>` binds the key in **every** document whose contract declares it. That is
+what a chart does: one template line writes `metrics.enabled` into all eight of `tankovault`'s
+services. A scope is written only where the default over-claims, meaning the chart writes the key
+for some of the documents that declare it and not others.
+
+| Suffix        | What it asserts                                                         |
+|---------------|--------------------------------------------------------------------------|
+| `optional`    | omitted rather than written empty when the value is falsy (a `with` guard) |
+| `when <path>` | written only when the chart value at `<path>` is truthy (an `if` guard)   |
+
+--------------------------------------------------------------------------------------------
+The six relationships that actually occur, and where each one lands
+--------------------------------------------------------------------------------------------
+
+Measured across all five charts that map values onto a contract, not designed from one:
+
+| Relationship      | Real example                            | How it is said                 |
+|-------------------|-----------------------------------------|--------------------------------|
+| projection        | all seven of `portfolio`'s keys         | `projection <key>`             |
+| optional          | `telemetry.sentry_dsn`, in three charts | `projection <key> optional`    |
+| structured        | `bucket.entries`, `webhook.paths`       | `structured <key>`             |
+| composition       | `mp-stats` `server.bind_addr`           | `composed <key>` on each input |
+| gated subtree     | `netcup` `metrics.*`                    | `projection <key> when <path>` |
+| one value, one    | `tankovault` `metrics.listen`           | `composed <key>`, on its own   |
+| shared key        | `tankovault` `metrics.enabled`, ×8      | `projection <key>`, unscoped   |
+| partial scope     | a key some documents declare unwritten  | `projection <a>,<b>:<key>`     |
+| not surfaced      | `netcup` `discord.webhook_url`          | no marker; `unbound` instead   |
+
+Two of those six are conditions rather than shapes, and collapsing them into classes was the first
+thing this format got wrong. A `gated` class would have said nothing about `metrics.ip` being a
+one-to-one projection, and a value that is both gated *and* optional would have been inexpressible.
+Orthogonal suffixes cost one token each and compose.
+
+`composed` and `structured` are the two the mapping cannot be *derived* from, and the marker is
+honest about that. `printf "%s:%v" host port` is not recoverable from a comment, and the keys under
+`bucket.entries` are the operator's own names; in both cases the marker asserts the binding and
+claims nothing about the transformation. That is still the whole of what coverage needs, and it is
+what tells payoff 2 that a round-trip probe on such a value has to be written by hand.
+
+**A lone `composed` is legal, and used to be refused.** The rule was "a composition of one is a
+projection", which sounded right against `mp-stats`' `server.bind_addr` — `printf "%s:%v"` over
+two values — and is false: `tankovault`'s `metrics.listen` is `printf "0.0.0.0:%v"` over one
+value and a literal the chart supplies. That is not a projection, because the key's text is not
+the value's text, and it is not two values either. So `composed` says "this value is *an* input",
+where the other inputs may be other values or the chart's own literals, and the arity is read off
+the number of markers on the key rather than asserted by the class. What is lost with the rule is
+a check on a single value labelled `composed` when it is really a projection; nothing offline
+could tell those apart anyway, and the rule was rejecting a shape that occurs.
+
+--------------------------------------------------------------------------------------------
+Two namespaces a marker may name, and the ones it deliberately may not
+--------------------------------------------------------------------------------------------
+
+`schema.keys` — the settings the loader owns — and `external.env` — the variables the contract
+declares that some *other* library reads. `portfolio` needs the second: `server.host`,
+`server.port` and `logLevel` are `IP`, `PORT` and `RUST_LOG`, owned by the Dioxus toolchain and by
+`tracing`, and they are the three values in that chart whose entire purpose is to reach the image.
+Refusing to bind them would leave a reader unable to tell "no marker because this is not
+configuration" from "no marker because someone forgot", which is the distinction the whole gate
+exists to make. They validate identically — an `external.env` entry carries the same `docs`,
+`default`, `required` and `constraint` fields a key does — so the gate is the same code, and
+payoff 3 works on them unchanged. Payoff 2 does not: an external variable is not in the document,
+so a round-trip probe through `config` was never available for it either way.
+
+They are **not** counted by the coverage rule. The loader does not own that namespace; a chart
+that surfaces no value for `RUST_LOG` is not delinquent, it simply does not offer to set it.
+Coverage is over `schema.keys` alone.
+
+Not nameable, on purpose:
+
+- **The loader variables** (`NETCUP_OFFER_BOT_CONFIG`, `..._SECRETS_DIR`). `configMount.configDir`
+  does feed one, but it is the chart's own mount plumbing rather than a setting of the
+  application, and no coverage rule will ever be written over it.
+- **The secrets directory.** A key delivered as a mounted file — `netcup`'s
+  `discord.webhook_url` — is genuinely reached by a chart value, and a `secret` class was drafted
+  for it and dropped: `config-secrets.py` already reconciles credential delivery across every
+  channel, and it does so from the *rendered manifests*. A comment asserting the same thing would
+  be a second and strictly weaker opinion about a fact something else derives. Such keys are
+  written off in the declaration's `unbound` list instead, with a reason that names the gate which
+  does check them.
+
+--------------------------------------------------------------------------------------------
+Why this parser reads text rather than YAML
+--------------------------------------------------------------------------------------------
+
+Not a shortcut, and not a thing to replace with a real YAML parse later: PyYAML discards comments
+entirely, and the marker *is* a comment. `yaml.safe_load` on `values.yaml` returns a mapping in
+which no marker has ever existed. Nothing in the stdlib round-trips YAML comments, and this
+repository's scripts are stdlib plus PyYAML by rule, so a line-by-line reader is the only
+implementation available. It still has to track indentation, because `Marker.values_path` is the
+value's full dotted path and the leaf name alone is useless to both later payoffs.
+
+--------------------------------------------------------------------------------------------
+Where the marker must sit, which was measured rather than chosen
+--------------------------------------------------------------------------------------------
+
+**The first line inside the value's `# @schema` block, written as a YAML comment.** Two other
+tools read the comments above a chart value and both regenerate a file CI commits, so a placement
+here is a claim about them, not a matter of taste. Ten placements were measured on both pilots, by
+moving all fifteen markers and regenerating `values.schema.json` and `README.md` scoped to each
+chart:
+
+| Placement                                    | values.schema.json | README.md         |
+|----------------------------------------------|--------------------|-------------------|
+| first line inside `# @schema`, as `# # ...`  | identical          | identical         |
+| last line inside `# @schema`, as `# # ...`   | identical          | identical         |
+| appended to a schema line as a YAML comment  | identical          | identical         |
+| as a schema key, `# config: projection ...`  | identical          | identical         |
+| bare `# @config` inside `# @schema`          | **helm schema fails**  | —             |
+| own comment line anywhere above the `# --`   | **15 leading `\\n`**| identical         |
+| own comment line last in the block           | identical          | **15 rows fouled**|
+| own comment line, blank line, then the block | identical          | identical         |
+| blank line between the block and the value   | **every description lost** | 15 rows fouled |
+| trailing comment on the value line           | identical          | identical         |
+
+The mechanism explains every row. helm-docs starts a description at `# --` and ends it at the next
+non-comment line, so anything above the description is invisible to it and anything below is
+appended to it. helm-schema collects the *whole* comment block as that description, and for an
+`@`-prefixed line drops the content but keeps the line — a leading newline in fifteen generated
+descriptions:
+
+    -  "description": "Log level (`telemetry.log_level`)."
+    +  "description": "\\nLog level (`telemetry.log_level`)."
+
+But inside its own delimiters the content is not description, it is the schema, parsed as YAML.
+A YAML comment there is discarded by the parser that reads it, which is why the first four rows
+are byte-identical and why this is a property of YAML rather than of a helm-schema version. Bare
+`# @config` is the same position spelt as YAML *content*, and it fails the plugin outright: `@` is
+a reserved indicator in YAML, so the block stops being a document.
+
+Of the five clean rows this file takes the first and refuses the other four. `# config:` survives
+only because helm-schema ignores keys it does not know, which is lenience rather than a rule, and
+it asserts a schema keyword that is not one. Appending to `# type: string` hangs the marker off a
+token it says nothing about. And the blank-line placement makes a blank line load-bearing in a
+file where the row below it shows what a misplaced one costs — every description in the chart.
+
+Available everywhere it is needed: all 1,128 documented values across the five charts that map
+values onto a contract carry a `@schema` block — 179 in `portfolio`, 114 in `netcup-offer-bot`,
+172, 173 and 490 in the other three. Not one is description-only, so no chart has to be told to
+add a schema block in order to bind a value.
+
+What this placement gives up, stated because the first draft of this file used it as the reason
+for the other one: attachment becomes positional again. A trailing comment is *on* the line it
+describes and nothing can re-target it, whereas a marker in the block is attached by contiguity —
+the same contiguity the description already depends on, but the marker now has to be read across
+the closing delimiter and the description to reach its value. `parse_values` therefore refuses
+every way that can go wrong rather than guessing: a blank line before the value, and a block that
+ends at something other than a mapping key.
+
+--------------------------------------------------------------------------------------------
+One value, several keys
+--------------------------------------------------------------------------------------------
+
+A value's markers are the **run of lines directly inside the opening `# @schema`**, and there may
+be more than one. Under the trailing-comment placement there could not be — a line has one comment
+— and that was written up as a property of the grammar that made "one value binds one key" free.
+It is not a property of anything: `tankovault`'s `internal.tls.certDir` is the directory three
+contract keys are built from, `internal.tls.cert`, `internal.tls.key` and `internal.tls.ca`, by
+three `printf`s in one template. Refusing the second marker would have forced two of those three
+bindings to go unsaid, and coverage would then have owed them from somewhere else.
+
+So a value may bind several keys, one marker each, and the parser refuses only the two ways that
+cannot be meant: the same target twice on one value, and a marker below the schema rather than in
+the run above it. The converse — one key bound by several values — is still `check-config-bindings`
+rule 4's, and still needs `composed` on every one of them.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+# The comment introducer. `@config` rather than `@contract` because a marker names the *setting* a
+# value feeds; the contract is merely the document that happens to describe it.
+MARKER = "@config"
+
+PROJECTION = "projection"
+STRUCTURED = "structured"
+COMPOSED = "composed"
+EXTERNAL = "external"
+
+CLASSES = (PROJECTION, STRUCTURED, COMPOSED, EXTERNAL)
+
+# Classes whose target is a `schema.keys` path; `external` is the one that is not.
+KEY_CLASSES = (PROJECTION, STRUCTURED, COMPOSED)
+
+# The delimiter helm-schema encloses a value's schema in, and the only region of `values.yaml`
+# whose comment content is YAML rather than prose. That is what makes it the one place a marker
+# can sit without either generator seeing it — see the module docstring.
+_SCHEMA_DELIM = re.compile(r"^ *# @schema *$")
+
+_MAPPING_KEY = re.compile(r"^(?P<indent> *)(?P<name>[A-Za-z0-9_][A-Za-z0-9_.\-]*):(?P<rest> .*|)$")
+_SEQUENCE_ITEM = re.compile(r"^ *-( .*|)$")
+_BLOCK_SCALAR = re.compile(r"^[|>][-+0-9]*$")
+_VALUES_PATH = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_.\-]*$")
+_TARGET = re.compile(r"^(?:(?P<documents>[A-Za-z0-9_.\-]+(?:,[A-Za-z0-9_.\-]+)*):)?"
+                     r"(?P<name>[A-Za-z0-9_.\-]+)$")
+
+
+class BindingError(Exception):
+    """A `values.yaml` whose markers cannot be read as ones."""
+
+
+@dataclass(frozen=True)
+class Marker:
+    """One `# @config` comment, and the chart value whose `@schema` block it was written in.
+
+    `values_path` is the dotted path of that value — `csp.cloudflare.scriptNonce` — derived from
+    the indentation of the *value* the block belongs to, not of the marker, so it cannot disagree
+    with the file. It is the field the two later payoffs read: the probe target for payoff 2, the
+    description target for payoff 3.
+
+    `line` is the marker's own line, because that is the line a reader has to edit; the value it
+    binds is a few lines below it and named in every message.
+
+    `documents` is the scope of the binding: the `config-contract.yaml` documents the value feeds,
+    or `None` for the default — *every* document whose contract declares the target. The default is
+    the common case rather than the ambiguous one, because a chart writes one value into every
+    service that reads it: `tankovault`'s `metrics.enabled` reaches all eight of its services from
+    one line of the template, and eight of its key paths are declared by eight documents each.
+    A scope is written only where the default would over-claim.
+    """
+
+    chart: str
+    values_path: str
+    line: int
+    cls: str
+    documents: tuple[str, ...] | None
+    target: str
+    optional: bool
+    condition: str | None
+
+    @property
+    def where(self) -> str:
+        """`chart/values.yaml:LINE`, for a message a reader can jump to."""
+        return f"{self.chart}/values.yaml:{self.line}"
+
+
+def split_comment(line: str) -> tuple[str, str | None]:
+    """Split one line into its YAML and its trailing comment, respecting quotes.
+
+    A `#` inside a quoted scalar is data — `password: "a#b"` is an ordinary value — so a naive
+    `line.split("#")` would truncate it and then fail to find the mapping key it was reading.
+    Cheap to do properly, and the alternative is a parser that is wrong on a chart nobody has
+    written yet.
+    """
+    single = double = False
+    index = 0
+    while index < len(line):
+        character = line[index]
+        if single:
+            single = character != "'"
+        elif double:
+            if character == "\\":
+                index += 1
+            elif character == '"':
+                double = False
+        elif character == "'":
+            single = True
+        elif character == '"':
+            double = True
+        elif character == "#" and (index == 0 or line[index - 1] in " \t"):
+            return line[:index], line[index + 1 :].strip()
+        index += 1
+    return line, None
+
+
+def is_marker(comment: str | None) -> bool:
+    """Whether a comment body is a marker, and not merely a word beginning the same way."""
+    return comment is not None and (comment == MARKER or comment.startswith(MARKER + " "))
+
+
+def parse_marker(text: str) -> tuple[str, str | None, str, bool, str | None]:
+    """Read one marker's body — everything after `@config` — into its five parts.
+
+    Raises `BindingError` on anything else. There is no lenient reading of a marker: a comment that
+    was meant to be one and is not understood must fail here, because the alternative is a value
+    that looks bound to a reviewer and is bound to nothing.
+    """
+    tokens = text.split()
+    if not tokens:
+        raise BindingError(f"`{MARKER}` names nothing; expected `{MARKER} <class> <target>`")
+
+    cls = tokens.pop(0)
+    if cls not in CLASSES:
+        raise BindingError(f"unknown class {cls!r}; known classes are {', '.join(CLASSES)}")
+
+    if not tokens:
+        raise BindingError(f"`{MARKER} {cls}` names no target")
+
+    matched = _TARGET.match(tokens.pop(0))
+    if matched is None:
+        raise BindingError(
+            "a target is `<key.path>`, or `<document>[,<document>...]:<key.path>` to scope it, "
+            "in the contract's own spelling"
+        )
+    target = matched.group("name")
+
+    documents = None
+    if matched.group("documents") is not None:
+        documents = tuple(matched.group("documents").split(","))
+        if len(set(documents)) != len(documents):
+            raise BindingError(f"the scope {','.join(documents)!r} names a document twice")
+
+    optional = bool(tokens) and tokens[0] == "optional"
+    if optional:
+        tokens.pop(0)
+
+    condition = None
+    if tokens and tokens[0] == "when":
+        tokens.pop(0)
+        if not tokens:
+            raise BindingError("`when` names no values path")
+        condition = tokens.pop(0)
+        if not _VALUES_PATH.match(condition):
+            raise BindingError(f"`when {condition}` is not a dotted values path")
+
+    if tokens:
+        # Including `when ... optional`, the other order. One relationship has one spelling;
+        # accepting both would make two files that wrote it differently look like they said
+        # different things.
+        raise BindingError(
+            f"unexpected {' '.join(tokens)!r}; the form is "
+            f"`{MARKER} <class> <target> [optional] [when <values-path>]`, in that order"
+        )
+
+    return cls, documents, target, optional, condition
+
+
+def schema_comment(comment: str | None) -> str | None:
+    """The YAML comment carried by one line *inside* a `# @schema` block, if it carries one.
+
+    Inside the delimiters the text after `# ` is the schema, parsed as YAML, so a marker written
+    there is a comment within that YAML and the line reads `# # @config ...`. This returns the
+    inner comment — `@config ...` — for such a line, and `None` for a line whose schema content is
+    real schema and therefore none of this file's business.
+    """
+    if comment is None or not comment.startswith("#"):
+        return None
+    return comment[1:].strip()
+
+
+def parse_values(path: Path, chart: str | None = None) -> list[Marker]:
+    """Every marker in one `values.yaml`, each carrying the dotted path of the value it binds.
+
+    Walks the file as lines, because the marker is a comment and no YAML reader available here
+    keeps one — see the module docstring. Every problem in the file is collected before any is
+    raised, which is the posture every gate in this group takes: one broken line must not hide the
+    state of the rest.
+
+    Reading a marker is a small state machine rather than a line test, because the marker sits in
+    the value's `@schema` block: open the block, take its first line, close it, cross the `# --`
+    description, and bind at the mapping key that ends the run. Every way that walk can end
+    somewhere other than a value is refused rather than guessed at — the price of a placement that
+    is attached by contiguity instead of by being on the line it describes.
+    """
+    chart = chart or path.parent.name
+    problems: list[str] = []
+    markers: list[Marker] = []
+
+    # The mapping nesting, as (indent, name). A key at indent i closes everything at indent >= i.
+    stack: list[tuple[int, str]] = []
+    # Regions whose interior this parser does not model: sequence items and block scalars. Neither
+    # holds a values path a marker may be written against.
+    skip_deeper_than: int | None = None
+
+    in_schema = False
+    # True while the reader is still in the block's opening run of marker lines.
+    in_marker_run = False
+    # The markers read out of a block, waiting for the value that block belongs to.
+    pending: list[tuple[int, tuple]] = []
+
+    def strand(what: str) -> None:
+        """Markers whose block never reached a value bind nothing. Say so, naming both."""
+        nonlocal pending
+        for line_number, _ in pending:
+            problems.append(
+                f"{chart}/values.yaml:{line_number}: this `{MARKER}` marker's `@schema` block is "
+                f"followed by {what} rather than by the value it binds, so it binds nothing"
+            )
+        pending = []
+
+    for number, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw.rstrip()
+
+        if not line.strip():
+            # A blank line ends the comment run, which is exactly how both generators lose the
+            # description too — measured: every description in the chart disappears.
+            if not in_schema:
+                strand("a blank line")
+            continue
+
+        indent = len(line) - len(line.lstrip(" "))
+        if skip_deeper_than is not None:
+            if indent > skip_deeper_than:
+                continue
+            skip_deeper_than = None
+
+        code, comment = split_comment(line)
+
+        if _SCHEMA_DELIM.match(line):
+            if in_schema:
+                in_schema = False
+                in_marker_run = False
+            else:
+                strand("a second `@schema` block")
+                in_schema = True
+                in_marker_run = True
+            continue
+
+        if in_schema:
+            nested = schema_comment(comment)
+            if is_marker(nested):
+                if not in_marker_run:
+                    problems.append(
+                        f"{chart}/values.yaml:{number}: this `{MARKER}` marker is below the "
+                        "schema rather than above it. A value's markers are the run of lines "
+                        "directly inside the opening `# @schema`, so that a reader looking for "
+                        "what a value binds reads the top of one block and stops"
+                    )
+                else:
+                    try:
+                        parsed = parse_marker(nested[len(MARKER) :].strip())
+                    except BindingError as failure:
+                        problems.append(f"{chart}/values.yaml:{number}: {failure}")
+                    else:
+                        duplicate = next(
+                            (
+                                line_number
+                                for line_number, other in pending
+                                if (other[1], other[2]) == (parsed[1], parsed[2])
+                            ),
+                            None,
+                        )
+                        if duplicate is not None:
+                            problems.append(
+                                f"{chart}/values.yaml:{number}: this value already binds "
+                                f"{parsed[2]!r} on line {duplicate}; one binding said twice is "
+                                "one of the two being out of date"
+                            )
+                        else:
+                            pending.append((number, parsed))
+            elif is_marker(comment):
+                problems.append(
+                    f"{chart}/values.yaml:{number}: this `{MARKER}` marker is schema *content* "
+                    "rather than a comment on it, and `@` is a reserved indicator in YAML, so "
+                    "`helm schema` fails on the block outright. Write it as a comment within the "
+                    f"schema: `# # {MARKER} ...`"
+                )
+                in_marker_run = False
+            else:
+                in_marker_run = False
+            continue
+
+        if not code.strip():
+            if is_marker(comment):
+                problems.append(
+                    f"{chart}/values.yaml:{number}: this `{MARKER}` marker is a comment line of "
+                    "its own, outside the `@schema` delimiters. Both generators read that run as "
+                    "the value's description: above the `# --` helm-schema emits a leading "
+                    "newline into values.schema.json, and below it helm-docs appends the marker "
+                    f"to the value's row in README.md. Write it as `# # {MARKER} ...` on the "
+                    "first line inside the block instead"
+                )
+            continue
+
+        if _SEQUENCE_ITEM.match(code):
+            strand("a sequence item")
+            _refuse(problems, chart, number, comment, "a sequence item")
+            skip_deeper_than = indent
+            continue
+
+        key = _MAPPING_KEY.match(code.rstrip())
+        if key is None:
+            strand("a line this parser cannot read as a value")
+            _refuse(problems, chart, number, comment, "a line this parser cannot read as a value")
+            continue
+
+        while stack and stack[-1][0] >= indent:
+            stack.pop()
+        stack.append((indent, key.group("name")))
+
+        if _BLOCK_SCALAR.match(key.group("rest").strip()):
+            skip_deeper_than = indent
+
+        if is_marker(comment):
+            problems.append(
+                f"{chart}/values.yaml:{number}: this `{MARKER}` marker is the value's trailing "
+                "comment. Both generators ignore it there, so this is a convention rather than a "
+                "measurement: every other piece of metadata about a value lives above it, and the "
+                f"marker's place is the first line inside the `@schema` block, as `# # {MARKER} "
+                "...`"
+            )
+
+        values_path = ".".join(name for _, name in stack)
+        for marker_line, (cls, documents, target, optional, condition) in pending:
+            markers.append(
+                Marker(
+                    chart=chart,
+                    values_path=values_path,
+                    line=marker_line,
+                    cls=cls,
+                    documents=documents,
+                    target=target,
+                    optional=optional,
+                    condition=condition,
+                )
+            )
+        pending = []
+
+    strand("the end of the file")
+
+    if problems:
+        raise BindingError("\n".join(problems))
+    return markers
+
+
+def _refuse(problems: list[str], chart: str, number: int, comment: str | None, what: str) -> None:
+    if is_marker(comment):
+        problems.append(
+            f"{chart}/values.yaml:{number}: this `{MARKER}` marker sits on {what}; a marker "
+            "describes one mapping value and is written inside that value's `@schema` block"
+        )
+
+
+def has_path(values: object, path: str) -> bool:
+    """Whether a dotted values path exists, including one whose value is `null` or `false`.
+
+    Existence rather than truth: a `when metrics.enabled` marker is checked against a chart whose
+    own default is `enabled: false`, and the question the gate can answer offline is whether the
+    gate value is still spelt that way — not whether it happens to be on in `values.yaml`.
+
+    Deliberately not `config_declaration.dig`, whose `None` return cannot tell a missing path from
+    one set to `null`, and which this module would otherwise import a YAML reader to reach.
+    """
+    current = values
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return False
+        current = current[part]
+    return True

--- a/.github/scripts/config_declaration.py
+++ b/.github/scripts/config_declaration.py
@@ -35,12 +35,13 @@ GATES = {
 
 # Keys each level may carry. Anything else is a typo that would otherwise be ignored in silence,
 # which for a file whose whole job is to be exhaustive is the worst possible failure mode.
-DECLARATION_KEYS = {"documents", "reason", "unconfigured"}
+DECLARATION_KEYS = {"documents", "reason", "unconfigured", "bindings", "unbound"}
 DOCUMENT_KEYS = {"name", "source", "images", "consumers", "exempt"}
 SOURCE_KEYS = {"kind", "selector", "key", "format"}
 IMAGE_KEYS = {"values", "contract"}
 CONSUMER_KEYS = {"workload", "containers"}
 EXEMPT_KEYS = {"values", "gates", "reason"}
+UNBOUND_KEYS = {"keys", "reason", "documents"}
 
 FORMATS = ("toml", "json", "yaml")
 
@@ -83,6 +84,38 @@ class Exemption:
 
 
 @dataclass(frozen=True)
+class Unbound:
+    """Contract keys this chart deliberately surfaces no value for, and why.
+
+    A different axis from `Exemption` above, and the two are not interchangeable. An exemption is
+    per `ci/` values file and per gate: it says one rendered *fixture* is not held to one of the
+    four checks. This says a set of *keys* has no chart value binding it, which is a property of
+    the chart and of every fixture at once, and it relaxes no gate — `check-config` still validates
+    whatever those keys' rendered values turn out to be.
+
+    **Several keys to one reason, and the keys still listed one by one.** The first draft was one
+    entry per key, which reads well for the two keys `s3-bucket-perma-link` writes off and does not
+    survive `tankovault`: 127 of its key paths are surfaced by nothing, and per-document entries
+    made that 345 of them, all repeating a handful of sentences. A shared reason is what those keys
+    actually have in common. What is *not* offered is a pattern or a prefix: every key is written
+    out, so an image release that adds one turns the gate red until somebody puts it in a list on
+    purpose, which is the whole reason this file exists.
+
+    `documents` scopes the write-off the way a marker's scope does — absent means every document
+    whose contract declares the key. Naming documents says the key is surfaced in some of them and
+    not others.
+
+    The `reason` is mandatory for the reason an exemption's is: a key no value reaches is either a
+    considered decision or the exact oversight `check-config-bindings` exists to catch, and nothing
+    but a sentence tells the two apart.
+    """
+
+    keys: tuple[str, ...]
+    reason: str
+    documents: tuple[str, ...] | None
+
+
+@dataclass(frozen=True)
 class Document:
     name: str
     source: Source
@@ -107,11 +140,24 @@ class Document:
 
 @dataclass(frozen=True)
 class Declaration:
+    """One chart's `config-contract.yaml`.
+
+    `bindings` is the chart's enrolment in `check-config-bindings`, and it is a declared fact
+    rather than an inferred one on purpose. Enrolment used to be "the chart carries at least one
+    marker", which reads well until a chart *stops* carrying them: a botched edit, a rewritten
+    `values.yaml`, a marker spelt in a way the parser does not recognise, and the chart drops out
+    of the report without a word — measured, not imagined. With the switch in the declaration the
+    two disagreements are both errors: markers without `bindings: true`, and `bindings: true`
+    without markers.
+    """
+
     chart: str
     path: Path
     documents: list[Document]
     reason: str | None
     unconfigured: list[str]
+    bindings: bool
+    unbound: list[Unbound]
 
 
 def load_declaration(chart_dir: Path) -> Declaration | None:
@@ -135,12 +181,26 @@ def load_declaration(chart_dir: Path) -> Declaration | None:
             f"{path}: `documents` is empty, which is an explicit opt-out and needs a `reason`"
         )
 
+    bindings = document.get("bindings", False)
+    if not isinstance(bindings, bool):
+        raise DeclarationError(
+            f"{path}: `bindings` is the chart's enrolment in check-config-bindings and must be "
+            f"true or false, not {bindings!r}"
+        )
+
+    # Named apart from `document`, the parsed mapping this function is reading, so the two are
+    # never mistaken for each other while the file is being edited.
+    declared = [_load_document(path, entry) for entry in raw_documents]
+    names = {entry.name for entry in declared}
+
     return Declaration(
         chart=chart_dir.name,
         path=path,
-        documents=[_load_document(path, entry) for entry in raw_documents],
+        documents=declared,
         reason=reason,
         unconfigured=list(document.get("unconfigured") or []),
+        bindings=bindings,
+        unbound=_load_unbound(path, document.get("unbound") or [], names),
     )
 
 
@@ -252,6 +312,79 @@ def _load_exemptions(path: Path, name: str, exemptions: Iterable[Any]) -> list[E
                 values=str(exemption.get("values") or ""),
                 gates=[str(gate) for gate in gates],
                 reason=str(exemption["reason"]),
+            )
+        )
+    return loaded
+
+
+def _load_unbound(path: Path, entries: Iterable[Any], documents: set[str]) -> list[Unbound]:
+    """The contract keys this chart binds no value to, each group with a written reason.
+
+    Read here rather than in `config_bindings.py` for the reason everything else about this file
+    is: `config-contract.yaml` has one reader, and a second parser of the same document would be
+    free to disagree with this one about what an unknown key means. A marker states a fact about a
+    value and belongs beside the value; the decision not to surface a key is a decision about the
+    key, and belongs beside the contract that declares it.
+
+    Chart-level rather than per document, because that is what the fact is: a key nothing surfaces
+    is unsurfaced everywhere it is declared. `documents` narrows it where that is untrue.
+    """
+    loaded = []
+    seen: dict[tuple[str, str | None], int] = {}
+
+    for position, entry in enumerate(entries):
+        where = f"unbound[{position}]"
+        if not isinstance(entry, dict):
+            raise DeclarationError(f"{path}: every entry of `unbound` must be a mapping")
+        reject_unknown(path, where, entry, UNBOUND_KEYS)
+
+        keys = entry.get("keys")
+        if not isinstance(keys, list) or not keys:
+            raise DeclarationError(
+                f"{path}: {where}: `keys` is missing or empty; an entry writes off at least one "
+                "key, listed by name — there is no pattern form, so a key an image release adds "
+                "cannot be written off by something somebody typed before it existed"
+            )
+        for key in keys:
+            if not isinstance(key, str) or not key:
+                raise DeclarationError(f"{path}: {where}: every entry of `keys` must be a name")
+
+        if not entry.get("reason"):
+            raise DeclarationError(
+                f"{path}: {where}: no `reason`; a key nothing surfaces is either a decision or "
+                "the oversight this gate exists to catch, and silence cannot say which"
+            )
+
+        scope = entry.get("documents")
+        if scope is not None:
+            if not isinstance(scope, list) or not scope:
+                raise DeclarationError(
+                    f"{path}: {where}: `documents` scopes the write-off and must be a non-empty "
+                    "list; leave it out to write the keys off wherever they are declared"
+                )
+            unknown = sorted({str(name) for name in scope} - documents)
+            if unknown:
+                raise DeclarationError(
+                    f"{path}: {where}: `documents` names {', '.join(repr(n) for n in unknown)}, "
+                    f"which this chart does not declare (declared: {', '.join(sorted(documents))})"
+                )
+            scope = tuple(str(name) for name in scope)
+
+        for key in keys:
+            for name in scope or (None,):
+                if (key, name) in seen:
+                    raise DeclarationError(
+                        f"{path}: {where}: {key!r} is already written off by "
+                        f"unbound[{seen[(key, name)]}]; two reasons for one key means one of them "
+                        "is not the reason"
+                    )
+                seen[(key, name)] = position
+
+        loaded.append(
+            Unbound(
+                keys=tuple(str(key) for key in keys),
+                reason=str(entry["reason"]),
+                documents=scope,
             )
         )
     return loaded

--- a/.github/scripts/tests/test_contract_bindings.py
+++ b/.github/scripts/tests/test_contract_bindings.py
@@ -1,0 +1,991 @@
+#!/usr/bin/env python3
+"""Configuration binding markers: the grammar, the placement rule, and the six gate rules.
+
+Every one of these has a plausible-looking wrong implementation that a run over this repository
+would not expose, because all five enrolled charts are correct — which is the whole problem with
+testing a gate against the tree it was written for.
+
+Four of them are worth naming here, because getting any of them wrong makes the gate report
+coverage it has not established:
+
+  the placement rule    the marker is the first line inside the value's `@schema` block,
+                        written as a YAML comment. Measured over ten placements on both pilots:
+                        the schema block is the one region of the file whose comment content is
+                        YAML rather than prose, so both generators discard it and both generated
+                        files come back byte-identical. Every other position is refused and each
+                        refusal names the damage it does, so a reader who finds one of them
+                        tidier meets the measurement rather than a preference
+
+  the values path       derived from indentation, so `csp.cloudflare.scriptNonce` is what a later
+                        generator writes its probe against. A parser that returned the leaf name
+                        would look right on every flat chart and be useless on the first nested
+                        one
+
+  the quoted hash       `password: "a#b"` is an ordinary value, and a parser that split on the
+                        first `#` would read its key wrong and report a marker that is not there
+
+  composed both ways    two values feeding one key is legal *only* when both say `composed`, and
+                        a lone `composed` is refused. Implement only the first half and `composed`
+                        becomes a way to switch off the duplicate rule
+
+  coverage's namespace  over `schema.keys` alone. Counting `external.env` would make a chart that
+                        declines to surface `RUST_LOG` look delinquent; counting the keys but
+                        crediting an `external` marker for one would let a marker of the wrong
+                        class satisfy the rule
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+
+import config_bindings as cb  # noqa: E402
+from config_declaration import DeclarationError, load_declaration  # noqa: E402
+from config_report import Report  # noqa: E402
+
+FIXTURES = SCRIPTS.parent / "testdata" / "contracts"
+
+DIGEST = "sha256:" + "1" * 64
+
+
+def _load(name: str, filename: str):
+    """Import a hyphenated entry point, the way `test_contract_secrets` already does."""
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+entry = _load("config_bindings_entry", "check-config-bindings.py")
+
+
+def fixture(name: str) -> dict:
+    return json.loads((FIXTURES / f"{name}.json").read_text(encoding="utf-8"))
+
+
+# --------------------------------------------------------------------------------------------
+# A chart on disk, because the gate reads two committed files and there is no point pretending
+# --------------------------------------------------------------------------------------------
+
+
+class ChartBuilder:
+    """A throwaway `charts/` tree holding one chart, for the gate to walk."""
+
+    def __init__(self, root: Path, name: str = "fixture"):
+        self.root = root
+        self.name = name
+        self.dir = root / name
+        (self.dir / "contracts").mkdir(parents=True)
+        (self.dir / "Chart.yaml").write_text(
+            f"name: {name}\nversion: 1.0.0\nappVersion: v1\n", encoding="utf-8"
+        )
+
+    def contract(self, document: str, contract: dict) -> ChartBuilder:
+        (self.dir / "contracts" / f"{document}.json").write_text(
+            json.dumps(
+                {
+                    "source": {
+                        "image": "docker.io/example/app",
+                        "digest": DIGEST,
+                        "sha256": "0" * 64,
+                        "fetched": "2026-01-01T00:00:00Z",
+                    },
+                    "contract": contract,
+                }
+            ),
+            encoding="utf-8",
+        )
+        return self
+
+    def values(self, text: str) -> ChartBuilder:
+        (self.dir / "values.yaml").write_text(text, encoding="utf-8")
+        return self
+
+    def declaration(self, body: str) -> ChartBuilder:
+        (self.dir / "config-contract.yaml").write_text(body, encoding="utf-8")
+        return self
+
+    def run(self) -> Report:
+        report = Report()
+        entry.run(self.root, report)
+        return report
+
+
+def messages(report: Report) -> str:
+    return "\n".join(finding.message for _, finding in report.errors)
+
+
+DECLARATION = """\
+bindings: true
+documents:
+  - name: api
+    source:
+      kind: ConfigMap
+      selector: { app: fixture }
+      key: config.toml
+    images:
+      - values: image
+        contract: contracts/api.json
+"""
+
+
+def declaration_with(unbound: str) -> str:
+    """The fixture declaration plus a chart-level `unbound` block, which is not indented."""
+    return DECLARATION + unbound
+
+
+def bound(line: str, marker: str, schema: str = "type: string") -> str:
+    """One value with its marker where the format puts it: first inside the `@schema` block.
+
+    A helper rather than fifteen spelt-out blocks, so the placement lives in one place here too.
+    The tests that are *about* the placement spell their own values out instead, because a helper
+    that produced the wrong one would make them pass.
+    """
+    indent = line[: len(line) - len(line.lstrip(" "))]
+    block = ("# @schema", f"# # {marker}", f"# {schema}", "# @schema", "# -- Description.")
+    return "".join(f"{indent}{entry}\n" for entry in block) + line + "\n"
+
+
+# Every `api` key bound, so a case that adds nothing starts from a passing chart and the failure
+# under test is the only difference.
+COVERED = (
+    bound("sessionTtl: 3600", "@config projection auth.session_ttl", "type: integer")
+    + bound('databaseUrl: ""', "@config projection database.url")
+    + bound("logLevel: info", "@config projection log.level")
+    + bound("repos: {}", "@config structured github.repos", "type: object")
+)
+
+
+# --------------------------------------------------------------------------------------------
+# The grammar
+# --------------------------------------------------------------------------------------------
+
+
+class TestGrammar(unittest.TestCase):
+    """`@config <class> <target> [optional] [when <values-path>]`, and nothing else."""
+
+    def test_a_bare_projection(self):
+        self.assertEqual(
+            cb.parse_marker("projection isr.ttl_secs"),
+            (cb.PROJECTION, None, "isr.ttl_secs", False, None),
+        )
+
+    def test_every_class_is_accepted(self):
+        for cls in cb.CLASSES:
+            self.assertEqual(cb.parse_marker(f"{cls} a.b")[0], cls)
+
+    def test_optional(self):
+        self.assertEqual(
+            cb.parse_marker("projection telemetry.sentry_dsn optional"),
+            (cb.PROJECTION, None, "telemetry.sentry_dsn", True, None),
+        )
+
+    def test_a_condition(self):
+        self.assertEqual(
+            cb.parse_marker("projection metrics.ip when metrics.enabled"),
+            (cb.PROJECTION, None, "metrics.ip", False, "metrics.enabled"),
+        )
+
+    def test_optional_and_a_condition_compose(self):
+        self.assertEqual(
+            cb.parse_marker("projection a.b optional when c.d"),
+            (cb.PROJECTION, None, "a.b", True, "c.d"),
+        )
+
+    def test_a_scoped_target(self):
+        self.assertEqual(
+            cb.parse_marker("projection bootstrap:auth.session_ttl"),
+            (cb.PROJECTION, ("bootstrap",), "auth.session_ttl", False, None),
+        )
+
+    def test_a_scope_of_several_documents(self):
+        """What `tankovault`'s branding needs: three documents declare it, two are sent it."""
+        self.assertEqual(
+            cb.parse_marker("projection api,frontend:branding.name")[1],
+            ("api", "frontend"),
+        )
+
+    def test_an_unscoped_target_is_every_document_declaring_it(self):
+        """`None` rather than a list, because the set is the contracts' answer and not the
+        marker's — a document added later declaring the same key is bound by the same line."""
+        self.assertIsNone(cb.parse_marker("projection auth.session_ttl")[1])
+
+    def test_a_scope_naming_one_document_twice_is_refused(self):
+        with self.assertRaisesRegex(cb.BindingError, "names a document twice"):
+            cb.parse_marker("projection api,api:auth.session_ttl")
+
+    def test_an_external_variable(self):
+        self.assertEqual(cb.parse_marker("external RUST_LOG")[1:3], (None, "RUST_LOG"))
+
+    def test_an_unknown_class_is_refused(self):
+        with self.assertRaisesRegex(cb.BindingError, "unknown class 'gated'"):
+            cb.parse_marker("gated metrics.ip")
+
+    def test_a_missing_target_is_refused(self):
+        with self.assertRaisesRegex(cb.BindingError, "names no target"):
+            cb.parse_marker("projection")
+
+    def test_a_dangling_when_is_refused(self):
+        with self.assertRaisesRegex(cb.BindingError, "names no values path"):
+            cb.parse_marker("projection a.b when")
+
+    def test_the_suffix_order_is_fixed(self):
+        """One relationship, one spelling — the reversed order is not silently accepted."""
+        with self.assertRaisesRegex(cb.BindingError, "in that order"):
+            cb.parse_marker("projection a.b when c.d optional")
+
+    def test_trailing_prose_is_refused(self):
+        with self.assertRaisesRegex(cb.BindingError, "unexpected"):
+            cb.parse_marker("projection a.b because reasons")
+
+
+# --------------------------------------------------------------------------------------------
+# The parser: attachment, values paths, and the placement rule
+# --------------------------------------------------------------------------------------------
+
+
+class TestParser(unittest.TestCase):
+    def parse(self, text: str) -> list[cb.Marker]:
+        with tempfile.TemporaryDirectory() as workspace:
+            path = Path(workspace) / "values.yaml"
+            path.write_text(text, encoding="utf-8")
+            return cb.parse_values(path, "fixture")
+
+    def test_a_marker_is_the_first_line_inside_the_value_s_schema_block(self):
+        markers = self.parse(
+            "# @schema\n"
+            "# # @config projection isr.ttl_secs\n"
+            "# type: integer\n"
+            "# @schema\n"
+            "# -- Revalidation interval in seconds.\n"
+            "ttlSecs: 0\n"
+        )
+        self.assertEqual(len(markers), 1)
+        self.assertEqual(markers[0].values_path, "ttlSecs")
+        self.assertEqual(markers[0].target, "isr.ttl_secs")
+
+    def test_the_line_reported_is_the_marker_s_own(self):
+        """What a reader has to edit, which is no longer the line the value is on."""
+        markers = self.parse(bound("ttlSecs: 0", "@config projection isr.ttl_secs"))
+        self.assertEqual(markers[0].line, 2)
+
+    def test_the_values_path_is_the_full_dotted_path(self):
+        """Derived from the *value's* indentation, not the marker's, though they agree here."""
+        markers = self.parse(
+            "csp:\n"
+            "  cloudflare:\n"
+            + bound("    scriptNonce: true", "@config projection csp.cloudflare.script_nonce")
+        )
+        self.assertEqual(markers[0].values_path, "csp.cloudflare.scriptNonce")
+
+    def test_a_sibling_key_closes_the_nesting(self):
+        markers = self.parse(
+            "csp:\n"
+            "  cloudflare:\n"
+            "    scriptNonce: true\n"
+            + bound("ttlSecs: 0", "@config projection isr.ttl_secs")
+        )
+        self.assertEqual(markers[0].values_path, "ttlSecs")
+
+    def test_a_marker_on_a_key_that_opens_a_map(self):
+        """`structured` binds a subtree, so the block sits above a key with no scalar on it."""
+        markers = self.parse(
+            bound("entries:", "@config structured bucket.entries", "type: object")
+            + "  first: x\n"
+        )
+        self.assertEqual((markers[0].values_path, markers[0].cls), ("entries", cb.STRUCTURED))
+
+    def test_the_schema_itself_is_untouched_by_the_parser(self):
+        """Only the marker's own line is read; the schema around it is helm-schema's business."""
+        markers = self.parse(
+            "# @schema\n"
+            "# # @config projection isr.ttl_secs\n"
+            "# type: integer\n"
+            "# minimum: 0\n"
+            "# enum: [0, 1]\n"
+            "# @schema\n"
+            "# -- Revalidation interval in seconds.\n"
+            "ttlSecs: 0\n"
+        )
+        self.assertEqual([marker.values_path for marker in markers], ["ttlSecs"])
+
+    def test_every_other_placement_is_refused_with_what_it_costs(self):
+        """Ten placements were measured on both pilots; nine of them are refused here.
+
+        Four are byte-clean and still refused, because one relationship has one spelling: the
+        block's last line, a schema line's own trailing comment, `# config:` as a schema key, and
+        a marker separated from the block by a blank line. The rest each break something — a
+        leading newline in fifteen generated descriptions, fifteen fouled README rows, a `helm
+        schema` that will not parse the block at all — and the message says which.
+        """
+        cases = {
+            # Outside the delimiters: both generators read that run as the description.
+            "own comment line above the description": (
+                "# @schema\n# type: integer\n# @schema\n"
+                "# @config projection isr.ttl_secs\n# -- Interval.\nttlSecs: 0\n",
+                "comment line of its own",
+            ),
+            "own comment line below the description": (
+                "# @schema\n# type: integer\n# @schema\n"
+                "# -- Interval.\n# @config projection isr.ttl_secs\nttlSecs: 0\n",
+                "comment line of its own",
+            ),
+            "no block at all": (
+                "# @config projection isr.ttl_secs\nttlSecs: 0\n",
+                "comment line of its own",
+            ),
+            # Inside the delimiters, but as schema content: `@` is a reserved YAML indicator.
+            "bare inside the block": (
+                "# @schema\n# @config projection isr.ttl_secs\n# type: integer\n# @schema\n"
+                "# -- Interval.\nttlSecs: 0\n",
+                "reserved indicator in YAML",
+            ),
+            # Inside the delimiters and byte-clean, but below the schema rather than above it.
+            "below the schema": (
+                "# @schema\n# type: integer\n# # @config projection isr.ttl_secs\n# @schema\n"
+                "# -- Interval.\nttlSecs: 0\n",
+                "below the schema",
+            ),
+            # Still on the value line, which is where this format started.
+            "the value's trailing comment": (
+                "# @schema\n# type: integer\n# @schema\n"
+                "# -- Interval.\nttlSecs: 0  # @config projection isr.ttl_secs\n",
+                "the value's trailing comment",
+            ),
+        }
+        for name, (values, expected) in cases.items():
+            with self.subTest(placement=name):
+                with self.assertRaisesRegex(cb.BindingError, expected):
+                    self.parse(values)
+
+    def test_a_value_may_bind_several_keys(self):
+        """`tankovault`'s `internal.tls.certDir` is the directory three contract keys are built
+        from, by three `printf`s in one template. Under the trailing-comment placement a second
+        marker could not be written at all, and that was mistaken for a rule."""
+        markers = self.parse(
+            "# @schema\n"
+            "# # @config composed internal.tls.cert\n"
+            "# # @config composed internal.tls.key\n"
+            "# # @config composed internal.tls.ca\n"
+            "# type: string\n"
+            "# @schema\n"
+            "certDir: /etc/tls\n"
+        )
+        self.assertEqual(
+            [(marker.values_path, marker.target) for marker in markers],
+            [
+                ("certDir", "internal.tls.cert"),
+                ("certDir", "internal.tls.key"),
+                ("certDir", "internal.tls.ca"),
+            ],
+        )
+        self.assertEqual([marker.line for marker in markers], [2, 3, 4])
+
+    def test_one_value_binding_one_key_twice_is_refused(self):
+        """The only duplicate that cannot be meant: one binding said twice."""
+        with self.assertRaisesRegex(cb.BindingError, "already binds"):
+            self.parse(
+                "# @schema\n"
+                "# # @config projection isr.ttl_secs\n"
+                "# # @config projection isr.ttl_secs\n"
+                "# type: integer\n"
+                "# @schema\n"
+                "ttlSecs: 0\n"
+            )
+
+    def test_a_marker_below_the_schema_is_refused(self):
+        """The run is at the top of the block, so a value's bindings are read in one place."""
+        with self.assertRaisesRegex(cb.BindingError, "below the schema"):
+            self.parse(
+                "# @schema\n"
+                "# type: integer\n"
+                "# # @config projection isr.ttl_secs\n"
+                "# @schema\n"
+                "ttlSecs: 0\n"
+            )
+
+    def test_a_marker_whose_block_never_reaches_a_value_is_refused(self):
+        """The cost of a placement attached by contiguity: every way it can miss is an error."""
+        for values, expected in (
+            (bound("ttlSecs: 0", "@config projection isr.ttl_secs").replace(
+                "# -- Description.\n", "# -- Description.\n\n"
+            ), "a blank line"),
+            ("# @schema\n# # @config projection isr.ttl_secs\n# type: integer\n# @schema\n",
+             "the end of the file"),
+            ("# @schema\n# # @config projection isr.ttl_secs\n# type: integer\n# @schema\n"
+             "# @schema\n# type: string\n# @schema\nother: x\n",
+             "a second `@schema` block"),
+        ):
+            with self.subTest(expected=expected):
+                with self.assertRaisesRegex(cb.BindingError, expected):
+                    self.parse(values)
+
+    def test_a_marker_on_a_sequence_item_is_refused(self):
+        with self.assertRaisesRegex(cb.BindingError, "sequence item"):
+            self.parse("hosts:\n  - example.com  # @config projection a.b\n")
+
+    def test_a_block_whose_value_is_a_sequence_item_is_refused(self):
+        with self.assertRaisesRegex(cb.BindingError, "a sequence item"):
+            self.parse(
+                "hosts:\n"
+                "  # @schema\n"
+                "  # # @config projection a.b\n"
+                "  # type: string\n"
+                "  # @schema\n"
+                "  - example.com\n"
+            )
+
+    def test_a_hash_inside_a_quoted_value_is_not_a_comment(self):
+        markers = self.parse(
+            'password: "a # b"\n' + bound("ttlSecs: 0", "@config projection isr.ttl_secs")
+        )
+        self.assertEqual([marker.values_path for marker in markers], ["ttlSecs"])
+
+    def test_a_value_holding_a_hash_still_takes_its_marker(self):
+        markers = self.parse(
+            bound('dsn: "https://x#y"', "@config projection telemetry.sentry_dsn")
+        )
+        self.assertEqual(markers[0].target, "telemetry.sentry_dsn")
+
+    def test_a_word_that_merely_begins_like_the_marker_is_not_one(self):
+        self.assertEqual(
+            self.parse(
+                "# @schema\n# # @configuration of sorts\n# type: integer\n# @schema\n"
+                "ttlSecs: 0\n"
+            ),
+            [],
+        )
+
+    def test_keys_inside_a_sequence_do_not_disturb_the_nesting(self):
+        markers = self.parse(
+            "ingress:\n"
+            "  hosts:\n"
+            "    - host: example.com\n"
+            "      path: /\n"
+            + bound("ttlSecs: 0", "@config projection isr.ttl_secs")
+        )
+        self.assertEqual(markers[0].values_path, "ttlSecs")
+
+    def test_a_block_scalar_body_does_not_disturb_the_nesting(self):
+        markers = self.parse(
+            "script: |\n"
+            "  key: not-a-values-path\n"
+            + bound("ttlSecs: 0", "@config projection isr.ttl_secs")
+        )
+        self.assertEqual(markers[0].values_path, "ttlSecs")
+
+    def test_a_file_with_no_marker_yields_nothing(self):
+        self.assertEqual(self.parse("# -- Just a value.\nttlSecs: 0\n"), [])
+
+    def test_every_problem_in_a_file_is_reported_at_once(self):
+        """The posture every gate in this group takes: one broken line does not hide the rest."""
+        with self.assertRaises(cb.BindingError) as raised:
+            self.parse(
+                bound("first: 1", "@config gated a.b")
+                + bound("second: 2", "@config projection")
+            )
+        self.assertIn("values.yaml:2", str(raised.exception))
+        self.assertIn("values.yaml:8", str(raised.exception))
+
+class TestUnboundDeclaration(unittest.TestCase):
+    """`config-contract.yaml` rejects unknown keys by design, so this had to be a real extension."""
+
+    def load(self, body: str):
+        with tempfile.TemporaryDirectory() as workspace:
+            chart = Path(workspace) / "fixture"
+            chart.mkdir()
+            (chart / "config-contract.yaml").write_text(body, encoding="utf-8")
+            return load_declaration(chart)
+
+    def test_an_entry_is_read(self):
+        declaration = self.load(
+            declaration_with(
+                "unbound:\n"
+                "  - keys: [discord.webhook_url]\n"
+                "    reason: Delivered as a secret file.\n"
+            )
+        )
+        [unbound] = declaration.unbound
+        self.assertEqual(unbound.keys, ("discord.webhook_url",))
+        self.assertEqual(unbound.reason, "Delivered as a secret file.")
+        self.assertIsNone(unbound.documents)
+
+    def test_one_reason_covers_several_keys(self):
+        """What `tankovault` needs: 144 keys and three sentences, not 144 sentences."""
+        declaration = self.load(
+            declaration_with(
+                "unbound:\n"
+                "  - keys: [a.one, a.two, a.three]\n"
+                "    reason: The image's own default stands.\n"
+            )
+        )
+        self.assertEqual(declaration.unbound[0].keys, ("a.one", "a.two", "a.three"))
+
+    def test_a_scope_narrows_the_write_off(self):
+        declaration = self.load(
+            declaration_with(
+                "unbound:\n"
+                "  - keys: [branding.name]\n"
+                "    documents: [api]\n"
+                "    reason: Only the frontend is sent this half of the block.\n"
+            )
+        )
+        self.assertEqual(declaration.unbound[0].documents, ("api",))
+
+    def test_a_scope_naming_no_declared_document_is_refused(self):
+        with self.assertRaisesRegex(DeclarationError, "which this chart does not declare"):
+            self.load(
+                declaration_with(
+                    "unbound:\n  - keys: [a.b]\n    documents: [worker]\n"
+                    "    reason: Because.\n"
+                )
+            )
+
+    def test_one_key_written_off_twice_is_refused(self):
+        """Two reasons for one key means one of them is not the reason."""
+        with self.assertRaisesRegex(DeclarationError, "already written off"):
+            self.load(
+                declaration_with(
+                    "unbound:\n"
+                    "  - keys: [a.b]\n    reason: One.\n"
+                    "  - keys: [a.b]\n    reason: Two.\n"
+                )
+            )
+
+    def test_an_absent_list_is_empty_rather_than_missing(self):
+        self.assertEqual(self.load(DECLARATION).unbound, [])
+
+    def test_a_reason_is_mandatory(self):
+        with self.assertRaisesRegex(DeclarationError, "no `reason`"):
+            self.load(declaration_with("unbound:\n  - keys: [discord.webhook_url]\n"))
+
+    def test_an_entry_with_no_keys_is_refused(self):
+        with self.assertRaisesRegex(DeclarationError, "`keys` is missing or empty"):
+            self.load(declaration_with("unbound:\n  - reason: Because.\n"))
+
+    def test_there_is_no_pattern_form(self):
+        """The keys are listed, so a key the next release adds cannot be pre-emptively covered."""
+        with self.assertRaisesRegex(DeclarationError, "`keys` is missing or empty"):
+            self.load(declaration_with("unbound:\n  - keys: []\n    reason: Because.\n"))
+
+    def test_an_unknown_field_is_refused(self):
+        with self.assertRaisesRegex(DeclarationError, "unknown key"):
+            self.load(
+                declaration_with(
+                    "unbound:\n  - keys: [a.b]\n"
+                    "    reason: Because.\n    gates: [env]\n"
+                )
+            )
+
+    def test_the_gate_exemption_axis_is_untouched(self):
+        """`exempt` is per fixture, per gate and per document; `unbound` is per key and per chart.
+
+        They sit at different levels of the file now, which is the clearest statement yet that
+        they are different axes: one relaxes a check for one rendered fixture, the other records
+        that no value reaches a key anywhere.
+        """
+        declaration = self.load(
+            DECLARATION.replace(
+                "documents:\n",
+                "unbound:\n  - keys: [database.url]\n"
+                "    reason: Delivered as a secret file.\ndocuments:\n",
+            )
+            + "    exempt:\n"
+            "      - values: '*'\n"
+            "        gates: [closed]\n"
+            "        reason: The chart renders a key the contract omits.\n"
+        )
+        self.assertEqual(declaration.documents[0].relaxed("ci/anything.yaml"), {"closed"})
+        self.assertEqual([entry.keys for entry in declaration.unbound], [("database.url",)])
+
+
+# --------------------------------------------------------------------------------------------
+# The gate
+# --------------------------------------------------------------------------------------------
+
+
+class GateCase(unittest.TestCase):
+    def check(self, values: str, unbound: str = "", contract: dict | None = None) -> Report:
+        with tempfile.TemporaryDirectory() as workspace:
+            builder = ChartBuilder(Path(workspace))
+            builder.contract("api", contract if contract is not None else fixture("api"))
+            builder.declaration(declaration_with(unbound))
+            builder.values(values)
+            return builder.run()
+
+    def assertPasses(self, report: Report) -> None:
+        self.assertEqual(messages(report), "")
+
+    def assertFails(self, report: Report, pattern: str) -> None:
+        self.assertRegex(messages(report), pattern)
+
+
+class TestEnrolment(GateCase):
+    def test_a_chart_that_does_not_declare_bindings_is_not_checked(self):
+        with tempfile.TemporaryDirectory() as workspace:
+            builder = ChartBuilder(Path(workspace))
+            builder.contract("api", fixture("api"))
+            builder.declaration(DECLARATION.replace("bindings: true\n", ""))
+            builder.values("# -- Nothing bound here.\nttlSecs: 0\n")
+            report = Report()
+            self.assertEqual(entry.run(Path(workspace), report), [])
+            self.assertEqual(report.findings, [])
+
+    def test_a_declared_chart_owes_every_key_of_its_contract(self):
+        self.assertFails(
+            self.check(bound("sessionTtl: 3600", "@config projection auth.session_ttl")),
+            r"declares 'database\.url' and no chart value binds it",
+        )
+
+    def test_markers_without_the_switch_are_refused(self):
+        """The half that inferring enrolment got right, kept: a marker nothing holds is worse."""
+        with tempfile.TemporaryDirectory() as workspace:
+            builder = ChartBuilder(Path(workspace))
+            builder.contract("api", fixture("api"))
+            builder.declaration(DECLARATION.replace("bindings: true\n", ""))
+            builder.values(bound("sessionTtl: 3600", "@config projection auth.session_ttl"))
+            self.assertFails(builder.run(), "does not declare `bindings: true`")
+
+    def test_the_switch_without_markers_is_refused(self):
+        """The half it got wrong. A chart that loses its markers used to leave in silence."""
+        with tempfile.TemporaryDirectory() as workspace:
+            builder = ChartBuilder(Path(workspace))
+            builder.contract("api", fixture("api"))
+            builder.declaration(DECLARATION)
+            builder.values("# -- Nothing bound here.\nttlSecs: 0\n")
+            self.assertFails(builder.run(), "carries no `@config` marker")
+
+    def test_markers_with_no_declaration_at_all_are_refused(self):
+        with tempfile.TemporaryDirectory() as workspace:
+            builder = ChartBuilder(Path(workspace))
+            builder.values(bound("sessionTtl: 3600", "@config projection auth.session_ttl"))
+            self.assertFails(builder.run(), "no config-contract.yaml")
+
+class TestRule1TargetExists(GateCase):
+    def test_a_covered_chart_passes(self):
+        self.assertPasses(self.check(COVERED))
+
+    def test_an_unknown_contract_path_fails(self):
+        self.assertFails(
+            self.check(COVERED + bound("typo: 1", "@config projection auth.session_tt1")),
+            r"contract key 'auth\.session_tt1', which no contract this chart declares carries "
+            r"\(did you mean auth\.session_ttl\?\)",
+        )
+
+    def test_an_unknown_external_variable_fails(self):
+        self.assertFails(
+            self.check(COVERED + bound("port: 1", "@config external PORTT")),
+            r"external\.env variable 'PORTT'",
+        )
+
+    def test_a_contract_key_named_as_an_external_variable_fails(self):
+        """The two namespaces are separate, and a class picks exactly one of them."""
+        self.assertFails(
+            self.check(COVERED + bound("ttl: 1", "@config external auth.session_ttl")),
+            r"external\.env variable 'auth\.session_ttl'",
+        )
+
+    def test_a_scope_naming_an_undeclared_document_fails(self):
+        self.assertFails(
+            self.check(COVERED + bound("x: 1", "@config projection worker:auth.session_ttl")),
+            "is scoped to 'worker', which this chart does not declare",
+        )
+
+
+class TestRule2ClassMatchesTheKey(GateCase):
+    def test_structured_on_a_scalar_key_fails(self):
+        values = COVERED.replace(
+            "# @config projection auth.session_ttl", "# @config structured auth.session_ttl"
+        )
+        self.assertFails(self.check(values), "the contract calls 'auth.session_ttl' a scalar")
+
+    def test_projection_on_a_structured_key_fails(self):
+        values = COVERED.replace(
+            "# @config structured github.repos", "# @config projection github.repos"
+        )
+        self.assertFails(self.check(values), "the contract calls 'github.repos' structured")
+
+
+class TestRule3TheCondition(GateCase):
+    def test_a_condition_naming_a_real_values_path_passes(self):
+        self.assertPasses(
+            self.check(
+                "metrics:\n  enabled: false\n"
+                + COVERED.replace(
+                    "# @config projection log.level",
+                    "# @config projection log.level when metrics.enabled",
+                )
+            )
+        )
+
+    def test_a_condition_naming_nothing_fails(self):
+        self.assertFails(
+            self.check(
+                COVERED.replace(
+                    "# @config projection log.level",
+                    "# @config projection log.level when metrics.enabled",
+                )
+            ),
+            "no value at that path",
+        )
+
+
+class TestRule4Uniqueness(GateCase):
+    def test_a_value_cannot_carry_two_markers_at_all(self):
+        """No gate rule covers it because `parse_values` refuses it first, two ways.
+
+        A second marker on one line is prose inside the first, which `parse_marker` refuses; a
+        second marker line in one block is refused by the parser's own rule. Under the earlier
+        placement the second case could not be written down at all, and this is the test that
+        records the difference.
+        """
+        with self.assertRaisesRegex(cb.BindingError, "unexpected"):
+            self.check(
+                COVERED + bound("both: 1", "@config projection log.level @config projection a.b")
+            )
+
+    def test_two_values_binding_one_key_fail(self):
+        self.assertFails(
+            self.check(COVERED + bound("second: info", "@config projection log.level")),
+            r"'log\.level' is bound by 2 values",
+        )
+
+    def test_two_composed_values_binding_one_key_pass(self):
+        values = COVERED.replace(
+            bound("logLevel: info", "@config projection log.level"),
+            bound("host: 0.0.0.0", "@config composed log.level")
+            + bound("port: 8080", "@config composed log.level"),
+        )
+        self.assertPasses(self.check(values))
+
+    def test_a_mixed_pair_fails(self):
+        values = COVERED.replace(
+            bound("logLevel: info", "@config projection log.level"),
+            bound("host: 0.0.0.0", "@config composed log.level")
+            + bound("port: 8080", "@config projection log.level"),
+        )
+        self.assertFails(self.check(values), "only `composed` admits several")
+
+    def test_a_lone_composed_is_legitimate(self):
+        """One value and a literal the chart supplies — `tankovault`'s `metrics.listen`.
+
+        This used to be refused, on the reasoning that a composition of one is a projection. It
+        is not: `printf "0.0.0.0:%v" .Values.metrics.port` produces a key whose text is not the
+        value's text, and there is no third thing to call it. The rule was rejecting a shape that
+        occurs, so it went; what it protected against — `composed` used to wave away the duplicate
+        rule — is unreachable, because that rule only fires when two values bind one key.
+        """
+        values = COVERED.replace(
+            "# @config projection log.level", "# @config composed log.level"
+        )
+        self.assertPasses(self.check(values))
+
+
+class TestRule5Coverage(GateCase):
+    def test_a_missing_key_fails(self):
+        self.assertFails(
+            self.check(
+                COVERED.replace(
+                    bound("repos: {}", "@config structured github.repos", "type: object"), ""
+                )
+            ),
+            r"declares 'github\.repos' and no chart value binds it",
+        )
+
+    def test_an_unbound_entry_covers_it(self):
+        self.assertPasses(
+            self.check(
+                COVERED.replace(
+                    bound("repos: {}", "@config structured github.repos", "type: object"), ""
+                ),
+                unbound="unbound:\n  - keys: [github.repos]\n    reason: Not offered.\n",
+            )
+        )
+
+    def test_a_secret_key_is_not_exempt_by_default(self):
+        """Silence is never an answer: `database.url` is `secret: true` and still owed."""
+        report = self.check(
+            COVERED.replace(bound('databaseUrl: ""', "@config projection database.url"), "")
+        )
+        self.assertFails(report, r"declares 'database\.url' and no chart value binds it")
+        self.assertFails(report, "check-config-secrets")
+
+    def test_an_unbound_entry_naming_no_contract_key_fails(self):
+        self.assertFails(
+            self.check(
+                COVERED, unbound="unbound:\n  - keys: [github.repo]\n    reason: Typo.\n"
+            ),
+            r"writes off 'github\.repo', which no contract this chart declares carries",
+        )
+
+    def test_a_key_both_bound_and_unbound_fails(self):
+        self.assertFails(
+            self.check(
+                COVERED,
+                unbound="unbound:\n  - keys: [github.repos]\n    reason: Not offered.\n",
+            ),
+            "while a marker binds it",
+        )
+
+    def test_external_variables_are_not_owed(self):
+        """`PORT` belongs to the toolchain, not to the loader; declining to surface it is fine."""
+        self.assertPasses(self.check(COVERED))
+
+    def test_an_external_marker_does_not_credit_a_contract_key(self):
+        contract = copy.deepcopy(fixture("api"))
+        contract["external"]["env"].append(
+            {
+                "name": "GITHUB_REPOS",
+                "owner": "octocrab",
+                "docs": "Unrelated.",
+                "ty": "String",
+                "values": [],
+                "constraint": {"type": "string"},
+                "text_form": "text",
+                "default": None,
+                "required": False,
+                "secret": False,
+            }
+        )
+        values = COVERED.replace(
+            bound("repos: {}", "@config structured github.repos", "type: object"),
+            bound("repos: {}", "@config external GITHUB_REPOS", "type: object"),
+        )
+        self.assertFails(
+            self.check(values, contract=contract),
+            r"declares 'github\.repos' and no chart value binds it",
+        )
+
+
+# --------------------------------------------------------------------------------------------
+# The pilots, as they are committed
+# --------------------------------------------------------------------------------------------
+
+
+class TestTheEnrolledCharts(unittest.TestCase):
+    """Every enrolled chart, read from the tree rather than rebuilt.
+
+    Between them they carry each shape the format claims to have, which is the point of asserting
+    them here rather than only over fixtures:
+
+      `portfolio`               seven pure projections, plus the three `external.env` variables
+                                the Dioxus toolchain and `tracing` own
+      `netcup-offer-bot`        an optional projection, a pair gated on `metrics.enabled`, and a
+                                credential written off rather than marked
+      `s3-bucket-perma-link`    the only `structured` binding in the tree, and two credentials
+                                delivered as files
+      `mp-stats-legacy-viewer`  the only `composed` one: `server.bind_addr` is `printf` over two
+                                values, and both say so
+
+    `tankovault` is deliberately absent — see `test_tankovault_is_not_enrolled_yet`.
+    """
+
+    charts = SCRIPTS.parents[1] / "charts"
+
+    def markers(self, chart: str) -> dict[str, cb.Marker]:
+        found = cb.parse_values(self.charts / chart / "values.yaml", chart)
+        return {marker.values_path: marker for marker in found}
+
+    def test_portfolio_binds_an_external_variable(self):
+        marker = self.markers("portfolio")["server.port"]
+        self.assertEqual((marker.cls, marker.target), (cb.EXTERNAL, "PORT"))
+
+    def test_portfolio_projects_a_nested_value(self):
+        marker = self.markers("portfolio")["csp.cloudflare.scriptNonce"]
+        self.assertEqual(marker.target, "csp.cloudflare.script_nonce")
+
+    def test_netcup_marks_the_sentry_dsn_optional(self):
+        marker = self.markers("netcup-offer-bot")["telemetry.sentryDsn"]
+        self.assertTrue(marker.optional)
+        self.assertIsNone(marker.condition)
+
+    def test_netcup_gates_the_metrics_subtree(self):
+        for path in ("metrics.ip", "metrics.port"):
+            marker = self.markers("netcup-offer-bot")[path]
+            self.assertEqual(marker.condition, "metrics.enabled")
+
+    def test_netcup_writes_off_the_webhook_rather_than_marking_it(self):
+        self.assertNotIn("discord.webhookUrl", self.markers("netcup-offer-bot"))
+        declaration = load_declaration(self.charts / "netcup-offer-bot")
+        [unbound] = declaration.unbound
+        self.assertEqual(unbound.keys, ("discord.webhook_url",))
+        self.assertTrue(unbound.reason)
+
+    def test_the_structured_binding_is_the_bucket_map(self):
+        """The operator names the keys under it, which is the whole of what `structured` says."""
+        marker = self.markers("s3-bucket-perma-link")["bucket.entries"]
+        self.assertEqual((marker.cls, marker.target), (cb.STRUCTURED, "bucket.entries"))
+
+    def test_the_s3_credentials_are_written_off_rather_than_marked(self):
+        declaration = load_declaration(self.charts / "s3-bucket-perma-link")
+        [unbound] = declaration.unbound
+        self.assertEqual(sorted(unbound.keys), ["s3.access_key", "s3.secret_key"])
+        self.assertIn("check-config-secrets", unbound.reason)
+
+    def test_the_composed_pair_is_the_bind_address(self):
+        """Two values, one key, and a `printf` between them that no marker claims to reproduce."""
+        markers = self.markers("mp-stats-legacy-viewer")
+        for path in ("server.host", "server.port"):
+            self.assertEqual(
+                (markers[path].cls, markers[path].target), (cb.COMPOSED, "server.bind_addr")
+            )
+
+    def test_every_enrolled_chart_passes_the_gate(self):
+        report = Report()
+        enrolled = entry.run(self.charts, report)
+        self.assertEqual(
+            [(chart, keys, external) for chart, keys, external in enrolled],
+            [
+                ("mp-stats-legacy-viewer", 8, 0),
+                ("netcup-offer-bot", 5, 0),
+                ("portfolio", 7, 3),
+                ("s3-bucket-perma-link", 7, 0),
+                ("tankovault", 99, 0),
+            ],
+        )
+        self.assertEqual(messages(report), "")
+
+    def test_tankovault_binds_one_value_into_every_document_that_reads_it(self):
+        """The rule that chart forced: unscoped means every document declaring the key.
+
+        `metrics.enabled` is one line of `derivedConfig` written into all eight services, and one
+        value carries one marker. 38 markers resolve to 99 bindings here, which is the arithmetic
+        of that rule and the reason the chart is enrolable at all.
+        """
+        marker = self.markers("tankovault")["metrics.enabled"]
+        self.assertIsNone(marker.documents)
+        self.assertEqual(marker.target, "metrics.enabled")
+
+    def test_tankovault_scopes_the_branding_block_by_who_reads_it(self):
+        """Three documents declare `branding.*`; each service is sent only the half it reads."""
+        markers = self.markers("tankovault")
+        self.assertEqual(markers["branding.name"].documents, ("api", "frontend"))
+        self.assertEqual(markers["branding.botUserAgent"].documents, ("worker",))
+
+    def test_tankovault_binds_three_keys_from_one_directory(self):
+        """One value, three markers — the case the earlier one-marker rule made unwriteable."""
+        found = cb.parse_values(self.charts / "tankovault" / "values.yaml", "tankovault")
+        targets = [m.target for m in found if m.values_path == "internal.tls.certDir"]
+        self.assertEqual(targets, ["internal.tls.cert", "internal.tls.key", "internal.tls.ca"])
+
+    def test_tankovault_writes_off_what_it_does_not_surface_in_families(self):
+        """144 keys, three reasons, and every key still listed by name."""
+        declaration = load_declaration(self.charts / "tankovault")
+        written_off = [key for entry in declaration.unbound for key in entry.keys]
+        self.assertEqual(len(written_off), len(set(written_off)))
+        self.assertGreater(len(written_off), 100)
+        self.assertLess(len(declaration.unbound), 10)
+        for entry in declaration.unbound:
+            self.assertTrue(entry.reason.strip())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_contract_secrets.py
+++ b/.github/scripts/tests/test_contract_secrets.py
@@ -107,7 +107,15 @@ def with_plain_text_key(name: str = "api") -> dict:
 
 
 def declaration(chart: str = "fixture") -> Declaration:
-    return Declaration(chart=chart, path=Path(chart), documents=[], reason=None, unconfigured=[])
+    return Declaration(
+        chart=chart,
+        path=Path(chart),
+        documents=[],
+        reason=None,
+        unconfigured=[],
+        bindings=False,
+        unbound=[],
+    )
 
 
 def container(name: str = "app", env: dict | None = None, mounts: list | None = None) -> dict:
@@ -401,7 +409,13 @@ class TestGateThreeReach(unittest.TestCase):
             exempt=[],
         )
         return Declaration(
-            chart="c", path=Path("c"), documents=[document], reason=None, unconfigured=[]
+            chart="c",
+            path=Path("c"),
+            documents=[document],
+            reason=None,
+            unconfigured=[],
+            bindings=False,
+            unbound=[],
         )
 
     def test_a_declared_container_is_within_reach(self):

--- a/.github/scripts/tests/test_contract_testgen.py
+++ b/.github/scripts/tests/test_contract_testgen.py
@@ -120,6 +120,8 @@ def declaration(*documents: tuple[str, str, dict[str, str]]) -> Declaration:
         ],
         reason=None,
         unconfigured=[],
+        bindings=False,
+        unbound=[],
     )
 
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -510,6 +510,12 @@ jobs:
       - name: Report configuration contract coverage
         run: just check-contract-coverage
 
+      # Key-level, where the step above is chart-level: it fails when an enrolled chart has
+      # a contract key no `# @config` marker in its values.yaml reaches. Reads two committed
+      # files per chart, so it needs neither the render above nor the jv install.
+      - name: Check configuration binding markers
+        run: just check-config-bindings
+
       - name: Contract model unit tests
         run: just test-contract-union
 

--- a/charts/mp-stats-legacy-viewer/Chart.yaml
+++ b/charts/mp-stats-legacy-viewer/Chart.yaml
@@ -1,6 +1,6 @@
 name: mp-stats-legacy-viewer
 description: MP Stats Legacy Viewer
-version: 3.2.0
+version: 3.2.1
 appVersion: v0.17.2
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts

--- a/charts/mp-stats-legacy-viewer/README.md
+++ b/charts/mp-stats-legacy-viewer/README.md
@@ -1,6 +1,6 @@
 # mp-stats-legacy-viewer
 
-![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![AppVersion: v0.17.2](https://img.shields.io/badge/AppVersion-v0.17.2-informational?style=flat-square)
+![Version: 3.2.1](https://img.shields.io/badge/Version-3.2.1-informational?style=flat-square) ![AppVersion: v0.17.2](https://img.shields.io/badge/AppVersion-v0.17.2-informational?style=flat-square)
 
 MP Stats Legacy Viewer
 

--- a/charts/mp-stats-legacy-viewer/config-contract.yaml
+++ b/charts/mp-stats-legacy-viewer/config-contract.yaml
@@ -6,6 +6,15 @@
 # principle `just chart-index` already follows. `just check-config` reads this, unions the
 # contracts of every image listed, and validates the rendered ConfigMap, the container
 # environment and the mounted secret file names against the result.
+
+# Whether `just check-config-bindings` holds this chart's values against the keys below.
+#
+# Declared rather than inferred from the chart carrying markers: a chart that loses them — a
+# botched edit, a spelling the parser does not recognise — would otherwise drop out of that gate's
+# report without a word. With the switch here, markers without it and it without markers are both
+# errors.
+bindings: true
+
 documents:
   - name: viewer
 

--- a/charts/mp-stats-legacy-viewer/values.yaml
+++ b/charts/mp-stats-legacy-viewer/values.yaml
@@ -36,6 +36,7 @@ image:
 # @schema
 server:
   # @schema
+  # # @config composed server.bind_addr
   # type: string
   # @schema
   # -- Host half of the bind address (`server.bind_addr`). `0.0.0.0` is what makes the Service
@@ -43,6 +44,7 @@ server:
   host: 0.0.0.0
 
   # @schema
+  # # @config composed server.bind_addr
   # type: integer
   # minimum: 1
   # maximum: 65535
@@ -52,6 +54,7 @@ server:
   port: 8080
 
   # @schema
+  # # @config projection server.dist_dir
   # type: string
   # @schema
   # -- Built frontend served as the SPA (`server.dist_dir`). The server refuses to start unless
@@ -60,6 +63,7 @@ server:
   distDir: /dist
 
   # @schema
+  # # @config projection server.data_dir
   # type: string
   # @schema
   # -- The converter's output, served under `/data` (`server.data_dir`). The default is where
@@ -75,6 +79,7 @@ server:
   # fails the boot before the listener binds.
   csp:
     # @schema
+    # # @config projection server.csp.enabled
     # type: boolean
     # @schema
     # -- Attach the header at all (`server.csp.enabled`). Turn it off only when something in
@@ -88,6 +93,7 @@ server:
     # each one widens the policy, and only for a product that is actually switched on.
     cloudflare:
       # @schema
+      # # @config projection server.csp.cloudflare.script_nonce
       # type: boolean
       # @schema
       # -- Reserve a per-response nonce in `script-src` and serve documents `Cache-Control:
@@ -99,6 +105,7 @@ server:
       scriptNonce: false
 
       # @schema
+      # # @config projection server.csp.cloudflare.turnstile
       # type: boolean
       # @schema
       # -- Admit `https://challenges.cloudflare.com` in `script-src` and `frame-src`
@@ -107,6 +114,7 @@ server:
       turnstile: false
 
       # @schema
+      # # @config projection server.csp.cloudflare.web_analytics
       # type: boolean
       # @schema
       # -- Admit the Web Analytics beacon and the endpoint it reports to

--- a/charts/netcup-offer-bot/Chart.yaml
+++ b/charts/netcup-offer-bot/Chart.yaml
@@ -1,6 +1,6 @@
 name: netcup-offer-bot
 description: This chart deploys the Netcup Offer Bot, which monitors https://www.netcup-sonderangebote.de/ RSS feed and sends notifications to Discord webhooks when new offers are available.
-version: 5.1.1
+version: 5.1.2
 appVersion: v2.1.1
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts

--- a/charts/netcup-offer-bot/README.md
+++ b/charts/netcup-offer-bot/README.md
@@ -1,6 +1,6 @@
 # netcup-offer-bot
 
-![Version: 5.1.1](https://img.shields.io/badge/Version-5.1.1-informational?style=flat-square) ![AppVersion: v2.1.1](https://img.shields.io/badge/AppVersion-v2.1.1-informational?style=flat-square)
+![Version: 5.1.2](https://img.shields.io/badge/Version-5.1.2-informational?style=flat-square) ![AppVersion: v2.1.1](https://img.shields.io/badge/AppVersion-v2.1.1-informational?style=flat-square)
 
 This chart deploys the Netcup Offer Bot, which monitors https://www.netcup-sonderangebote.de/ RSS feed and sends notifications to Discord webhooks when new offers are available.
 

--- a/charts/netcup-offer-bot/config-contract.yaml
+++ b/charts/netcup-offer-bot/config-contract.yaml
@@ -6,6 +6,37 @@
 # principle `just chart-index` already follows. `just check-config` reads this, unions the
 # contracts of every image listed, and validates the rendered ConfigMap, the container
 # environment and the mounted secret file names against the result.
+
+# Whether `just check-config-bindings` holds this chart's values against the keys below.
+#
+# Declared rather than inferred from the chart carrying markers: a chart that loses them — a
+# botched edit, a spelling the parser does not recognise — would otherwise drop out of that gate's
+# report without a word. With the switch here, markers without it and it without markers are both
+# errors.
+bindings: true
+
+# Contract keys no chart value binds, each group with the reason it does not.
+#
+# Chart-level: a key nothing surfaces is unsurfaced in every document that declares it, and this
+# chart declares one. `documents:` narrows an entry where that is untrue.
+#
+# Secret keys are not exempt by default, and this chart is why the rule was refused:
+# `telemetry.sentry_dsn` is `secret: true` in the same contract *and* is projected into
+# `config.toml` by `telemetry.sentryDsn`. A blanket "credentials need no marker" would have
+# written off a key this chart binds, and the gate would then stop noticing if that projection
+# were dropped. Each key is written out.
+unbound:
+  - keys:
+      - discord.webhook_url
+    reason: >-
+      Delivered as a file in the secrets directory — from the Secret this chart renders, or
+      from `existingSecret` under the file name `discord__webhook_url` — and never written
+      into `config.toml`, because a bearer credential in a ConfigMap is readable by anything
+      that can read the namespace. `discord.webhookUrl` is the value that carries it, so the
+      binding does exist; it simply does not run through the configuration document the
+      markers describe. `just check-config-secrets` is what reconciles that channel, and it
+      does it from the rendered manifests rather than from a comment.
+
 documents:
   - name: bot
 

--- a/charts/netcup-offer-bot/values.yaml
+++ b/charts/netcup-offer-bot/values.yaml
@@ -53,6 +53,7 @@ discord:
 # @schema
 feed:
   # @schema
+  # # @config projection feed.check_interval_secs
   # type: integer
   # minimum: 1
   # @schema
@@ -64,12 +65,14 @@ feed:
 # @schema
 telemetry:
   # @schema
+  # # @config projection telemetry.log_level
   # enum: [TRACE, DEBUG, INFO, WARN, ERROR]
   # @schema
   # -- Log level (`telemetry.log_level`).
   logLevel: INFO
 
   # @schema
+  # # @config projection telemetry.sentry_dsn optional
   # type: string
   # @schema
   # -- Sentry DSN (`telemetry.sentry_dsn`). Empty disables Sentry entirely.
@@ -268,6 +271,7 @@ metrics:
   enabled: false
 
   # @schema
+  # # @config projection metrics.ip when metrics.enabled
   # type: string
   # @schema
   # -- Address the Prometheus exporter binds (`metrics.ip`). The bot's own default is
@@ -276,6 +280,7 @@ metrics:
   ip: 0.0.0.0
 
   # @schema
+  # # @config projection metrics.port when metrics.enabled
   # type: integer
   # minimum: 1
   # maximum: 65535

--- a/charts/portfolio/Chart.yaml
+++ b/charts/portfolio/Chart.yaml
@@ -1,6 +1,6 @@
 name: portfolio
 description: Personal portfolio built with Rust (Yew frontend, Axum server).
-version: 5.1.2
+version: 5.1.3
 appVersion: v2.6.0
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts

--- a/charts/portfolio/README.md
+++ b/charts/portfolio/README.md
@@ -1,6 +1,6 @@
 # portfolio
 
-![Version: 5.1.2](https://img.shields.io/badge/Version-5.1.2-informational?style=flat-square) ![AppVersion: v2.6.0](https://img.shields.io/badge/AppVersion-v2.6.0-informational?style=flat-square)
+![Version: 5.1.3](https://img.shields.io/badge/Version-5.1.3-informational?style=flat-square) ![AppVersion: v2.6.0](https://img.shields.io/badge/AppVersion-v2.6.0-informational?style=flat-square)
 
 Personal portfolio built with Rust (Yew frontend, Axum server).
 

--- a/charts/portfolio/config-contract.yaml
+++ b/charts/portfolio/config-contract.yaml
@@ -8,6 +8,24 @@
 # environment and the mounted secret file names against the result. A chart with no such file is
 # skipped; `documents: []` plus a `reason` is the only permitted opt-out, and
 # `just check-contract-coverage` is what stops it from being escaped by forgetting.
+
+# Whether `just check-config-bindings` holds this chart's values against the keys below.
+#
+# Declared rather than inferred from the chart carrying markers: a chart that loses them — a
+# botched edit, a spelling the parser does not recognise — would otherwise drop out of that gate's
+# report without a word. With the switch here, markers without it and it without markers are both
+# errors.
+bindings: true
+
+# Contract keys no chart value binds, each group with the reason it does not.
+#
+# None: all seven keys are bound, which is what makes this chart the simplest enrolment in the
+# tree. `server.host`, `server.port` and `logLevel` carry markers too, and are not the reason this
+# list is empty — they bind `IP`, `PORT` and `RUST_LOG`, which are `external.env` variables owned
+# by the Dioxus toolchain and by `tracing`. The coverage rule is over `schema.keys` alone, so that
+# namespace neither needs an entry here nor could be satisfied by one.
+unbound: []
+
 documents:
   - name: server
 

--- a/charts/portfolio/values.yaml
+++ b/charts/portfolio/values.yaml
@@ -71,12 +71,14 @@ terminationGracePeriodSeconds: 30
 # supplied through `config`.
 server:
   # @schema
+  # # @config external IP
   # type: string
   # @schema
   # -- Bind address, passed as `IP`.
   host: 0.0.0.0
 
   # @schema
+  # # @config external PORT
   # type: integer
   # minimum: 1
   # maximum: 65535
@@ -86,6 +88,7 @@ server:
   port: 8080
 
 # @schema
+# # @config external RUST_LOG
 # type: string
 # @schema
 # -- Log verbosity, passed as `RUST_LOG`. Accepts standard tracing directives (`info`, `debug`,
@@ -97,6 +100,7 @@ logLevel: info
 # @schema
 assets:
   # @schema
+  # # @config projection assets.dist_dir
   # type: string
   # @schema
   # -- Directory holding the bundled assets (`assets.dist_dir`), relative to the working
@@ -113,6 +117,7 @@ assets:
 # make room for.
 csp:
   # @schema
+  # # @config projection csp.hash_inline_scripts
   # type: boolean
   # @schema
   # -- Hash the document's inline scripts (`csp.hash_inline_scripts`) instead of admitting all
@@ -129,6 +134,7 @@ csp:
   # the policy, so each is switched on only for a product that is actually in use.
   cloudflare:
     # @schema
+    # # @config projection csp.cloudflare.script_nonce
     # type: boolean
     # @schema
     # -- Reserve a per-response nonce in `script-src` (`csp.cloudflare.script_nonce`) for the
@@ -141,6 +147,7 @@ csp:
     scriptNonce: true
 
     # @schema
+    # # @config projection csp.cloudflare.turnstile
     # type: boolean
     # @schema
     # -- Admit `https://challenges.cloudflare.com` in `script-src` *and* `frame-src`
@@ -149,6 +156,7 @@ csp:
     turnstile: false
 
     # @schema
+    # # @config projection csp.cloudflare.web_analytics
     # type: boolean
     # @schema
     # -- Admit the Cloudflare Web Analytics beacon and the endpoint it reports to
@@ -163,6 +171,7 @@ csp:
 # instead of re-rendering.
 isr:
   # @schema
+  # # @config projection isr.cache_dir
   # type: string
   # @schema
   # -- Writable directory rendered HTML is cached into (`isr.cache_dir`). Empty disables ISR and
@@ -173,6 +182,7 @@ isr:
   cacheDir: /tmp/isr
 
   # @schema
+  # # @config projection isr.ttl_secs
   # type: integer
   # minimum: 0
   # @schema

--- a/charts/s3-bucket-perma-link/Chart.yaml
+++ b/charts/s3-bucket-perma-link/Chart.yaml
@@ -1,6 +1,6 @@
 name: s3-bucket-perma-link
 description: This chart deploys a simple web server that provides permanent links to specific S3 bucket resources. It allows you to define static URL paths that always point to specific files in your S3 buckets.
-version: 4.1.1
+version: 4.1.2
 appVersion: v1.1.1
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts

--- a/charts/s3-bucket-perma-link/README.md
+++ b/charts/s3-bucket-perma-link/README.md
@@ -1,6 +1,6 @@
 # s3-bucket-perma-link
 
-![Version: 4.1.1](https://img.shields.io/badge/Version-4.1.1-informational?style=flat-square) ![AppVersion: v1.1.1](https://img.shields.io/badge/AppVersion-v1.1.1-informational?style=flat-square)
+![Version: 4.1.2](https://img.shields.io/badge/Version-4.1.2-informational?style=flat-square) ![AppVersion: v1.1.1](https://img.shields.io/badge/AppVersion-v1.1.1-informational?style=flat-square)
 
 This chart deploys a simple web server that provides permanent links to specific S3 bucket resources. It allows you to define static URL paths that always point to specific files in your S3 buckets.
 

--- a/charts/s3-bucket-perma-link/config-contract.yaml
+++ b/charts/s3-bucket-perma-link/config-contract.yaml
@@ -6,6 +6,31 @@
 # principle `just chart-index` already follows. `just check-config` reads this, unions the
 # contracts of every image listed, and validates the rendered ConfigMap, the container
 # environment and the mounted secret file names against the result.
+
+# Whether `just check-config-bindings` holds this chart's values against the keys below.
+#
+# Declared rather than inferred from the chart carrying markers: a chart that loses them — a
+# botched edit, a spelling the parser does not recognise — would otherwise drop out of that gate's
+# report without a word. With the switch here, markers without it and it without markers are both
+# errors.
+bindings: true
+
+# Contract keys no chart value binds, each group with the reason it does not.
+#
+# Chart-level: a key nothing surfaces is unsurfaced in every document that declares it, and this
+# chart declares one. `documents:` narrows an entry where that is untrue.
+unbound:
+  - keys:
+      - s3.access_key
+      - s3.secret_key
+    reason: >-
+      Delivered as files in S3_PERMA_LINK_SECRETS_DIR, from `s3.accessKey` and `s3.secretKey`,
+      and never written into `config.toml` — a long-lived object-store credential in a
+      ConfigMap is readable by anything that can read the namespace. Both bindings exist; they
+      run through the Secret rather than through the configuration document the markers
+      describe, and `just check-config-secrets` reconciles that channel from the rendered
+      manifests rather than from a comment.
+
 documents:
   - name: server
 

--- a/charts/s3-bucket-perma-link/values.yaml
+++ b/charts/s3-bucket-perma-link/values.yaml
@@ -36,12 +36,14 @@ image:
 # @schema
 server:
   # @schema
+  # # @config projection server.host
   # type: string
   # @schema
   # -- Bind address (`server.host`). `0.0.0.0` is what makes the Service reach the listener.
   host: 0.0.0.0
 
   # @schema
+  # # @config projection server.port
   # type: integer
   # minimum: 1
   # maximum: 65535
@@ -55,6 +57,7 @@ server:
 # @schema
 s3:
   # @schema
+  # # @config projection s3.host
   # type: string
   # @schema
   # -- S3-compatible API endpoint (`s3.host`), e.g. `s3.eu-central-1.amazonaws.com` or
@@ -62,6 +65,7 @@ s3:
   host: "s3.amazon.com"
 
   # @schema
+  # # @config projection s3.region
   # type: string
   # @schema
   # -- Region identifier used when signing requests (`s3.region`).
@@ -85,6 +89,7 @@ s3:
 # @schema
 bucket:
   # @schema
+  # # @config structured bucket.entries
   # type: object
   # additionalProperties:
   #   type: object
@@ -110,12 +115,14 @@ bucket:
 # @schema
 telemetry:
   # @schema
+  # # @config projection telemetry.log_level
   # enum: [trace, debug, info, warn, error]
   # @schema
   # -- Log level (`telemetry.log_level`).
   logLevel: info
 
   # @schema
+  # # @config projection telemetry.sentry_dsn optional
   # type: string
   # @schema
   # -- Sentry DSN (`telemetry.sentry_dsn`). Empty disables Sentry entirely.

--- a/charts/tankovault/Chart.yaml
+++ b/charts/tankovault/Chart.yaml
@@ -1,6 +1,6 @@
 name: tankovault
 description: This chart deploys the full TankoVault manga aggregator stack — frontend, api, control-plane, worker, notifier, sync, challenge-solver and render — hardened to the restricted Pod Security Standard, with file-backed configuration that reloads in place instead of restarting pods, optional bundled PostgreSQL, Valkey, NATS JetStream and TRAWL, and optional Prometheus metrics, alerting rules and Grafana dashboards.
-version: 5.2.2
+version: 5.2.3
 appVersion: 8.2.0
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts

--- a/charts/tankovault/README.md
+++ b/charts/tankovault/README.md
@@ -1,6 +1,6 @@
 # tankovault
 
-![Version: 5.2.2](https://img.shields.io/badge/Version-5.2.2-informational?style=flat-square) ![AppVersion: 8.2.0](https://img.shields.io/badge/AppVersion-8.2.0-informational?style=flat-square)
+![Version: 5.2.3](https://img.shields.io/badge/Version-5.2.3-informational?style=flat-square) ![AppVersion: 8.2.0](https://img.shields.io/badge/AppVersion-8.2.0-informational?style=flat-square)
 
 This chart deploys the full TankoVault manga aggregator stack — frontend, api, control-plane, worker, notifier, sync, challenge-solver and render — hardened to the restricted Pod Security Standard, with file-backed configuration that reloads in place instead of restarting pods, optional bundled PostgreSQL, Valkey, NATS JetStream and TRAWL, and optional Prometheus metrics, alerting rules and Grafana dashboards.
 

--- a/charts/tankovault/config-contract.yaml
+++ b/charts/tankovault/config-contract.yaml
@@ -16,6 +16,228 @@
 #
 # A selector matching zero or several objects is reported rather than resolved, so a component
 # that is renamed or dropped fails loudly instead of becoming a skipped check.
+
+# Whether `just check-config-bindings` holds this chart's values against the keys below.
+#
+# Declared rather than inferred from the chart carrying markers: a chart that loses them — a
+# botched edit, a spelling the parser does not recognise — would otherwise drop out of that gate's
+# report without a word. With the switch here, markers without it and it without markers are both
+# errors.
+bindings: true
+
+# Contract keys no chart value binds, each group with the reason it does not.
+#
+# Chart-level, and grouped: nine documents declare 167 key paths between them, and one entry per
+# key per document would be 345 of them repeating four sentences. The keys are still written out
+# one by one — there is no pattern form — so a key the next release adds turns
+# `just check-config-bindings` red until someone decides which group it belongs in.
+#
+# Four groups, and the difference between them is what a reader needs: eleven keys the chart
+# derives from the topology it just built, fifteen delivered as files in the secrets directory,
+# the `branding.*` keys that *are* surfaced but are deliberately not sent to every service that
+# declares them, and the rest — settings the image reads and this chart offers no value for.
+#
+# `documents:` appears on the third group only, which is the shape it exists for.
+unbound:
+  - keys:
+      - bind_addr
+      - control_plane_url
+      - frontend.api_upstream
+      - internal.caller.name
+      - internal.peers
+      - internal.tls.probe_listen
+      - rate_limit.backend
+      - sync_url
+      - telemetry.service_name
+      - worker.challenge_solver_endpoint
+      - worker_url
+    reason: >-
+      Written by the chart from the topology it has just built rather than from any value an operator
+      sets — a Service address, a port fixed in `tankovault.serviceSpecs`, a slug, or the peer list
+      of the service being rendered. There is no chart value to put a marker on, and inventing one
+      would make the release's own shape configurable for no reason. `just check-config` validates
+      whatever these render to.
+
+  - keys:
+      - anilist.client_id
+      - anilist.client_secret
+      - anilist.token_encryption_key
+      - auth.jwt_secret
+      - auth.mfa_encryption_key
+      - auth.password_pepper
+      - channels.discord_webhook_url
+      - channels.webhook_url
+      - database.url
+      - email.password
+      - email.url
+      - email.username
+      - internal.caller.token
+      - internal.token
+      - seed_admin_password
+    reason: >-
+      Delivered as a file in TANKOVAULT_SECRETS_DIR — from the Secret this chart renders, or from
+      `existingSecret` — and never written into a ConfigMap, because a credential there is readable
+      by anything that can read the namespace. Chart values do carry these; the binding runs through
+      the Secret rather than through the configuration document a marker describes, and `just
+      check-config-secrets` reconciles that channel from the rendered manifests rather than from a
+      comment.
+
+  - keys:
+      - branding.bot_user_agent
+    documents: [api, frontend]
+    reason: >-
+      Surfaced by a chart value, and deliberately not written into these documents. Every service
+      that declares the block is sent only the half it reads: `api` serves the reader-facing identity
+      and stamps it into mail and the WebAuthn prompt, `frontend` rewrites the app shell's title and
+      description from the name and tagline alone, and `worker` reads the crawler user-agent and
+      nothing else. Emitting the whole block to all three would give each of them keys it never
+      opens. The marker on the value names the documents that do receive it.
+
+  - keys:
+      - branding.copyright.holder
+      - branding.copyright.notice
+      - branding.copyright.year
+      - branding.licence.name
+      - branding.licence.url
+      - branding.project_url
+      - branding.releases_url
+      - branding.wordmark.accent
+      - branding.wordmark.lead
+    documents: [frontend, worker]
+    reason: >-
+      Surfaced by a chart value, and deliberately not written into these documents. Every service
+      that declares the block is sent only the half it reads: `api` serves the reader-facing identity
+      and stamps it into mail and the WebAuthn prompt, `frontend` rewrites the app shell's title and
+      description from the name and tagline alone, and `worker` reads the crawler user-agent and
+      nothing else. Emitting the whole block to all three would give each of them keys it never
+      opens. The marker on the value names the documents that do receive it.
+
+  - keys:
+      - branding.name
+      - branding.tagline
+    documents: [worker]
+    reason: >-
+      Surfaced by a chart value, and deliberately not written into these documents. Every service
+      that declares the block is sent only the half it reads: `api` serves the reader-facing identity
+      and stamps it into mail and the WebAuthn prompt, `frontend` rewrites the app shell's title and
+      description from the name and tagline alone, and `worker` reads the crawler user-agent and
+      nothing else. Emitting the whole block to all three would give each of them keys it never
+      opens. The marker on the value names the documents that do receive it.
+
+  - keys:
+      - anilist.default_conflict_policy
+      - anilist.graphql_url
+      - anilist.min_request_interval_ms
+      - anilist.oauth_base
+      - audit.enabled
+      - audit.record_ip
+      - audit.record_user_agent
+      - audit.retention_days
+      - audit.sweep_interval_hours
+      - auth.access_ttl_minutes
+      - auth.cookie_secure
+      - auth.mfa_challenge_ttl_minutes
+      - auth.refresh_ttl_days
+      - auth.step_up_max_ttl_minutes
+      - auth.step_up_ttl_minutes
+      - auth.totp_issuer
+      - auth.webauthn_rp_id
+      - auth.webauthn_rp_name
+      - channels.timeout_secs
+      - chapter_outliers.enabled
+      - chapter_outliers.gap_factor
+      - chapter_outliers.max_rejected_fraction
+      - chapter_outliers.min_body
+      - chapter_outliers.min_gap
+      - chapter_outliers.min_sample
+      - chapter_outliers.sparse_factor
+      - client.max_version
+      - client.min_version
+      - client.release_repo
+      - database.acquire_timeout_secs
+      - database.max_connections
+      - email.envelope_from
+      - email.timeout_secs
+      - features.refresh_secs
+      - frontend.connect_timeout_secs
+      - frontend.max_body_bytes
+      - frontend.notices_path
+      - frontend.static_dir
+      - matching.auto_merge
+      - matching.block_auto_merge_on_author_conflict
+      - matching.block_auto_merge_on_numeric_conflict
+      - matching.block_auto_merge_on_type_conflict
+      - matching.block_auto_merge_on_year_conflict
+      - matching.candidate_limit
+      - matching.high
+      - matching.low
+      - metadata.enrich_batch
+      - metadata.enrich_enabled
+      - metadata.enrich_interval_secs
+      - metadata.enrich_max_series
+      - metadata.priority
+      - metadata.tags.adult_tags
+      - metadata.tags.blocklist
+      - metadata.tags.use_defaults
+      - metrics.http_requests
+      - metrics.route
+      - rate_limit.auth.burst
+      - rate_limit.auth.per_minute
+      - rate_limit.enabled
+      - rate_limit.expensive.burst
+      - rate_limit.expensive.per_minute
+      - rate_limit.global.burst
+      - rate_limit.global.per_minute
+      - rate_limit.trust_forwarded_for
+      - reconcile_interval_secs
+      - render.challenge_wait_ms
+      - render.chrome_path
+      - render.default_wait_ms
+      - render.headless
+      - render.nav_timeout_ms
+      - render.no_sandbox
+      - render.session_ttl_secs
+      - render.user_agent
+      - scheduler.failure_backoff_max_secs
+      - scheduler.fast_interval_secs
+      - scheduler.full_interval_secs
+      - scheduler.merge_sweep_interval_secs
+      - scheduler.merge_sweep_max_auto_merges
+      - scheduler.merge_sweep_pairs
+      - scheduler.merge_sweep_recheck
+      - scheduler.merge_sweep_requeue
+      - scheduler.merge_sweep_rotation_interval_secs
+      - scheduler.reconcile_interval_secs
+      - scheduler.recsys_batch
+      - scheduler.recsys_full_interval_secs
+      - scheduler.recsys_incremental_interval_secs
+      - scheduler.recsys_incremental_max
+      - scheduler.run_stale_after_secs
+      - security.cors.allow_credentials
+      - security.cors.allowed_origins
+      - security.cors.max_age_secs
+      - security.expose_api_docs
+      - security.hsts
+      - security.hsts_max_age_secs
+      - security.max_body_bytes
+      - security.request_timeout_secs
+      - security.security_headers
+      - security.trust_request_id
+      - solver.backend
+      - solver.max_timeout_ms
+      - solver.session_ttl_secs
+      - telemetry.json_logs
+      - telemetry.log_filter
+      - worker.max_catalog_pages
+      - worker.max_concurrent_providers
+      - worker.provider_refresh_secs
+    reason: >-
+      Read by the image and not surfaced as a chart value: the application's own default stands, and
+      an operator who needs to move one writes it into the raw `config` tree or
+      `services.<name>.config`, which `just check-config` then validates against this same contract.
+      Listed key by key rather than written off as a family, so that a key the next release adds
+      turns this gate red until somebody decides which of the three it is.
+
 documents:
   - name: frontend
 

--- a/charts/tankovault/values.yaml
+++ b/charts/tankovault/values.yaml
@@ -123,6 +123,7 @@ auth:
 # indistinguishable.
 internal:
   # @schema
+  # # @config projection internal.identity
   # enum: [mtls, token]
   # @schema
   # -- Identification mode. `mtls` identifies a caller by the DNS SAN on its verified client
@@ -286,6 +287,7 @@ internal:
       name: tankovault-ca
 
       # @schema
+      # # @config composed internal.tls.ca
       # type: string
       # @schema
       # -- Key holding the PEM bundle, in whichever object `source` selects.
@@ -327,6 +329,9 @@ internal:
         namespaceSelector: {}
 
     # @schema
+    # # @config composed internal.tls.cert
+    # # @config composed internal.tls.key
+    # # @config composed internal.tls.ca
     # type: string
     # @schema
     # -- Directory the keypair is mounted at, as `tls.crt` and `tls.key`. With
@@ -334,6 +339,7 @@ internal:
     certDir: /etc/tankovault/tls
 
     # @schema
+    # # @config composed internal.tls.ca
     # type: string
     # @schema
     # -- Directory the CA bundle is mounted at, when it comes from an object of its own. Kept
@@ -418,6 +424,7 @@ anilist:
   tokenEncryptionKey: ""
 
   # @schema
+  # # @config projection sync:anilist.redirect_uri optional
   # type: string
   # @schema
   # -- OAuth redirect URI. Left empty it is derived from the ingress as
@@ -434,12 +441,14 @@ anilist:
 # configuration falls back to a no-op mailer that logs and drops.
 email:
   # @schema
+  # # @config projection email.host optional
   # type: string
   # @schema
   # -- SMTP host. Empty disables outbound email entirely.
   host: ""
 
   # @schema
+  # # @config projection email.port
   # type: integer
   # minimum: 1
   # maximum: 65535
@@ -448,6 +457,7 @@ email:
   port: 587
 
   # @schema
+  # # @config projection email.security
   # enum: [starttls, tls, none]
   # @schema
   # -- Transport security for the relay connection.
@@ -466,12 +476,14 @@ email:
   password: ""
 
   # @schema
+  # # @config projection email.from optional
   # type: string
   # @schema
   # -- `From` header, e.g. `TankoVault <no-reply@example.com>`. Required for any mail to be sent.
   from: ""
 
   # @schema
+  # # @config projection email.base_url optional
   # type: string
   # @schema
   # -- Public base URL used to build links in outgoing mail. Left empty it is derived from the
@@ -484,6 +496,7 @@ email:
 # -- Notification fan-out targets read by the `notifier` service.
 channels:
   # @schema
+  # # @config structured notifier:channels.email_to optional
   # type: array
   # items:
   #   type: string
@@ -2103,12 +2116,14 @@ bootstrap:
     enabled: false
 
     # @schema
+    # # @config projection bootstrap:seed_admin_username optional
     # type: string
     # @schema
     # -- Administrator username.
     username: admin
 
     # @schema
+    # # @config projection bootstrap:seed_admin_email optional
     # type: string
     # @schema
     # -- Administrator email address.
@@ -2355,6 +2370,7 @@ valkey:
 # `valkey.enabled` is false.
 externalRedis:
   # @schema
+  # # @config composed redis.url
   # type: string
   # @schema
   # -- Connection URL, e.g. `redis://host:6379`. Empty leaves Redis unconfigured, which is
@@ -2476,6 +2492,7 @@ nats:
 # -- Point TankoVault at a NATS you already run. Used whenever `nats.enabled` is false.
 externalNats:
   # @schema
+  # # @config composed nats.url
   # type: string
   # @schema
   # -- Connection URL, e.g. `nats://host:4222`. Required by control-plane, worker and notifier;
@@ -2587,6 +2604,7 @@ trawl:
 # -- Point the challenge solver at a TRAWL you already run.
 externalTrawl:
   # @schema
+  # # @config composed challenge-solver:solver.trawl_endpoint
   # type: string
   # @schema
   # -- Endpoint URL, e.g. `http://trawl:8191`.
@@ -2618,6 +2636,7 @@ ingress:
   host: ""
 
   # @schema
+  # # @config composed api:auth.webauthn_origin
   # type: string
   # @schema
   # -- Override the derived external URL used for `anilist.redirect_uri`, `email.base_url` and
@@ -2735,6 +2754,7 @@ gateway:
   host: ""
 
   # @schema
+  # # @config composed api:auth.webauthn_origin
   # type: string
   # @schema
   # -- Override the derived external URL used for `anilist.redirect_uri`, `email.base_url` and
@@ -2928,6 +2948,7 @@ gateway:
 # cover them. These are the only two things `'self'` can never reach.
 cloudflare:
   # @schema
+  # # @config projection frontend:frontend.cloudflare.script_nonce optional
   # type: boolean
   # @schema
   # -- Send a freshly minted `'nonce-…'` in `script-src` on every response. Set this when the zone
@@ -2945,6 +2966,7 @@ cloudflare:
   scriptNonce: false
 
   # @schema
+  # # @config projection frontend:frontend.cloudflare.turnstile optional
   # type: boolean
   # @schema
   # -- Admit `https://challenges.cloudflare.com` in `script-src` and `frame-src`, for a Turnstile
@@ -2973,6 +2995,7 @@ cloudflare:
 # TankoVault; a normal install fills in none of it.
 branding:
   # @schema
+  # # @config projection api,frontend:branding.name optional
   # type: string
   # @schema
   # -- The product name, in prose. Substituted for `{brand}` in every translated message that names
@@ -2990,6 +3013,7 @@ branding:
   # -- The two-tone lockup drawn in the SPA's rail and footer.
   wordmark:
     # @schema
+    # # @config projection api:branding.wordmark.lead optional
     # type: string
     # @schema
     # -- The half drawn in the body colour. Setting this is what opts into a two-tone lockup:
@@ -2999,6 +3023,7 @@ branding:
     lead: ""
 
     # @schema
+    # # @config projection api:branding.wordmark.accent optional
     # type: string
     # @schema
     # -- The half drawn in the accent colour. Empty draws `lead` alone. Meaningless without
@@ -3006,6 +3031,7 @@ branding:
     accent: ""
 
   # @schema
+  # # @config projection api,frontend:branding.tagline optional
   # type: string
   # @schema
   # -- One line under the wordmark. Empty keeps the shipped tagline, which is **translated**;
@@ -3019,6 +3045,7 @@ branding:
   # -- The footer's copyright line.
   copyright:
     # @schema
+    # # @config projection api:branding.copyright.holder optional
     # type: string
     # @schema
     # -- Who holds it. Empty keeps `Tim Schönle`, which is upstream's — set it on any deployment
@@ -3026,6 +3053,7 @@ branding:
     holder: ""
 
     # @schema
+    # # @config projection api:branding.copyright.year optional
     # type: string
     # @schema
     # -- A year or a range (`2024–2026`). Empty resolves per response to the current year, so a
@@ -3034,6 +3062,7 @@ branding:
     year: ""
 
     # @schema
+    # # @config projection api:branding.copyright.notice optional
     # type: string
     # @schema
     # -- The whole notice, verbatim, for when `© {year} {holder}` does not fit. Wins over `holder`
@@ -3049,12 +3078,14 @@ branding:
   # code, which is governed by the licence the source ships under.
   licence:
     # @schema
+    # # @config projection api:branding.licence.name optional
     # type: string
     # @schema
     # -- What the footer prints. Empty keeps `PolyForm Noncommercial 1.0.0`.
     name: ""
 
     # @schema
+    # # @config projection api:branding.licence.url optional
     # type: string
     # @schema
     # -- Absolute `http(s)` URL the label links to. Empty renders it as plain text, which is what
@@ -3062,6 +3093,7 @@ branding:
     url: ""
 
   # @schema
+  # # @config projection api:branding.project_url optional
   # type: string
   # @schema
   # -- Absolute `http(s)` URL for the footer's source link and the desktop client's About tab.
@@ -3069,6 +3101,7 @@ branding:
   projectUrl: ""
 
   # @schema
+  # # @config projection api:branding.releases_url optional
   # type: string
   # @schema
   # -- Absolute `http(s)` URL where a reader downloads the native client. Advertised by the web
@@ -3076,6 +3109,7 @@ branding:
   releasesUrl: ""
 
   # @schema
+  # # @config projection worker:branding.bot_user_agent optional
   # type: string
   # @schema
   # -- The identifiable crawler user-agent the `worker` sends, applied to any provider still
@@ -3096,6 +3130,7 @@ branding:
 # links that 404.
 legal:
   # @schema
+  # # @config projection api:legal.dir optional
   # type: string
   # @schema
   # -- Directory relative `sources` paths resolve against, and where the chart mounts any
@@ -3103,6 +3138,7 @@ legal:
   dir: /etc/tankovault/legal
 
   # @schema
+  # # @config structured api:legal.documents optional
   # type: object
   # additionalProperties: true
   # @schema
@@ -3154,12 +3190,14 @@ legal:
 # request-facing listener and outside its own HTTP metrics middleware.
 metrics:
   # @schema
+  # # @config projection metrics.enabled
   # type: boolean
   # @schema
   # -- Expose the metrics port on each Service.
   enabled: true
 
   # @schema
+  # # @config composed metrics.listen
   # type: integer
   # minimum: 1
   # maximum: 65535

--- a/just/contracts.just
+++ b/just/contracts.just
@@ -133,6 +133,67 @@ check-contract-coverage:
     {{ resolve_python }}
     "$python" {{ scripts }}/check-config.py --coverage-only --charts {{ charts }}
 
+# Hold every configuration binding marker in a chart's values.yaml against the key it names.
+#
+# `check-contract-coverage` above is chart-level: it answers whether a chart has a contract, and
+# its `unconfigured` escape hatch lists *images*. So the failure this repository actually keeps
+# hitting is invisible to it — an image release adds a setting, the automated bump repins the
+# digest and omits everything else, and nothing notices that the new key is reached by no chart
+# value. `check-config` cannot see it either: a key nothing renders is not a key rendered wrongly.
+#
+# A `# @config` marker in values.yaml is the missing fact — one line inside the value's `@schema`
+# block, naming the contract key that value feeds and how it gets there:
+#
+#     # @schema
+#     # # @config projection telemetry.sentry_dsn optional
+#     # type: string
+#     # @schema
+#     # -- Sentry DSN (`telemetry.sentry_dsn`). Empty disables Sentry entirely.
+#     sentryDsn: ""
+#
+# It reads as a comment inside a comment because that is exactly what it is: inside the `@schema`
+# delimiters the text is the schema, parsed as YAML, so a YAML comment there is discarded by the
+# only parser that reads it. That is the one position in the file both generators ignore, and it
+# was found by measuring ten of them — see `config_bindings.py`.
+#
+# This recipe is the gate over them. The grammar, the five rules, the placement constraint the
+# two generated artefacts impose and every deliberate omission are in `config_bindings.py`'s and
+# `check-config-bindings.py`'s docstrings, which is where they belong rather than repeated here.
+#
+# **Nothing writes a marker.** They are hand-written, and a generator would have had to land in
+# the same change as the format it depends on, which is the one shape a reviewer cannot check.
+#
+# Enrolment is opt-in and declared, by `bindings: true` in `config-contract.yaml`, so a gate that
+# failed unenrolled charts is not red for work nobody has scheduled — and does not end up
+# disabled, which is worse than absent. Declared rather than inferred from the markers themselves
+# because a chart that loses them would otherwise leave the report in silence, which is drift of
+# exactly the kind this gate exists to see.
+#
+# All five charts that map values onto a contract are enrolled, `tankovault` included. That chart
+# is where four of this format's rules come from — an unscoped marker binding every document that
+# declares the key, several markers on one value, a chart-level `unbound` taking a list of keys,
+# and a lone `composed` being legitimate — because its nine documents falsified the first draft of
+# each. `check-config-bindings.py` records which measurement forced which.
+#
+# **In `just check`, unlike most of this group.** The recipes kept out of the aggregate are kept
+# out for one of two reasons: they need a network (`contracts`), or they print rather than assert
+# (`explain`, `contract-diff`, `check-config-secrets`). This one asserts, reads two committed
+# files per chart, needs neither render nor cluster nor network, and cannot go red for a chart
+# nobody enrolled. It also fails exactly where it is wanted: on the Renovate pull request that
+# repinned the digest, in the same run that shows the reviewer the contract diff.
+#
+# Deliberately without the staleness interlock the gates above apply, for the reason
+# `config-secrets` is: this compares values.yaml against the committed contract, whether that copy
+# is current is `just check-contracts`' question, and refusing to run during a bump would withdraw
+# the report from the one pull request it exists for.
+[doc("Hold every `# @config` binding marker against the contract key it names")]
+[group('contracts')]
+check-config-bindings:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    {{ resolve_python }}
+    "$python" {{ scripts }}/check-config-bindings.py --charts {{ charts }}
+
 # Unit tests for the contract model, over fixtures rather than over a registry.
 #
 # The union is tested here and nowhere else: every document in the repository binds a single image,

--- a/justfile
+++ b/justfile
@@ -165,7 +165,7 @@ default:
 # Documentation job ever adopts `just contract-tests`, this belongs back out beside the other two.
 [doc("Every gate CI runs that does not need a Kubernetes cluster")]
 [group('meta')]
-check: deps test validate-manifests check-immutable check-config check-contract-coverage check-contract-tests test-contract-union lint lint-policy
+check: deps test validate-manifests check-immutable check-config check-contract-coverage check-config-bindings check-contract-tests test-contract-union lint lint-policy
 
 # Install the pinned Helm plugins. The CI composite action calls this recipe too, so the versions
 # above are the only place they are declared.


### PR DESCRIPTION
Adds configuration binding markers — a comment convention stating which contract key a chart value feeds — a parser, and an offline gate. **Enrols all five charts that map values onto a contract**, `tankovault` included.

Four of the format's rules come from that chart and each replaced a rule that read as obviously right until nine documents were put through it — the section below has the measurements.

**No generation.** Nothing rewrites `values.yaml`. Landing a generator together with the format it depends on would make both unreviewable.

## Grammar

```
# @schema
# # @config <class> [<document>[,<document>...]:]<key> [optional] [when <values-path>]
# <the rest of the schema, untouched>
# @schema
# -- <the description helm-docs already reads>
<key>: <value>
```

The markers are the **run of lines at the top of the block**, so a value may bind several keys. Without a scope a marker binds its key in **every** document whose contract declares it, which is what a chart does: one template line writes `metrics.enabled` into all eight of `tankovault`'s services.

```yaml
  # @schema
  # # @config projection telemetry.sentry_dsn optional
  # type: string
  # @schema
  # -- Sentry DSN (`telemetry.sentry_dsn`). Empty disables Sentry entirely.
  sentryDsn: ""
```

The other three shapes in the pilots, marker lines only: `# # @config external PORT`,
`# # @config projection csp.cloudflare.script_nonce`, `# # @config projection metrics.ip when
metrics.enabled`.

Four classes — `projection`, `structured`, `composed`, `external` — plus two orthogonal suffixes. The six-row taxonomy turned out to be **four shapes and two conditions**: collapsing `gated` into a class would say nothing about `metrics.ip` also being a 1:1 projection, and a value both gated and optional would be inexpressible.

`composed` and `structured` assert the binding and claim nothing about the transformation — `printf "%s:%v" host port` is not recoverable from a comment, and the keys under `bucket.entries` are the operator's own names. That is all coverage needs, and it is the signal telling a future probe generator that such a case must be written by hand.

## The placement finding — this changed the design

Ten placements measured on both pilots: all fifteen markers moved each time, then
`values.schema.json` and `README.md` regenerated with `helm schema` and `helm-docs` scoped to each
chart and compared byte for byte.

| Placement | `values.schema.json` | `README.md` |
| --- | --- | --- |
| **first line inside `# @schema`, as `# # ...`** | identical | identical |
| last line inside `# @schema`, as `# # ...` | identical | identical |
| appended to a schema line as a YAML comment | identical | identical |
| as a schema key, `# config: projection ...` | identical | identical |
| bare `# @config` inside `# @schema` | **`helm schema` fails** | — |
| own comment line anywhere above the `# --` | **15 leading `\n`** | identical |
| own comment line last in the block | identical | **15 rows fouled** |
| own comment line, blank line, then the block | identical | identical |
| blank line between the block and the value | **every description lost** | 15 rows fouled |
| trailing comment on the value line | identical | identical |

The mechanism explains every row. helm-docs starts a description at `# --` and ends it at the next
non-comment line, so anything above the description is invisible to it and anything below is
appended to it. helm-schema collects the **whole** block as that description and, for an
`@`-prefixed line, drops the content and keeps the line:

```diff
-  "description": "Log level (`telemetry.log_level`)."
+  "description": "\nLog level (`telemetry.log_level`)."
```

```diff
-| telemetry.logLevel | string | `"INFO"` | Log level (`telemetry.log_level`). |
+| telemetry.logLevel | string | `"INFO"` | Log level (`telemetry.log_level`). @config projection telemetry.log_level |
```

**But inside its own delimiters the content is not the description — it is the schema, parsed as
YAML.** A YAML comment there is discarded by the only parser that reads it, which is why the first
four rows are byte-identical and why this is a property of YAML rather than of a helm-schema
version. Bare `# @config` is the same position spelt as YAML *content* and fails the plugin
outright: `@` is a reserved indicator in YAML.

Available everywhere it is needed: **all 1,128 documented values across the five contract-carrying
charts have a `@schema` block** — 179 in `portfolio`, 114 in `netcup-offer-bot`, 172, 173 and 490
in the other three, none excepted.

Of the five clean rows the format takes the first and refuses the other four. `# config:` survives
only because helm-schema ignores keys it does not know, which is lenience rather than a rule, and
it asserts a schema keyword that is not one. Appending to `# type: string` hangs the marker off a
token it says nothing about. The blank-line placement makes a blank line load-bearing in a file
where the row below it shows what a misplaced one costs — every description in the chart.

**What this gives up**, stated plainly because an earlier draft of this PR used it as the argument
for the value line: attachment is positional again. `parse_values` therefore refuses every way a
block can fail to reach its value — a blank line, a sequence item, the end of the file, a second
`@schema` block — and refuses two markers in one block, which was free when a marker was a line's
only trailing comment.

This breaks the file's own convention — every other piece of metadata lives above the key — and it won on measurement, not taste. The compensation is real: a line has one trailing comment, so "no value binds two keys" stopped being a rule and became structural, and no comment-block edit can silently re-target a marker.

## Enrolment is declared, not inferred

`bindings: true` in `config-contract.yaml`. The obvious alternative — a chart is enrolled by
carrying at least one marker, matching how `config-contract.yaml` and `contract-tests.yaml` enrol
charts — was measured to fail in the direction that matters. Feeding the gate a `portfolio` whose
ten markers had been rewritten into a spelling the parser does not recognise produced **exit 0 and
a report the chart had silently vanished from**: no error, no mention, and the coverage rule it was
enrolled for simply not run. The same happens to a chart whose markers are deleted, which is
precisely the drift this gate exists to see.

With the switch in the declaration both disagreements are errors: markers without `bindings: true`,
and `bindings: true` without markers.

## Exemptions

A new `unbound:` list per document in `config-contract.yaml` — `{key, reason}`, reason mandatory. It sits beside the existing `exempt:` and does not touch it: `exempt` is per `ci/` fixture and per gate, `unbound` is per key and relaxes nothing.

**"Secret keys are exempt by default" is refused, and netcup is the proof.** `telemetry.sentry_dsn` is `secret: true` in that contract *and* is projected into the document by `telemetry.sentryDsn`. A blanket rule would write off a key the chart binds, and the gate would then stop noticing if that projection were dropped.

External variables are bindable (`external.env` carries the same shape a key does) but not counted by coverage — the loader does not own `PORT`/`RUST_LOG`. Without the class, portfolio's three listener values would be silent and a reader could not tell "not configuration" from "someone forgot".

## In `just check`

It asserts, needs no network, reads two committed files per chart with no render, and cannot go red for a chart nobody enrolled. It fails exactly where wanted — on the Renovate PR that repinned the digest, in the run that also shows the reviewer the contract diff. Also wired into `ci.yaml` beside `check-contract-coverage`.

## Verification

- `just test-contract-union` — **433 tests**, green.
- **`values.schema.json` and `README.md` byte-identical for all five enrolled charts**,
  regenerated with the markers in place and compared against the same tree with them removed —
  `tankovault` included, with 38 markers across its 3,680-line values.yaml.
- `just check-config` (full render), `just check-contract-coverage`, `just check-contract-tests`,
  `just check-config-bindings`, `just test-unit` on all five (tankovault: 221 tests) — all green.
- Failure messages, both directions:
  - deleted marker → ``the contract declares 'telemetry.sentry_dsn' and no chart value binds it. Add a `# @config ...` marker to the value line that feeds it, or an `unbound` entry with a reason``
  - corrupted path → ``binds the value 'isr.ttlSecs' to the contract key 'isr.ttl_sec', which no contract this chart declares carries (did you mean isr.ttl_secs?)``

## The five enrolled charts, and what each one is there for

| Chart | Bindings | What it carries that no other does |
| --- | --- | --- |
| `portfolio` | 7 + 3 env | the `external.env` namespace: `IP`, `PORT`, `RUST_LOG` |
| `netcup-offer-bot` | 5 | an `optional` projection, a pair gated on `metrics.enabled`, one credential written off |
| `s3-bucket-perma-link` | 7 | the only `structured` scalar binding, `bucket.entries`, plus two credentials written off |
| `mp-stats-legacy-viewer` | 8 | `composed` over two values: `server.bind_addr` is `printf` over host and port |
| `tankovault` | 99 | nine documents: unscoped bindings, scoped ones, a value binding three keys, and a lone `composed` |

Every mapping was read out of the chart's own `derivedConfig` helper rather than guessed from the
names, and every enrolled chart's `values.schema.json` and `README.md` were regenerated with the
markers in and compared byte for byte against the same tree with them out.

## What `tankovault` changed about the format

The first draft was designed against two single-document charts. `tankovault` declares **167
distinct key paths in 454 declarations across nine documents**, and enrolling it under that draft
produced **454 coverage failures**. Four rules did not survive it. Each is a small change and each
was forced by a measurement, not by taste.

**1. An unscoped marker binds every document that declares the key.** 77 of those 167 paths are
declared by several documents at once, eight of them by eight — `metrics.enabled`, `metrics.listen`,
`bind_addr`, `telemetry.*`. One line of `derivedConfig` writes each into every service. The draft
refused a target that resolved in more than one document:

```
tankovault/values.yaml:3157: the target 'metrics.enabled' is declared by 8 of this chart's
documents (...); qualify it as `<document>:metrics.enabled`
```

A value carries a marker and a qualified marker covers one document, so that made the case
inexpressible. A scope now **narrows** rather than being required, and naming a document whose
contract lacks the key is refused so a scope cannot go stale silently. Where documents disagree
about a key's *shape*, the marker is refused too: one path in two shapes is two settings.

**2. A value may bind several keys.** `internal.tls.certDir` is the directory
`internal.tls.cert`, `internal.tls.key` and `internal.tls.ca` are each built from, by three
`printf`s in one template. Under the trailing-comment placement a second marker could not be
written at all — and that impossibility had been written up as a property of the model. The
markers are a run at the top of the block now; the same target twice on one value is still
refused, and so is a marker below the schema.

**3. `unbound` moved to the chart and takes a list of keys.** Only **40 of the 167 paths are
written by any rendered document**; the other 127 are settings the image reads and this chart does
not surface. Per document that was **345 entries repeating four sentences**. It is now chart-level,
one reason per group, optionally scoped — and still **one key per line, with no pattern form**, so
a key the next release adds turns the gate red until somebody files it.

**4. A lone `composed` is legitimate.** `metrics.listen` is `printf "0.0.0.0:%v" .Values.metrics.port`
— one value and a literal. Not a `projection`, since the key's text is not the value's; and the
rule that called it one ("a composition of one is a projection") was rejecting a shape that occurs.
Rule 4's real direction — several values on one key must all say `composed` — is untouched.

**The result.** 38 markers resolving to **99 bindings**, and 144 keys written off in **six**
entries: 11 the chart derives from its own topology (a Service address, a port fixed in
`serviceSpecs`, a slug), 15 delivered as files in the secrets directory, 12 `branding.*` keys that
*are* surfaced but are deliberately not sent to every service that declares them, and 106 settings
the image reads that this chart offers no value for.

## Where the format felt forced

Reported honestly rather than discovered on chart three:

1. **`discord.webhook_url` is not really "not surfaced"** — `discord.webhookUrl` does reach it, through the Secret. A fifth `secret` class was drafted and dropped: `config-secrets.py` already reconciles that channel from the *rendered manifests*, and a comment asserting the same thing is a second, weaker opinion.
2. **Enrolment is per chart, not per document.** `tankovault`'s switch owes all nine documents at once. Right — coverage over *some* documents is not coverage — but it means a nine-service chart cannot be adopted a document at a time, and this PR is the size it is because of that.
3. **`optional` is unverifiable offline.** `when <path>` at least checks the gate value exists. A rule that "a required key with no default may not be optional" was considered and killed by netcup, where `discord.webhook_url` is exactly that shape and is legitimately file-delivered.
4. **The `branding.*` write-offs are the weakest entries in the tree.** They say a key is surfaced but deliberately not sent to some documents, which is true and is also the one family whose reason a reader has to check against `tankovault.branding.config` to believe.
5. **`# # @config` reads as a comment inside a comment**, because that is what it is. It is the
   price of the only position both generators ignore, and the parser refuses the four tidier-looking
   in-block spellings that are equally clean so the file cannot end up with two conventions.

## Merge note

Rebased onto `main` at #465, the automated tankovault 8.2.0 bump. Collisions resolved here:

- **`justfile`** — `main` added `check-contract-tests` to the `check` aggregate on the same line this adds `check-config-bindings`; both are in it now.
- **Chart versions** — `main` had already reached `portfolio` 5.1.2 and `netcup-offer-bot` 5.1.1, so both bumps collapsed to nothing and `ct lint` would have failed on charts changed without one. Now **`portfolio` 5.1.3**, **`netcup-offer-bot` 5.1.2**, **`s3-bucket-perma-link` 4.1.2**, **`mp-stats-legacy-viewer` 3.2.1** and **`tankovault` 5.2.2**.
- **`Document.unbound`** — #456's `test_contract_testgen.py` constructs a `Document` directly and predates the field, which this adds as required (like `exempt`). Passes `unbound=[]`, rather than giving the field a default that would let a real declaration path skip it.

Unrelated environment note: the local helm-docs binary drifts from CI's independently of this change — regenerating either README with markers *removed* still produces 7–8 changed lines. That baseline was established first and compared against, so the committed READMEs change by exactly one line each, the version badge.
