### PR TITLE
feat(scripts): create a chart from the contract its image publishes

### DIFF
--- a/.github/configs/ruff.toml
+++ b/.github/configs/ruff.toml
@@ -1,0 +1,85 @@
+# Linting for `.github/scripts`, which is 11,000 lines of Python holding every gate in this
+# repository and, until this file, had no linter at all.
+#
+# That absence was not a decision anybody made. Seven entry scripts already carry `# noqa: E402`
+# on their imports — written for a linter that never landed — so the intent was there and the
+# tool was not.
+#
+# Configured here rather than in a `pyproject.toml` at the root, because there is no Python
+# package here to configure: `.github/scripts` is a directory of scripts a task runner invokes,
+# and a `pyproject.toml` would imply a distribution that does not exist. `.github/configs/` is
+# where every other tool's configuration already lives — `ct.yaml`, `kube-linter.yaml`,
+# `lintconf.yaml`, `render-api-versions.txt` — so this sits beside them.
+
+# The interpreter the recipes resolve to on a CI runner. Not the lowest version that would work:
+# the scripts already use `X | None` unions and `match`-free structural code, and pinning the
+# target to what actually runs them is what lets the linter flag a construct that would break
+# there rather than one that would break on a Python nobody uses.
+target-version = "py311"
+
+# Matches the width the scripts are already written to, and the width `values.yaml`'s comments
+# and the justfile's own prose use. Chosen by measuring the existing files rather than by taking
+# the tool's default of 88, which would have reported several hundred lines that are deliberate.
+line-length = 100
+
+[lint]
+# Deliberately more than the default `E4,E7,E9,F`, and deliberately not `ALL`.
+#
+#   E, W    pycodestyle: the whitespace and layout rules the files already follow
+#   F       pyflakes: unused imports and names, the single highest-value check here — this
+#           repository has already accumulated four of them, each found by hand
+#   I       import sorting, so an added import has one correct position rather than an opinion
+#   B       flake8-bugbear: mutable default arguments, `except` that swallows, loop-variable
+#           capture. Real defects rather than style
+#   UP      pyupgrade: keeps the files on one generation of syntax rather than two
+#   C4      comprehension rewrites, where the rewritten form is plainly clearer
+#   RUF     ruff's own, notably the mutable-dataclass-default check this codebase's many
+#           `@dataclass` types are exposed to
+select = ["E", "W", "F", "I", "B", "UP", "C4", "RUF"]
+
+# E402 — a module-level import after the `sys.path` bootstrap every entry script and every test
+# module needs — is deliberately *not* ignored here. Sixty-six of those imports already carry a
+# per-line `# noqa: E402`, written by hand, and each one marks the exact place the bootstrap makes
+# the import unavoidable. A blanket ignore would make all sixty-six dead comments and would also
+# stop reporting an import that landed after the bootstrap by accident. Keeping the rule on means
+# ruff validates the existing comments — an unused one is an `RUF100` — and a new entry script is
+# told once, at the line, why it needs one.
+ignore = [
+  # RUF002 flags a character in a *docstring* that could be confused with an ASCII one. The rule
+  # exists so a homoglyph cannot hide inside something that gets executed or compared, and a
+  # docstring is neither. This repository's prose is deliberately typographic — em dashes, arrows,
+  # `×8` meaning "eight of them" in `config_bindings`' marker table — and rewriting that to ASCII
+  # would make the tables worse to read in exchange for nothing.
+  #
+  # RUF001 (identifiers and string literals) and RUF003 (comments) stay on, which is where the
+  # rule's premise actually holds.
+  "RUF002",
+]
+
+[lint.isort]
+# The sibling modules are neither standard library nor third-party: they are this directory,
+# imported by name because it is on `sys.path`. Naming them keeps them in their own block rather
+# than mixed into third-party imports where a reader cannot tell them from PyYAML.
+known-first-party = [
+  "config_bindings",
+  "config_contract",
+  "config_coverage",
+  "config_declaration",
+  "config_diff",
+  "config_gate_container",
+  "config_gate_document",
+  "config_manifests",
+  "config_paths",
+  "config_report",
+  "config_scaffold",
+  "config_secrets",
+  "config_testgen",
+  "entry",
+]
+
+[format]
+# Not enabled as a gate. The files are hand-formatted to a house style the formatter disagrees
+# with in places — notably the long argument lists in `config_testgen`'s renderers, which are laid
+# out to be read as tables — and reflowing 11,000 lines to settle that is a change nobody asked
+# for. `just lint-python` lints; it does not format.
+docstring-code-format = false

--- a/.github/scripts/check-chassis.py
+++ b/.github/scripts/check-chassis.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Report where a chart's shared values blocks have drifted from the scaffold's copy.
+
+`just new-chart` writes a new chart from `.github/templates/chart/values.chassis.yaml` — the
+twenty-nine `values.yaml` blocks that are the same in every chart because `charts/common` owns the
+logic and these files only name it. Nothing keeps that copy and the charts in step. A block gains a
+sentence in one chart, the scaffold keeps the old wording, and the next chart created inherits it.
+
+That is the gap this reports, and it is worth being precise about which direction it runs in. The
+scaffold is **not** the authority. It was seeded from the majority text of the eight existing
+charts, which means it is right about most blocks by construction and has no claim to be right
+about any particular one. So this prints differences and exits 0: a chart that has deliberately
+diverged is a normal thing for a chart to do, and a gate that failed on it would be red for a
+decision somebody made on purpose.
+
+What the report is *for* is the other case — a block edited in one chart and nowhere else, which
+is the same drift `just new-chart` exists to stop and which nothing else in this repository can
+see. Reading the list and deciding, per block, whether the chart or the scaffold is behind is the
+work; this only makes the list.
+
+--------------------------------------------------------------------------------------------
+Why the comparison is textual
+--------------------------------------------------------------------------------------------
+
+A block is compared as the lines it occupies, comments included, not as the value it parses to.
+That is deliberate twice over.
+
+The `@schema` blocks *are* the interesting part: they are what `values.schema.json` is generated
+from, so a chart whose `podSecurityContext` block lost a `type: integer` has a materially
+different schema while parsing to the same mapping. And the `# --` descriptions are published —
+helm-docs renders them into every chart's README — so a description that improved in one chart and
+nowhere else is exactly the drift worth seeing.
+
+Whitespace at the end of a line is normalised away and nothing else is. Two blocks that differ
+only in trailing spaces are the same block, and a reader told otherwise would stop reading the
+report.
+
+--------------------------------------------------------------------------------------------
+What is deliberately not reported
+--------------------------------------------------------------------------------------------
+
+**A chart that does not carry a block at all.** `teamspeak` has no `extraVolumeMounts` and does
+not need one; "this chart is missing a block the scaffold writes" is a fact about what the chart
+does, not about drift. Only blocks present on both sides are compared.
+
+**Anything outside the chassis.** A chart's own configuration surface is per image and has no
+shared copy to drift from.
+
+Usage: python3 .github/scripts/check-chassis.py
+       python3 .github/scripts/check-chassis.py --charts charts --chassis <path>
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from config_paths import CHARTS_DIR
+
+CHASSIS = Path(".github/templates/chart/values.chassis.yaml")
+
+# A top-level mapping key in a values file. Anchored at column zero, which is what makes it a
+# *top-level* key and not any of the several hundred nested ones.
+_TOP_LEVEL = re.compile(r"^[A-Za-z][A-Za-z0-9]*:")
+
+# The library chart, which has no chassis: it renders nothing and carries no values of its own.
+LIBRARY = "common"
+
+
+def blocks(text: str) -> dict[str, list[str]]:
+    """Split a values file into its top-level blocks, each with the comment run above its key.
+
+    The comment run is part of the block and not of the one before it, because that run is the
+    `@schema` block and the `# --` description — the two things a reader is comparing. Attaching
+    it to the preceding key would report every difference against the wrong neighbour.
+    """
+    lines = text.splitlines()
+    starts = [index for index, line in enumerate(lines) if _TOP_LEVEL.match(line)]
+
+    found: dict[str, list[str]] = {}
+    for position, start in enumerate(starts):
+        end = starts[position + 1] if position + 1 < len(starts) else len(lines)
+
+        # Give the next block back the comment run and blank lines directly above its own key.
+        while end > start and (lines[end - 1].startswith("#") or not lines[end - 1].strip()):
+            end -= 1
+
+        top = start
+        while top > 0 and lines[top - 1].startswith("#"):
+            top -= 1
+
+        found[lines[start].split(":")[0]] = [line.rstrip() for line in lines[top:end]]
+    return found
+
+
+def compare(chassis: dict[str, list[str]], chart: str, values: dict[str, list[str]]) -> list[str]:
+    """A unified diff per shared block that differs. Empty when the chart matches the scaffold."""
+    report: list[str] = []
+    for name in sorted(chassis):
+        theirs = values.get(name)
+        if theirs is None or theirs == chassis[name]:
+            continue
+        report.extend(
+            difflib.unified_diff(
+                chassis[name],
+                theirs,
+                fromfile=f"scaffold/{name}",
+                tofile=f"{chart}/{name}",
+                lineterm="",
+                n=1,
+            )
+        )
+    return report
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("chart", nargs="?", default="", help="one chart, or every chart")
+    parser.add_argument("--charts", default=str(CHARTS_DIR))
+    parser.add_argument("--chassis", default=str(CHASSIS))
+    parser.add_argument(
+        "--summary", action="store_true", help="count the drifted blocks instead of diffing them"
+    )
+    args = parser.parse_args(argv)
+
+    chassis_path = Path(args.chassis)
+    if not chassis_path.is_file():
+        print(f"error: {chassis_path}: no chassis to compare against", file=sys.stderr)
+        return 1
+
+    chassis = blocks(chassis_path.read_text(encoding="utf-8"))
+    charts = Path(args.charts)
+    if not charts.is_dir():
+        print(f"error: {charts}: no such directory", file=sys.stderr)
+        return 1
+
+    # Walked here rather than through `config_declaration.chart_dirs`, because this reads no
+    # declaration and a chart without one is exactly as interesting to it as a chart with one.
+    directories = [charts / args.chart] if args.chart else sorted(charts.iterdir())
+
+    drifted = 0
+    shared = 0
+    for chart_dir in directories:
+        values_path = chart_dir / "values.yaml"
+        if chart_dir.name == LIBRARY or not values_path.is_file():
+            continue
+
+        values = blocks(values_path.read_text(encoding="utf-8"))
+        present = [name for name in chassis if name in values]
+        shared += len(present)
+        differing = [name for name in present if values[name] != chassis[name]]
+
+        if not differing:
+            print(f"in step: {chart_dir.name} ({len(present)} shared block(s))")
+            continue
+
+        drifted += len(differing)
+        print(
+            f"drifted: {chart_dir.name} "
+            f"({len(differing)} of {len(present)} shared block(s)): {', '.join(differing)}"
+        )
+        if not args.summary:
+            for line in compare(chassis, chart_dir.name, values):
+                print(f"    {line}")
+
+    print(f"\n==> {drifted} of {shared} shared block(s) differ from the scaffold's copy")
+    if drifted:
+        # Report only. The scaffold was seeded from the majority text of the existing charts, so
+        # it is right about most blocks by construction and has no claim to be right about any
+        # particular one — a chart that diverged on purpose is a normal thing, and failing on it
+        # would be red for somebody's decision. Deciding which side is behind is the work; this
+        # only makes the list.
+        print("    Each is a chart or a scaffold that is behind. Read them and decide which.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/scripts/check-config-bindings.py
+++ b/.github/scripts/check-config-bindings.py
@@ -2,7 +2,8 @@
 """Hold every `# @config` marker in a chart's values.yaml against the contract it names.
 
 `just check-contract-coverage` answers a chart-level question — does this chart carry a
-`config-contract.yaml` at all — and its `unconfigured` escape hatch lists *images*. So the
+`config-contract.yaml` at all — and its `unconfigured` escape hatch lists whole *image
+blocks*. So the
 repository's documented recurring failure is invisible to it: an image release adds a setting, the
 automated bump repins the digest and omits everything else, and no gate anywhere notices that the
 new key has no chart value. `check-config` will not catch it either, because a key nothing renders
@@ -110,13 +111,18 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-import config_bindings as cb  # noqa: E402
-import config_contract as cc  # noqa: E402
-from config_declaration import Declaration, DeclarationError, Document  # noqa: E402
-from config_declaration import load_declaration  # noqa: E402
-from config_report import Report  # noqa: E402
-
-CHARTS_DIR = Path("charts")
+import config_bindings as cb
+import config_contract as cc
+from config_declaration import (
+    Declaration,
+    DeclarationError,
+    Document,
+    chart_dirs,
+    load_declaration,
+    union_for,
+)
+from config_paths import CHARTS_DIR
+from config_report import Report
 
 
 class Bound:
@@ -133,12 +139,8 @@ class Bound:
         self.unions: dict[str, cc.Union] = {}
 
         for document in declaration.documents:
-            contracts = []
-            for reference in document.images:
-                vendored = cc.load_vendored(chart_dir / reference.contract)
-                contracts.append((f"{chart_dir.name}/{reference.contract}", vendored.contract))
             self.documents[document.name] = document
-            self.unions[document.name] = cc.union_contracts(contracts)
+            self.unions[document.name] = union_for(chart_dir, document)
 
     def namespace(self, name: str, cls: str) -> dict[str, dict[str, Any]]:
         """The half of one document's contract a marker of this class may name."""
@@ -473,10 +475,7 @@ def run(charts: Path, report: Report) -> list[tuple[str, int, int]]:
     gate = Gate(report)
     enrolled: list[tuple[str, int, int]] = []
 
-    for chart_dir in sorted(charts.iterdir()):
-        if not (chart_dir / "Chart.yaml").is_file():
-            continue
-
+    for chart_dir in chart_dirs(charts):
         counted = gate.check_chart(chart_dir)
         if counted is None:
             continue

--- a/.github/scripts/check-config.py
+++ b/.github/scripts/check-config.py
@@ -59,34 +59,30 @@ import sys
 from pathlib import Path
 from typing import Any
 
-import yaml
-
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-import config_contract as cc  # noqa: E402
-from config_coverage import check_coverage  # noqa: E402
-from config_declaration import (  # noqa: E402
+import config_contract as cc
+from config_coverage import check_coverage
+from config_declaration import (
     Binding,
     Consumer,
     Declaration,
     DeclarationError,
     Document,
     bind,
-    load_declaration,
+    declared,
 )
-from config_gate_container import ServiceLinkGate, check_container  # noqa: E402
-from config_gate_document import DocumentGate  # noqa: E402
-from config_manifests import (  # noqa: E402
+from config_gate_container import ServiceLinkGate, check_container
+from config_gate_document import DocumentGate
+from config_manifests import (
     containers_of,
     digest_of,
     load_manifests,
     pod_spec,
     select,
 )
-from config_report import Report, warning  # noqa: E402
-
-CHARTS_DIR = Path("charts")
-FIRST_PARTY = Path(".github/configs/first-party-images.txt")
+from config_paths import CHARTS_DIR, FIRST_PARTY, read_yaml
+from config_report import Report, warning
 
 
 class Runner:
@@ -102,19 +98,14 @@ class Runner:
     def run(self) -> int:
         """Check every chart that declares a contract; returns how many were checked."""
         checked = 0
-        for chart_dir in sorted(self.charts.iterdir()):
-            if not (chart_dir / "Chart.yaml").is_file():
-                continue
-            declaration = load_declaration(chart_dir)
-            if declaration is None or not declaration.documents:
-                continue
+        for chart_dir, declaration in declared(self.charts, documents_only=True):
             self.check_chart(chart_dir, declaration)
             checked += 1
         return checked
 
     def check_chart(self, chart_dir: Path, declaration: Declaration) -> None:
-        values = _read_yaml(chart_dir / "values.yaml")
-        app_version = _read_yaml(chart_dir / "Chart.yaml").get("appVersion")
+        values = read_yaml(chart_dir / "values.yaml")
+        app_version = read_yaml(chart_dir / "Chart.yaml").get("appVersion")
 
         for document in declaration.documents:
             where = f"{declaration.chart}: {document.name}"
@@ -257,10 +248,6 @@ class Runner:
             self.report.extend(where, check_container(manifests, spec, container, mine, relaxed))
 
         return checked
-
-
-def _read_yaml(path: Path) -> dict[str, Any]:
-    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
 
 
 def find_jv() -> str:

--- a/.github/scripts/check-immutable-fields.py
+++ b/.github/scripts/check-immutable-fields.py
@@ -185,7 +185,9 @@ def render(chart: Path, values: Path, extra: list[str] | None = None) -> list[di
     ]
     result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0:
-        raise RuntimeError(f"helm template failed for {chart.name} / {values.name}:\n{result.stderr}")
+        raise RuntimeError(
+            f"helm template failed for {chart.name} / {values.name}:\n{result.stderr}"
+        )
     return [doc for doc in yaml.safe_load_all(result.stdout) if doc]
 
 
@@ -197,7 +199,10 @@ def bumped_copy(chart: Path, destination: Path) -> Path:
     chart_yaml = target / "Chart.yaml"
     text = chart_yaml.read_text(encoding="utf-8")
     text = re.sub(r"^version: .*$", f"version: {PROBE_VERSION}", text, count=1, flags=re.MULTILINE)
-    text = re.sub(r"^appVersion: .*$", f"appVersion: {PROBE_VERSION}", text, count=1, flags=re.MULTILINE)
+    text = re.sub(
+        r"^appVersion: .*$", f"appVersion: {PROBE_VERSION}", text, count=1,
+        flags=re.MULTILINE,
+    )
     chart_yaml.write_text(text, encoding="utf-8")
     return target
 

--- a/.github/scripts/config-secrets.py
+++ b/.github/scripts/config-secrets.py
@@ -31,10 +31,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-import config_contract as cc  # noqa: E402
-from config_declaration import DeclarationError  # noqa: E402
-from config_report import Report, error, warning  # noqa: E402
-from config_secrets import (  # noqa: E402
+import config_contract as cc
+from config_declaration import DeclarationError
+from config_paths import CHARTS_DIR
+from config_report import Report, error, warning
+from config_secrets import (
     Credential,
     Mount,
     Reconciler,
@@ -43,9 +44,6 @@ from config_secrets import (  # noqa: E402
     credentials,
     declared_secrets,
 )
-
-CHARTS_DIR = Path("charts")
-
 
 # --------------------------------------------------------------------------------------------
 # The inventory
@@ -198,7 +196,9 @@ def report_of(surface: Surface) -> Report:
             ),
         )
 
-    for chart, workload, container, image, files, values_files in _by_container(surface.unclaimed):
+    for chart, workload, container, _image, files, values_files in _by_container(
+        surface.unclaimed
+    ):
         report.add(
             f"unclaimed: {chart}",
             error(

--- a/.github/scripts/config_bindings.py
+++ b/.github/scripts/config_bindings.py
@@ -22,7 +22,8 @@ Why the fact is worth writing down at all, in the order the payoffs arrive:
 
 **1. Key-level coverage — the only one this file serves today.**
 `just check-contract-coverage` is chart-level: it reports whether a chart carries a
-`config-contract.yaml`, and its `unconfigured` escape hatch lists *images*. Nothing in this
+`config-contract.yaml`, and its `unconfigured` escape hatch lists whole *image blocks*.
+Nothing in this
 repository notices when an image release adds a setting that no chart value reaches. That is the
 documented recurring failure here — an automated bump repins the digest and silently omits
 everything else — and a marker per value is what turns "the chart has a contract" into "every key

--- a/.github/scripts/config_contract.py
+++ b/.github/scripts/config_contract.py
@@ -55,9 +55,10 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, Sequence
+from typing import Any
 
 # --------------------------------------------------------------------------------------------
 # What the image publishes
@@ -720,7 +721,7 @@ def assert_value(constraint: dict[str, Any], value: Any) -> str | None:
             f"{', '.join(sorted(unsupported))}"
         )
 
-    if "type" in constraint and not _is_type(value, constraint["type"]):
+    if "type" in constraint and not is_type(value, constraint["type"]):
         return f"expected {constraint['type']}, got {json.dumps(value)}"
     if "enum" in constraint and value not in constraint["enum"]:
         allowed = ", ".join(json.dumps(option) for option in constraint["enum"])
@@ -756,7 +757,14 @@ def assert_value(constraint: dict[str, Any], value: Any) -> str | None:
     return None
 
 
-def _is_type(value: Any, declared: Any) -> bool:
+def is_type(value: Any, declared: Any) -> bool:
+    """Whether a value satisfies a JSON Schema `type`, scalar or list.
+
+    Public because `config_testgen` needs the same answer when it checks a synthesised candidate
+    against the constraint it has to satisfy, and had its own table-driven copy of this until the
+    two were merged. Two implementations of "is this an integer" is one more than the number of
+    places the `bool`-is-an-`int` trap has to be remembered.
+    """
     names = declared if isinstance(declared, list) else [declared]
     for name in names:
         if name == "integer" and isinstance(value, int) and not isinstance(value, bool):
@@ -809,7 +817,11 @@ def _levenshtein(left: str, right: str) -> int:
         current = [index]
         for position, b in enumerate(right, start=1):
             current.append(
-                min(previous[position] + 1, current[position - 1] + 1, previous[position - 1] + (a != b))
+                min(
+                    previous[position] + 1,
+                    current[position - 1] + 1,
+                    previous[position - 1] + (a != b),
+                )
             )
         previous = current
     return previous[-1]

--- a/.github/scripts/config_coverage.py
+++ b/.github/scripts/config_coverage.py
@@ -32,7 +32,7 @@ from typing import Any
 import yaml
 
 import config_contract as cc
-from config_declaration import DECLARATION, DeclarationError, load_declaration
+from config_declaration import DECLARATION, DeclarationError, chart_dirs, load_declaration
 from config_report import Report, warning
 
 
@@ -73,9 +73,12 @@ def check_coverage(charts: Path, first_party: Path, report: Report) -> None:
     covered: list[str] = []
     uncovered: list[tuple[str, list[str]]] = []
 
-    for chart_dir in sorted(charts.iterdir()):
+    for chart_dir in chart_dirs(charts):
+        # A chart with no values.yaml pins no image, so there is nothing here to be covered or
+        # uncovered. Checked here rather than in the shared walk because every other caller
+        # legitimately reads a chart without one.
         values_path = chart_dir / "values.yaml"
-        if not (chart_dir / "Chart.yaml").is_file() or not values_path.is_file():
+        if not values_path.is_file():
             continue
 
         values = yaml.safe_load(values_path.read_text(encoding="utf-8")) or {}
@@ -88,6 +91,8 @@ def check_coverage(charts: Path, first_party: Path, report: Report) -> None:
             continue
 
         declaration = load_declaration(chart_dir)
+        if declaration is not None:
+            check_unconfigured(chart_dir, declaration, values, report)
 
         if declaration is None or not declaration.documents:
             uncovered.append((chart_dir.name, [repository for _, repository in ours]))
@@ -109,6 +114,42 @@ def check_coverage(charts: Path, first_party: Path, report: Report) -> None:
                 )
 
     _report_coverage(covered, uncovered, report)
+
+
+def check_unconfigured(
+    chart_dir: Path, declaration, values: Any, report: Report
+) -> None:
+    """Hold every `unconfigured` entry to being a values path that pins an image.
+
+    **`unconfigured` holds values paths, not repository names**, and that had to be settled
+    because the two readers of the field disagreed. This gate unions it with the `values` of every
+    declared image and compares the result against the paths a chart pins, so a repository name
+    there matched nothing and silently bought no coverage; `just explain` printed the same field
+    as "images it pins that carry no contract", and two module docstrings said the same. No chart
+    in the repository sets it, so nothing was wrong yet — the first one to would have picked a
+    reading at random.
+
+    The values path wins for three reasons. It is the reading the only gate that acts on the field
+    already implements. That gate's own error message offers `unconfigured` as the alternative to
+    "a document's `images`", whose entries are values paths, so the message was already consistent
+    with it. And a repository name is ambiguous where a values path is not: a chart pinning the
+    same repository at two paths could not say which of them it meant.
+
+    Enforced here rather than in `load_declaration`, because deciding this needs the chart's
+    values.yaml and the declaration loader deliberately reads nothing but its own file. This is
+    the one gate that already has both open.
+    """
+    pinned = {path for path, _ in pinned_images(values)}
+    for entry in declaration.unconfigured:
+        if entry in pinned:
+            continue
+        report.fail(
+            f"{chart_dir.name}: {DECLARATION}",
+            f"`unconfigured` names {entry!r}, which is not a values path this chart pins an image "
+            f"at. The field holds values paths — the same spelling a document's `images[].values` "
+            f"uses — and not repository names"
+            + (f"; this chart pins images at {', '.join(sorted(pinned))}" if pinned else ""),
+        )
 
 
 def _report_coverage(

--- a/.github/scripts/config_declaration.py
+++ b/.github/scripts/config_declaration.py
@@ -15,13 +15,15 @@ has anything trustworthy to say.
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 import yaml
 
 import config_contract as cc
+from config_paths import dig
 
 DECLARATION = "config-contract.yaml"
 
@@ -155,6 +157,10 @@ class Declaration:
     path: Path
     documents: list[Document]
     reason: str | None
+    # Values paths — the same spelling a document's `images[].values` uses — at which this
+    # chart pins an image that reads no contract-described configuration. Not repository
+    # names: `config_coverage.check_unconfigured` records why the two readers disagreed,
+    # which reading won, and gates it.
     unconfigured: list[str]
     bindings: bool
     unbound: list[Unbound]
@@ -390,6 +396,47 @@ def _load_unbound(path: Path, entries: Iterable[Any], documents: set[str]) -> li
     return loaded
 
 
+# --------------------------------------------------------------------------------------------
+# Walking the tree
+# --------------------------------------------------------------------------------------------
+
+
+def chart_dirs(charts: Path) -> Iterator[Path]:
+    """Every chart directory under `charts`, in directory order.
+
+    "Is this a chart" is `Chart.yaml` and nothing else — not a name list, not an exclusion set —
+    so a chart added to the tree is picked up by every gate at once with nothing to update. That
+    was already true five times over; this is the one copy of it.
+
+    Sorted, so every report, every failure list and every generated file is ordered by the tree
+    rather than by whatever order the filesystem happened to return.
+    """
+    for chart_dir in sorted(charts.iterdir()):
+        if (chart_dir / "Chart.yaml").is_file():
+            yield chart_dir
+
+
+def declared(charts: Path, *, documents_only: bool = False) -> Iterator[tuple[Path, Declaration]]:
+    """Every chart carrying a declaration, paired with it.
+
+    `documents_only` is the distinction the five hand-written copies of this loop disagreed on,
+    and it is a real one rather than a convenience. A chart with `documents: []` has *opted out*
+    explicitly and carries a reason: `just explain` must see it, because "this chart opted out,
+    and here is why" is an answer somebody ran the command to get. `check-config` and the
+    credential inventory must not, because there is no document for them to read.
+
+    Passed as a keyword because at a call site `declared(charts, True)` says nothing about which
+    of the two it means.
+    """
+    for chart_dir in chart_dirs(charts):
+        declaration = load_declaration(chart_dir)
+        if declaration is None:
+            continue
+        if documents_only and not declaration.documents:
+            continue
+        yield chart_dir, declaration
+
+
 def reject_unknown(path: Path, where: str, mapping: dict, allowed: Iterable[str]) -> None:
     unknown = set(mapping) - set(allowed)
     if unknown:
@@ -412,16 +459,6 @@ class PinnedImage:
     reference: str
     normalized: str
     digest: str | None
-
-
-def dig(values: Any, path: str) -> Any:
-    """Follow a dotted values path, returning `None` at the first missing step."""
-    current = values
-    for part in path.split("."):
-        if not isinstance(current, dict) or part not in current:
-            return None
-        current = current[part]
-    return current
 
 
 def resolve_image(values: dict[str, Any], path: str, app_version: str | None) -> PinnedImage:
@@ -455,6 +492,65 @@ def resolve_image(values: dict[str, Any], path: str, app_version: str | None) ->
 # --------------------------------------------------------------------------------------------
 # Binding a document to the contracts that describe it
 # --------------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Loaded:
+    """One vendored contract, the reference that named it, and the label it is reported under.
+
+    The label is `<chart>/<path>` — `tankovault/contracts/api.json` — and it is built here rather
+    than at each call site because it is the string every message, every union source list and
+    every credential row identifies a contract by. Four callers were spelling it themselves.
+    """
+
+    reference: ImageRef
+    label: str
+    vendored: cc.Vendored
+
+
+def vendored_for(chart_dir: Path, document: Document) -> list[Loaded]:
+    """Load every contract one document binds. **Applies no staleness interlock.**
+
+    The bold part is the whole reason this function exists rather than each caller writing its own
+    three lines. Whether the vendored file is for the digest the chart *currently* pins is a
+    separate question from what the file says, and the four callers legitimately answer it four
+    different ways:
+
+    | Caller                          | Interlock | Why                                          |
+    |---------------------------------|-----------|----------------------------------------------|
+    | `bind`, for the gates           | yes       | a pass it cannot justify is worse than a fail |
+    | `check-config-bindings`         | no        | compares values.yaml against the committed    |
+    |                                 |           | copy; whether that copy is current is         |
+    |                                 |           | `check-contracts`' question                   |
+    | `config-secrets`, the inventory | no        | withholding it during a bump removes the      |
+    |                                 |           | document at the moment it is being read       |
+    | `generate-contract-tests`       | no        | would block regeneration in the window        |
+    |                                 |           | between a bump and the refresh                |
+
+    Each of those three is a considered decision with a paragraph behind it, and each was
+    previously expressed as *the absence* of code — a four-line loop that looked like a helper and
+    was in fact a deliberate bypass. A fifth consumer copying one of them would have inherited the
+    bypass without inheriting the reason. Now the absence has a name, and `bind` is the one that
+    visibly adds something.
+
+    Raises `ContractError` on a file that cannot be read or is not shaped like a contract; that is
+    not an interlock but a parse, and no caller wants to proceed past it.
+    """
+    return [
+        Loaded(
+            reference=reference,
+            label=f"{chart_dir.name}/{reference.contract}",
+            vendored=cc.load_vendored(chart_dir / reference.contract),
+        )
+        for reference in document.images
+    ]
+
+
+def union_for(chart_dir: Path, document: Document) -> cc.Union:
+    """The contracts of every image that reads one document, merged. No interlock — see above."""
+    return cc.union_contracts(
+        [(item.label, item.vendored.contract) for item in vendored_for(chart_dir, document)]
+    )
 
 
 @dataclass(frozen=True)
@@ -494,13 +590,16 @@ def bind(
     contracts: list[tuple[str, dict[str, Any]]] = []
     by_digest: dict[str, cc.Union] = {}
 
-    for reference in document.images:
-        path = chart_dir / reference.contract
-        label = f"{chart_dir.name}/{reference.contract}"
+    try:
+        loaded = vendored_for(chart_dir, document)
+    except cc.ContractError as failure:
+        return None, [str(failure)]
+
+    for item in loaded:
+        reference, label, vendored = item.reference, item.label, item.vendored
 
         try:
             pinned = resolve_image(values, reference.values, app_version)
-            vendored = cc.load_vendored(path)
         except (cc.ContractError, DeclarationError) as failure:
             return None, [str(failure)]
 

--- a/.github/scripts/config_diff.py
+++ b/.github/scripts/config_diff.py
@@ -53,8 +53,9 @@ nothing to collapse and the pass would only ever be dead code.
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field
-from typing import Any, Iterable
+from typing import Any
 
 import config_contract as cc
 

--- a/.github/scripts/config_gate_document.py
+++ b/.github/scripts/config_gate_document.py
@@ -90,7 +90,7 @@ class DocumentGate:
 
         try:
             instance = parse_document(data[source.key], source.format)
-        except Exception as failure:  # noqa: BLE001 — every parser raises its own type
+        except Exception as failure:
             return [error(f"{source.key}: is not valid {source.format}: {failure}")]
 
         schema = cc.strip_internals(union.json_schema)

--- a/.github/scripts/config_paths.py
+++ b/.github/scripts/config_paths.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""The paths and the two-line helpers every script in this directory had its own copy of.
+
+Nothing here is interesting. That is the point: each of these was declared in between two and
+eight files, identically, and an identical declaration in eight files is a fact that can be
+changed in one of them and stay wrong in the other seven — silently, because every copy still
+parses and every test still passes.
+
+Deliberately not a home for anything that decides something. `config_contract` owns the contract
+model, `config_declaration` owns `config-contract.yaml`, `config_manifests` owns the rendered
+objects, and a helper that grows a rule belongs in whichever of those the rule is about. What
+lives here is the answer to "where is `charts/`" and "read this YAML file", which are not rules
+and have no natural owner.
+
+`digest_of` in `config_manifests` is a near-neighbour of `dig` below and is not the same function
+— one splits an image reference, the other walks a values tree — so it stays where it is.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# The chart tree, relative to the repository root. Every entry point takes `--charts` and defaults
+# to this, so a caller can point the whole toolchain at a fixture directory.
+CHARTS_DIR = Path("charts")
+
+# The image repositories this organisation builds, and so the ones that can be expected to publish
+# a configuration contract. Read by `check-contract-coverage` to decide which charts owe a
+# declaration, and by `new-chart` to decide whether to write an opt-out — the two have to agree,
+# which is why neither spells the path itself.
+FIRST_PARTY = Path(".github/configs/first-party-images.txt")
+
+
+def read_yaml(path: Path) -> dict[str, Any]:
+    """One YAML document as a mapping, with an absent or empty file reading as `{}`.
+
+    The `or {}` is the whole reason this is a function rather than a call: `yaml.safe_load` of an
+    empty file returns `None`, and every caller here goes on to `.get()` something out of it. Three
+    files had this exact line; two of them had reached it independently.
+    """
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def dig(values: Any, path: str) -> Any:
+    """Follow a dotted values path, returning `None` at the first missing step.
+
+    Deliberately returns `None` for "not there" rather than raising, because every caller is
+    asking whether a chart happens to declare something — `image.registry`, a per-service image
+    block — and absence is an ordinary answer rather than an error.
+    """
+    current = values
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current

--- a/.github/scripts/config_scaffold.py
+++ b/.github/scripts/config_scaffold.py
@@ -1,0 +1,1363 @@
+#!/usr/bin/env python3
+"""Generating a chart's configuration surface from the contract its image publishes.
+
+Every other script in this group *reads* a chart and holds it against a contract. This one runs in
+the other direction: given a contract, it writes the chart values, the template helpers, the
+declaration and the round-trip enrolment that satisfy it — so a new chart starts life bound to
+its image rather than acquiring the binding one gate failure at a time.
+
+`Surface` is the seam that makes this usable for a chart with no contract at all. Every renderer
+below takes one and branches on whether it carries a `Union`, so an image that publishes nothing
+gets the chassis and the workload and no assertion about its configuration — which is what
+`teamspeak` and `paperless-ngx` are. See that class for what the plain form deliberately omits.
+
+That direction is available because the contract already carries everything the mapping needs.
+Per key it states the configuration path, a JSON Schema constraint, the documentation the
+producer wrote, the default the binary compiles in, whether the key is required, whether it is a
+credential and whether a file may supply it. What a person adds by hand is the *judgement* — that
+a particular setting deserves a first-class value rather than living in the `config` escape
+hatch, that a credential belongs in a file rather than in the ConfigMap — and this module states
+each of those judgements as a rule rather than leaving them to be made once per chart.
+
+--------------------------------------------------------------------------------------------
+Why generating `# @config` markers here is not the thing `config_bindings.py` refuses
+--------------------------------------------------------------------------------------------
+
+`config_bindings.py` says, in bold, that nothing generates a marker: they are hand-written,
+because a generator would have to land in the same change as the format it depends on, and a
+generated marker on an existing chart asserts a mapping the reviewer did not write and cannot
+check against anything.
+
+Neither objection reaches this module, and the difference is which artefact is derived. On an
+existing chart the *value* is the fact and the marker is a claim about it — a generator would be
+guessing which of `telemetry.logLevel` and `logging.level` feeds `telemetry.log_level`, and a
+wrong guess reads exactly like a right one. Here the value does not exist yet: the key is the
+fact, and the value and its marker are emitted together from that one key by one rule. There is
+no prior mapping for the marker to be wrong about, because the marker *is* the mapping and the
+value was named to match it.
+
+The gate is unchanged either way. `just check-config-bindings` holds what comes out of here
+against the same contract, so a scaffold whose rules are wrong fails on the chart's first run and
+not in production.
+
+--------------------------------------------------------------------------------------------
+Where each contract key goes
+--------------------------------------------------------------------------------------------
+
+One rule per row, applied in order; the first that matches wins.
+
+| The key is...                     | Destination                        | Why                     |
+|-----------------------------------|------------------------------------|-------------------------|
+| `reserved`                        | nothing, plus an `unbound` entry   | the loader owns it      |
+| `secret`, and file-supplyable     | `secretData`, plus `unbound`       | never a ConfigMap       |
+| `secret`, not file-supplyable     | nothing, plus an `unbound` entry   | no safe channel exists  |
+| `structured`                      | a chart value typed `object`       | the tree is the value   |
+| anything else                     | a chart value, typed and defaulted | the ordinary case       |
+
+The credential rule is the one worth arguing with, so it is written down rather than assumed. A
+`secret: true` key is delivered as a *file* and never written into the rendered document, because
+a ConfigMap is readable by anything that can read the namespace and a bearer credential in one is
+a credential that has leaked. This repository's own charts do not all follow that rule —
+`netcup-offer-bot` projects `telemetry.sentry_dsn` into `config.toml` while keeping
+`discord.webhook_url` in a file, which is a judgement about how much a particular credential is
+worth. A generator has no way to make that judgement and the conservative direction is the only
+defensible default: moving one key from the Secret into the ConfigMap afterwards is a deliberate
+edit somebody signs, where the opposite mistake is silent.
+
+A key that is `secret` and *not* file-supplyable has no channel at all — `file_supplyable` is
+false for everything but `text`, so a secret integer could only be delivered through the document
+or the environment, and both are refused for a credential. It is written off with a reason saying
+exactly that, rather than quietly projected.
+
+--------------------------------------------------------------------------------------------
+What is deliberately not generated
+--------------------------------------------------------------------------------------------
+
+**A Service, an Ingress, a HTTPRoute, a PodMonitor or a PersistentVolumeClaim.** Whether the
+workload listens, on what, and whether anything should reach it is not in the contract — a
+`server.port` key says the binary can bind a port, not that this deployment wants a Service in
+front of it. Scaffolding one would put a template in the chart that nobody chose and that the
+first `just render` would have to be read to discover.
+
+**Prose.** The generated `README.md.gotmpl` carries section headings and a comment saying so. A
+chart description written by a generator is a description nobody has read, and helm-docs will
+happily render it into the published README.
+
+**`ci/` fixtures beyond the one.** `ct` needs a values file that installs; the interesting ones —
+a fixture with the network policy on, one with the ingress off — are per chart and per decision.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import config_bindings as cb
+import config_contract as cc
+import config_testgen as tg
+
+# The marker vocabulary, taken from the parser rather than spelt again. A scaffold writing
+# `@config` while the gate looked for something else would produce a chart that fails the moment
+# it is created, which is the one failure mode a scaffold cannot be allowed to have.
+MARKER = cb.MARKER
+
+# The only document format this scaffold can write. `common` ships a TOML renderer and nothing
+# else, so a chart whose image reads YAML or JSON would need a helper the library does not have —
+# and inventing one inside a generated `_helpers.tpl` puts an untested renderer in every chart
+# that uses it. Refused with a message naming the gap instead.
+FORMAT = "toml"
+
+# Where a generated file goes, relative to the chart directory.
+DECLARATION = "config-contract.yaml"
+ENROLMENT = "contract-tests.yaml"
+CONTRACTS = "contracts"
+
+# The `values.yaml` subtree the raw escape hatch lives under, matching what `config_testgen`
+# writes its probes into. Held as one name so the two cannot disagree about it.
+CONFIG_ROOT = tg.VALUES_ROOT
+
+# Column the `values.yaml` comments wrap at, matching the existing charts.
+WIDTH = 96
+
+
+class ScaffoldError(Exception):
+    """A contract, or a chart name, this scaffold cannot honestly turn into a chart."""
+
+
+# --------------------------------------------------------------------------------------------
+# Naming
+# --------------------------------------------------------------------------------------------
+
+_CHART_NAME = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
+
+
+def check_chart_name(name: str) -> None:
+    """Refuse a name Helm, Kubernetes or this repository's own tooling would reject later.
+
+    Checked here rather than left to `helm lint`, because everything this module writes embeds
+    the name — template helper names, the release selector in the declaration, the suite file
+    names — and a name that fails at `helm lint` fails after all of it is on disk.
+    """
+    if not _CHART_NAME.match(name):
+        raise ScaffoldError(
+            f"{name!r} is not a valid chart name: lower-case alphanumerics and hyphens, starting "
+            "and ending with an alphanumeric"
+        )
+
+
+def camel(segment: str) -> str:
+    """`check_interval_secs` as `checkIntervalSecs` — one contract path segment as a chart value.
+
+    The convention every chart here already follows, verified against all five that map values
+    onto a contract: `feed.check_interval_secs` is `feed.checkIntervalSecs`, `discord.webhook_url`
+    is `discord.webhookUrl`, and a segment with no underscore — `metrics.ip`, `metrics.port` — is
+    left exactly as it is.
+    """
+    head, *rest = segment.split("_")
+    return head + "".join(part[:1].upper() + part[1:] for part in rest)
+
+
+def values_path_for(path: str) -> str:
+    """The dotted chart value that carries one contract key."""
+    return ".".join(camel(segment) for segment in path.split("."))
+
+
+def env_prefix(union: cc.Union) -> str:
+    """The dialect prefix as `common.fileConfig.env` wants it: without the trailing separator.
+
+    The contract states `NETCUP_OFFER_BOT_` because that is what it prepends to a variable name;
+    the library partial appends the separator itself, so passing the contract's spelling through
+    would produce `NETCUP_OFFER_BOT__CONFIG`.
+    """
+    return union.prefix.rstrip("_")
+
+
+# --------------------------------------------------------------------------------------------
+# Planning
+# --------------------------------------------------------------------------------------------
+
+PROJECTED = "projected"
+SECRET_FILE = "secret-file"
+WRITTEN_OFF = "written-off"
+
+
+@dataclass(frozen=True)
+class Placement:
+    """One contract key, and what the scaffold does with it.
+
+    `values_path` is set for everything but a write-off — a credential still gets a chart value,
+    it simply carries into the Secret rather than into the document.
+    """
+
+    key: dict[str, Any]
+    where: str
+    values_path: str
+    reason: str = ""
+
+    @property
+    def path(self) -> str:
+        return str(self.key["path"])
+
+    @property
+    def marker_class(self) -> str:
+        return cb.STRUCTURED if self.key.get("text_form") == "structured" else cb.PROJECTION
+
+    @property
+    def optional(self) -> bool:
+        return not self.key.get("required")
+
+
+@dataclass
+class Plan:
+    """Every key of one document, sorted into where the generated chart puts it."""
+
+    projected: list[Placement] = field(default_factory=list)
+    secrets: list[Placement] = field(default_factory=list)
+    written_off: list[Placement] = field(default_factory=list)
+
+    @property
+    def all(self) -> list[Placement]:
+        return self.projected + self.secrets + self.written_off
+
+    @property
+    def required_projected(self) -> list[Placement]:
+        """Keys the image demands and the chart must therefore render a value for."""
+        return [item for item in self.projected if not item.optional]
+
+
+@dataclass(frozen=True)
+class Surface:
+    """A chart's configuration surface, and where the scaffold learnt it.
+
+    The seam that lets this module scaffold a chart for an image that publishes no contract. Two
+    shapes exist and every renderer below branches on exactly one question — whether `union` is
+    set — rather than on a flag threaded through from the caller:
+
+    **Contracted.** `union` is the merged contract and `plan` sorts its keys, so `values.yaml`
+    carries a block per setting with the marker that binds it, `_helpers.tpl` projects them into
+    the document, and the chart is enrolled in `check-config`, `check-config-bindings` and the
+    generated round trip.
+
+    **Plain.** No contract exists to read, so the scaffold asserts nothing about the image's
+    configuration: no `config` escape hatch, no `configMount`, no ConfigMap and no Secret. What is
+    left is everything that was never about the contract — the chassis, the workload, the network
+    policy, the service account — which is two thirds of every chart here and all of what
+    `teamspeak` and `paperless-ngx` are made of.
+
+    The plain form is deliberately *less* than the contracted one rather than the same thing with
+    empty parts. A `configMount` in a chart whose image does not read a mounted file is a value an
+    operator can set and nothing honours; an empty `derivedConfig` is a helper that looks like a
+    mapping and maps nothing. Both would be scaffolding somebody has to notice and delete.
+    """
+
+    union: cc.Union | None = None
+    plan: Plan = field(default_factory=Plan)
+
+    @property
+    def contracted(self) -> bool:
+        return self.union is not None
+
+    @property
+    def form(self) -> str:
+        """The template subdirectory this surface's chart is built from."""
+        return "contract" if self.contracted else "plain"
+
+    @property
+    def prefix(self) -> str:
+        """The environment prefix the image's loader owns, or an empty string when unknown."""
+        return self.union.prefix if self.union is not None else ""
+
+
+def from_contract(union: cc.Union) -> Surface:
+    """The contracted surface: every key of one document, sorted."""
+    return Surface(union=union, plan=plan_keys(union))
+
+
+def plain() -> Surface:
+    """The surface of a chart whose image publishes no contract."""
+    return Surface()
+
+
+def plan_keys(union: cc.Union) -> Plan:
+    """Sort one document's keys by the table in this module's docstring."""
+    plan = Plan()
+    for path in sorted(union.keys):
+        key = union.keys[path]
+        values_path = values_path_for(path)
+
+        if key.get("reserved"):
+            plan.written_off.append(
+                Placement(
+                    key,
+                    WRITTEN_OFF,
+                    "",
+                    "Reserved by the loader: the image sets it itself, so a chart value feeding "
+                    "it would be overwritten at boot and would read to an operator as a setting "
+                    "that does nothing.",
+                )
+            )
+            continue
+
+        if key.get("secret"):
+            if cc.file_supplyable(key):
+                plan.secrets.append(Placement(key, SECRET_FILE, values_path))
+            else:
+                plan.written_off.append(
+                    Placement(
+                        key,
+                        WRITTEN_OFF,
+                        "",
+                        f"A credential whose `text_form` is {key.get('text_form')!r}, so no file "
+                        "can supply it — only the configuration document or the environment can, "
+                        "and a bearer credential in a ConfigMap is readable by anything that can "
+                        "read the namespace. Surfacing it would mean choosing one of those two, "
+                        "which is a decision for whoever knows what this credential is worth.",
+                    )
+                )
+            continue
+
+        plan.projected.append(Placement(key, PROJECTED, values_path))
+
+    return plan
+
+
+# --------------------------------------------------------------------------------------------
+# Rendering `values.yaml`
+# --------------------------------------------------------------------------------------------
+
+
+def wrap(text: str, prefix: str, width: int = WIDTH) -> list[str]:
+    """Comment lines, wrapped, each carrying `prefix`. Paragraph breaks are collapsed.
+
+    A `docs` block is Rust doc-comment prose and routinely runs to several paragraphs; a values
+    description is one paragraph by helm-docs' convention, so the paragraphs are joined rather
+    than reproduced. The full text stays available through `just explain`, which is the command
+    for reading a contract.
+    """
+    words = " ".join(text.split()).split()
+    lines: list[str] = []
+    current = prefix.rstrip()
+    for word in words:
+        candidate = f"{current} {word}" if current.strip() != prefix.strip() else f"{prefix}{word}"
+        if len(candidate) > width and current.strip() != prefix.strip():
+            lines.append(current)
+            current = f"{prefix}{word}"
+        else:
+            current = candidate
+    if current.strip() != prefix.strip():
+        lines.append(current)
+    return lines
+
+
+def summary_of(key: dict[str, Any]) -> str:
+    """The first paragraph of a key's documentation, or a sentence naming the key.
+
+    Never empty: helm-docs renders `# --` descriptions into the published values table, and a
+    blank row there is worse than a plain one — it reads as a value nobody thought about.
+    """
+    docs = key.get("docs")
+    if isinstance(docs, str) and docs.strip():
+        return " ".join(docs.split("\n\n")[0].split())
+    return f"The `{key['path']}` setting."
+
+
+def schema_lines(key: dict[str, Any], indent: str) -> list[str]:
+    """The `@schema` block for one contract key, from its constraint.
+
+    Only the keywords the contract vocabulary already allows are copied, and they are copied
+    rather than translated: `constraint` is JSON Schema and so is an `@schema` block, so a
+    `minimum` means the same thing on both sides. A `structured` key is the exception — its
+    constraint describes the TOML *literal* the environment layer would carry, where the chart
+    value is the tree itself.
+    """
+    body: list[str] = []
+
+    if key.get("text_form") == "structured":
+        types = ["object"]
+        body = ["additionalProperties: true"]
+    else:
+        constraint = key.get("constraint") or {}
+        declared = constraint.get("type")
+        types = [str(name) for name in (declared if isinstance(declared, list) else [declared])
+                 if name is not None]
+        for keyword in ("enum", "const", "minimum", "maximum", "exclusiveMinimum",
+                        "exclusiveMaximum", "multipleOf", "minLength", "maxLength", "pattern"):
+            if keyword not in constraint:
+                continue
+            body.append(f"{keyword}: {_schema_scalar(constraint[keyword])}")
+
+    if not types:
+        # The constraint names no type. Rather than guess one, accept every JSON type — the
+        # contract is still the authority on the value, and `just check-config` holds the
+        # rendered document against it either way. A `@schema` block is not optional here: the
+        # marker lives inside one, and helm-schema emits no property for a value without one.
+        types = ["string", "integer", "boolean", "array", "object", "null"]
+
+    # An optional key is one the chart may legitimately leave unset, and the derived helper omits
+    # it rather than writing it empty — so `null` has to be a value the schema accepts.
+    if not key.get("required") and "null" not in types:
+        types.append("null")
+
+    # Type names are schema vocabulary, not data, so they are written bare. `null` is the one that
+    # has to be quoted: unquoted it is YAML's null, and the schema would then declare no type at
+    # all where it meant to declare the null type.
+    rendered = ", ".join("'null'" if name == "null" else name for name in types)
+    head = f"type: {rendered}" if len(types) == 1 else f"type: [{rendered}]"
+
+    return [f"{indent}# {line}" for line in [head, *body]]
+
+
+def _schema_scalar(value: Any) -> str:
+    """One JSON Schema keyword's value, as the YAML an `@schema` comment carries."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if value is None:
+        return "null"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, list):
+        return "[" + ", ".join(_schema_scalar(item) for item in value) + "]"
+    return _quoted(str(value))
+
+
+def _quoted(text: str) -> str:
+    """A YAML double-quoted scalar. Used wherever a value could be read as something else."""
+    escaped = text.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def default_for(key: dict[str, Any]) -> Any:
+    """The value the generated chart writes for one key.
+
+    Three cases, and only the first is a real answer:
+
+    **The image publishes a default.** `default_value` is that default already parsed, which is
+    exactly what a values file wants. Written through, so the chart's default *is* the binary's
+    and the two cannot drift.
+
+    **Optional, with no default.** `null`, and the derived helper wraps the key in `with` — so
+    nothing is written into the document and the binary falls back to its compiled default. That
+    is what "unset" has to mean; writing an empty string instead would *supply* the key.
+
+    **Required, with no default.** The image demands a value and names none, so the chart has to
+    invent one and every invented value is wrong. What it must not be is invalid: a required
+    integer bounded at `minimum: 1` cannot be written as `0`, because the chart would then fail
+    `just check-config` on its first run for a reason that reads like a bug in the gate. So the
+    value is drawn from `config_testgen`'s candidate walk — the same constraint-satisfying search
+    the round-trip probes use — and every key that needed one is listed in the scaffolder's
+    closing output as something to replace with a value somebody chose.
+    """
+    if key.get("default_value") is not None:
+        return key["default_value"]
+
+    if not key.get("required"):
+        return None
+
+    if key.get("text_form") == "structured":
+        return {}
+
+    candidate = tg.satisfying(key)
+    if candidate is not None:
+        return candidate
+
+    constraint = key.get("constraint") or {}
+    declared = constraint.get("type")
+    if isinstance(declared, list):
+        declared = declared[0] if declared else None
+    return {"integer": 0, "number": 0, "boolean": False, "array": [], "object": {}}.get(
+        str(declared), ""
+    )
+
+
+def invented(plan: Plan) -> list[Placement]:
+    """The surfaced keys whose value the scaffold chose rather than read from the contract.
+
+    Reported rather than hidden. A required key with no published default is the one place this
+    generator has to guess, and a guess nobody was told about is the same defect as a missing key.
+    """
+    return [
+        item
+        for item in plan.projected
+        if not item.optional and item.key.get("default_value") is None
+    ]
+
+
+def values_scalar(value: Any) -> str:
+    """One default as it is written into `values.yaml`."""
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, list):
+        return "[]" if not value else "[" + ", ".join(values_scalar(item) for item in value) + "]"
+    if isinstance(value, dict):
+        return "{}"
+    return _quoted(str(value))
+
+
+def marker_line(placement: Placement, indent: str) -> str:
+    """The one line that binds a chart value to a contract key.
+
+    Written inside the `@schema` block, which is why it reads as a comment within a comment: the
+    text between the delimiters is the schema and is parsed as YAML, so a YAML comment there is
+    discarded by the only parser that reads it. `config_bindings.py` records why that is the one
+    position both generators ignore.
+    """
+    suffix = " optional" if placement.optional else ""
+    return f"{indent}# # {MARKER} {placement.marker_class} {placement.path}{suffix}"
+
+
+def description_lines(placement: Placement, indent: str) -> list[str]:
+    """The helm-docs description for one value: `# --` on the first line, `#` on the rest.
+
+    The marker belongs to the description as a whole and helm-docs reads it that way — repeating
+    it on every wrapped line puts a literal `--` in the middle of the rendered sentence.
+    """
+    key = placement.key
+    summary = summary_of(key).rstrip(".")
+    text = f"{summary} (`{key['path']}`)."
+    if placement.where == SECRET_FILE:
+        text += f" Delivered as the secrets-directory file `{_file_name(placement)}`."
+
+    wrapped = wrap(text, "", WIDTH - len(indent) - 5)
+    return [f"{indent}# -- {wrapped[0]}"] + [f"{indent}# {line}" for line in wrapped[1:]]
+
+
+def value_block(placement: Placement, indent: str = "") -> list[str]:
+    """One contract key as the `values.yaml` block that feeds it."""
+    leaf = placement.values_path.split(".")[-1]
+
+    lines = [f"{indent}# @schema"]
+    # A credential gets no marker, and the two facts that make that right are worth keeping
+    # together: every marker class names a way a value reaches the *configuration document*, and a
+    # credential delivered as a file never reaches it. `check-config-bindings` says the same thing
+    # from the other side — it refuses a key that is both bound by a marker and written off in
+    # `unbound`, which a marker here would make every credential.
+    if placement.where != SECRET_FILE:
+        lines.append(marker_line(placement, indent))
+    lines.extend(schema_lines(placement.key, indent))
+    lines.append(f"{indent}# @schema")
+    lines.extend(description_lines(placement, indent))
+
+    value = default_for(placement.key) if placement.where != SECRET_FILE else ""
+    if isinstance(value, dict) and not value:
+        lines.append(f"{indent}{leaf}: {{}}")
+    else:
+        lines.append(f"{indent}{leaf}: {values_scalar(value)}")
+    return lines
+
+
+def tree_of(placements: list[Placement]) -> dict[str, Any]:
+    """Group placements into the nested shape their chart values have.
+
+    A leaf is a `Placement`; a branch is a dict. Sorted at every level, so the generated file is a
+    property of the contract rather than of the order the keys happened to arrive in.
+    """
+    tree: dict[str, Any] = {}
+    for placement in placements:
+        segments = placement.values_path.split(".")
+        node = tree
+        for segment in segments[:-1]:
+            existing = node.get(segment)
+            if isinstance(existing, Placement):
+                raise ScaffoldError(
+                    f"the contract key {placement.path!r} needs the chart value "
+                    f"{'.'.join(segments)!r}, but {segment!r} is already a leaf value on the way "
+                    "there; the two cannot both exist and this mapping has to be written by hand"
+                )
+            node = node.setdefault(segment, {})
+        node[segments[-1]] = placement
+    return tree
+
+
+def render_tree(tree: dict[str, Any], indent: str = "") -> list[str]:
+    """The values blocks for one level of the tree, deepest structure last."""
+    lines: list[str] = []
+    for name in sorted(tree):
+        node = tree[name]
+        if lines:
+            lines.append("")
+        if isinstance(node, Placement):
+            lines.extend(value_block(node, indent))
+        else:
+            lines.append(f"{indent}# @schema")
+            lines.append(f"{indent}# additionalProperties: true")
+            lines.append(f"{indent}# @schema")
+            lines.append(f"{indent}{name}:")
+            lines.extend(render_tree(node, indent + "  "))
+    return lines
+
+
+def render_values(
+    chart: str,
+    surface: Surface,
+    repository: str,
+    tag: str,
+    chassis: str,
+    document_key: str,
+) -> str:
+    """The whole `values.yaml`: the image, the configuration surface, the chassis.
+
+    Ordered by how often it is edited rather than alphabetically. The image and the settings the
+    contract declares are what an operator opens the file for; the chassis is thirty blocks that
+    are the same in every chart and belongs after them, exactly where every existing chart already
+    puts it.
+
+    A plain surface stops after the image. Everything between it and the chassis — the settings,
+    `existingSecret`, `config`, `configExtraToml`, `configMount` — describes a loader this chart's
+    image is not known to have, and a value nothing honours is worse than an absent one.
+    """
+    plan = surface.plan
+    prefix = surface.prefix
+    lines = [
+        "# vim: set ft=yaml:",
+        "# yaml-language-server: $schema=values.schema.json",
+        "",
+        "# @schema",
+        "# additionalProperties: true",
+        "# @schema",
+        "image:",
+        "  # @schema",
+        "  # type: string",
+        "  # @schema",
+        "  # -- Registry host. Empty means Docker Hub.",
+        '  registry: ""',
+        "",
+        "  # @schema",
+        "  # type: string",
+        "  # @schema",
+        "  # -- The container image repository.",
+        f"  repository: {repository}",
+        "",
+        "  # @schema",
+        "  # type: string",
+        "  # @schema",
+        "  # -- The container image tag. Defaults to the chart's `appVersion` when empty.",
+        # Always quoted. A tag like `8.0` is a YAML float unquoted, and the chart's own schema
+        # types this as a string — so an unquoted numeric tag fails `helm template` on the
+        # scaffold's first render, for a reason that reads like a bug in the schema.
+        f"  tag: {_quoted(tag)}",
+        "",
+        "  # @schema",
+        '  # enum: ["", Always, IfNotPresent, Never]',
+        "  # @schema",
+        "  # -- The image pull policy. Empty resolves automatically from the tag/digest.",
+        '  pullPolicy: ""',
+        "",
+        "# @schema",
+        "# type: array",
+        "# @schema",
+        "# -- Optional image pull secrets for private registries",
+        "imagePullSecrets: []",
+    ]
+
+    if not surface.contracted:
+        lines += [
+            "",
+            "# " + "-" * (WIDTH - 2),
+        ]
+        lines.extend(
+            wrap(
+                "This image publishes no configuration contract, so nothing below was derived "
+                "from one and nothing here is held against one. Add the values the workload needs "
+                "in this section — with an `@schema` block each, which every gate in this "
+                "repository expects and `values.schema.json` is generated from.",
+                "# ",
+            )
+        )
+        lines += [
+            "# " + "-" * (WIDTH - 2),
+            "",
+        ]
+        return "\n".join(lines) + "\n" + chassis.strip() + "\n"
+
+    # One tree over the settings and the credentials together, rather than a section each. They
+    # share a namespace — `telemetry.log_level` is ordinary and `telemetry.sentry_dsn` is a
+    # credential — so two sections would emit `telemetry:` twice and YAML would silently keep only
+    # the second, dropping every value in the first. Which channel carries a value is said in its
+    # own description instead, where it stays true however the keys are grouped.
+    surfaced = plan.projected + plan.secrets
+    if surfaced:
+        lines.append("")
+        lines.append("# " + "-" * (WIDTH - 2))
+        lines.extend(
+            wrap(
+                f"The settings the image reads. `just explain {chart}` describes each one in full "
+                "— its accepted values, its default, and which spelling reaches it.",
+                "# ",
+            )
+        )
+        lines.append("#")
+        lines.extend(
+            wrap(
+                "A value marked as delivered through the secrets directory is written into a "
+                "Secret rather than into the ConfigMap, because a ConfigMap is readable by "
+                "anything that can read the namespace. `existingSecret` below replaces all of "
+                "them at once.",
+                "# ",
+            )
+        )
+        lines.append("# " + "-" * (WIDTH - 2))
+        lines.append("")
+        lines.extend(render_tree(tree_of(surfaced)))
+
+    lines.append("")
+    lines.append("# @schema")
+    lines.append("# type: string")
+    lines.append("# @schema")
+    lines.extend(
+        wrap(
+            "Name of an existing Secret carrying the credentials, keeping them out of values.yaml "
+            "and out of the Helm release object. **Its keys are configuration paths, not "
+            f"free-form names**: `{_example_secret_file(plan)}`, because the file name is what "
+            "the loader parses. Set, the chart renders no Secret of its own and the credential "
+            "values above are ignored.",
+            "# -- ",
+        )
+    )
+    lines.append('existingSecret: ""')
+
+    lines.extend(
+        [
+            "",
+            "# @schema",
+            "# type: object",
+            "# additionalProperties: true",
+            "# @schema",
+        ]
+    )
+    lines.extend(
+        wrap(
+            f"Extra configuration, expressed as the {FORMAT.upper()} tree the image reads "
+            f"(`{_example_key(plan)}`, ...). Merged over everything the chart derives from the "
+            "values above, so it can both extend and override them. Rendered into the mounted "
+            "ConfigMap — never into the environment, which the loader refuses to combine with a "
+            "file.",
+            "# -- ",
+        )
+    )
+    lines.append(f"{CONFIG_ROOT}: {{}}")
+
+    lines.extend(
+        [
+            "",
+            "# @schema",
+            "# type: string",
+            "# @schema",
+            "# -- Verbatim TOML appended after the rendered configuration. The escape hatch for",
+            "# anything the chart's TOML renderer cannot express, notably arrays of tables.",
+            'configExtraToml: ""',
+            "",
+            "# @schema",
+            "# additionalProperties: true",
+            "# @schema",
+            "configMount:",
+            "  # @schema",
+            "  # type: string",
+            "  # @schema",
+            f"  # -- Directory the rendered `{document_key}` is mounted at, passed as",
+            f"  # `{prefix}CONFIG`.",
+            f"  configDir: /etc/{chart}/config",
+            "",
+            "  # @schema",
+            "  # type: string",
+            "  # @schema",
+            "  # -- Directory the credential files are mounted at, passed as",
+            f"  # `{prefix}SECRETS_DIR`.",
+            f"  secretsDir: /etc/{chart}/secrets",
+            "",
+        ]
+    )
+
+    return "\n".join(lines) + "\n" + chassis.strip() + "\n"
+
+
+def _example_secret_file(plan: Plan) -> str:
+    """A real secrets-file name from this contract, for the `existingSecret` documentation."""
+    for placement in plan.secrets:
+        name = placement.key.get("secrets_file")
+        if name:
+            return str(name)
+    return "a__b"
+
+
+def _example_key(plan: Plan) -> str:
+    """A real configuration path from this contract, for the `config` documentation."""
+    return plan.projected[0].path if plan.projected else "section.setting"
+
+
+# --------------------------------------------------------------------------------------------
+# Rendering `templates/_helpers.tpl`
+# --------------------------------------------------------------------------------------------
+
+
+def toml_tree(placements: list[Placement]) -> dict[str, Any]:
+    """The contract paths of these placements as a nested tree, leaves being the placements."""
+    tree: dict[str, Any] = {}
+    for placement in placements:
+        segments = placement.path.split(".")
+        node = tree
+        for segment in segments[:-1]:
+            node = node.setdefault(segment, {})
+        node[segments[-1]] = placement
+    return tree
+
+
+def _derived_lines(tree: dict[str, Any], indent: str = "") -> list[str]:
+    """The YAML the `derivedConfig` helper emits, which `common.configToml` turns into TOML.
+
+    An optional setting is wrapped in `with` rather than written empty, and that distinction is
+    the whole reason this helper is generated rather than left to a per-chart hand. To the loader
+    an empty string is a *supplied* value: writing `sentry_dsn = ""` configures Sentry with a
+    blank DSN, which is not what an operator who left the value unset meant. `with` treats every
+    falsey value as absent, so an unset optional key never reaches the document at all.
+    """
+    lines: list[str] = []
+    for name in sorted(tree):
+        node = tree[name]
+        if not isinstance(node, Placement):
+            lines.append(f"{indent}{name}:")
+            lines.extend(_derived_lines(node, indent + "  "))
+            continue
+
+        reference = f".Values.{node.values_path}"
+        structured = node.key.get("text_form") == "structured"
+        bare = (node.key.get("constraint") or {}).get("type") in ("integer", "number", "boolean")
+
+        if node.optional:
+            lines.append(f"{indent}{{{{- with {reference} }}}}")
+            if structured:
+                lines.append(f"{indent}{name}:")
+                lines.append(f"{indent}  {{{{- toYaml . | nindent {len(indent) + 2} }}}}")
+            elif bare:
+                lines.append(f"{indent}{name}: {{{{ . }}}}")
+            else:
+                lines.append(f"{indent}{name}: {{{{ . | quote }}}}")
+            lines.append(f"{indent}{{{{- end }}}}")
+        elif structured:
+            lines.append(f"{indent}{name}:")
+            lines.append(f"{indent}  {{{{- toYaml {reference} | nindent {len(indent) + 2} }}}}")
+        elif bare:
+            lines.append(f"{indent}{name}: {{{{ {reference} }}}}")
+        else:
+            lines.append(f"{indent}{name}: {{{{ {reference} | quote }}}}")
+    return lines
+
+
+def _comment(*lines: str) -> str:
+    """A Go-template comment block, wrapped, in the house style."""
+    body: list[str] = []
+    for line in lines:
+        if not line:
+            body.append("")
+        else:
+            body.extend(wrap(line, "", WIDTH))
+    return "{{/*\n" + "\n".join(body) + "\n*/}}\n"
+
+
+def _file_name(placement: Placement) -> str:
+    """The secrets-directory file name one credential is read from.
+
+    Taken from the contract rather than derived from the path: `secrets_file` is what the producer
+    published, and a chart that computed its own spelling would be right until the day the
+    producer changed a separator.
+    """
+    name = placement.key.get("secrets_file")
+    if not name:
+        raise ScaffoldError(
+            f"the contract key {placement.path!r} is `secret: true` and declares no "
+            "`secrets_file`, so there is no file name to deliver it under"
+        )
+    return str(name)
+
+
+def render_helpers(chart: str, surface: Surface) -> str:
+    """`templates/_helpers.tpl`: the partials a chart of this shape defines.
+
+    Contracted: `derivedConfig` renders the chart's own values as the tree the image reads,
+    `effectiveConfig` merges the operator's raw `config` over it so the escape hatch can both
+    extend and override, `configToml` adds the verbatim appendix, `secretData` names each
+    credential by the file name the loader parses, `secretKeys` lists those names for the podspec,
+    and `validateValues` refuses a render that could only produce a container which fails at boot.
+
+    Plain: none of them. Every one describes a loader nothing here knows this image has, and an
+    empty `derivedConfig` is a helper that looks like a mapping and maps nothing. What is emitted
+    instead is a comment saying where a hand-written helper goes — a file rather than nothing, so
+    the first one is an edit and not a decision about where partials live in this repository.
+    """
+    if not surface.contracted:
+        return (
+            _comment(
+                f"Template partials for {chart}.",
+                "",
+                "Empty because this chart's image publishes no configuration contract, so there "
+                "was nothing to derive. Anything the templates need to compute — a volume that "
+                "resolves three ways, a derived configuration document, a guard that refuses an "
+                "impossible render — belongs here rather than inline, so the templates stay "
+                "readable and the computation is testable on its own.",
+            )
+        )
+
+    union = surface.union
+    plan = surface.plan
+    parts: list[str] = []
+
+    derived = _derived_lines(toml_tree(plan.projected))
+    parts.append(
+        _comment(
+            "The configuration this chart derives from its own first-class values, as the tree "
+            "the image reads.",
+            "",
+            "Optional settings are wrapped in `with` rather than written empty. To the loader an "
+            "empty value is a *supplied* value, so writing one would configure the setting blank "
+            "rather than leaving the binary on its compiled default — which is what an operator "
+            "who set nothing meant.",
+        )
+        + f'{{{{- define "{chart}.derivedConfig" -}}}}\n'
+        + ("\n".join(derived) + "\n" if derived else "")
+        + "{{- end -}}\n"
+    )
+
+    parts.append(
+        _comment(
+            "The configuration that actually reaches the image: the derived tree with the "
+            "operator's own `config` tree merged over it, so `config` can both extend and "
+            "override the values above.",
+            "",
+            "Not included: `configExtraToml`, which is appended verbatim and never parsed.",
+        )
+        + f'{{{{- define "{chart}.effectiveConfig" -}}}}\n'
+        + f'{{{{- $derived := include "{chart}.derivedConfig" . | fromYaml -}}}}\n'
+        + f"{{{{- toYaml (mergeOverwrite $derived (deepCopy (.Values.{CONFIG_ROOT} "
+        + "| default dict))) -}}\n"
+        + "{{- end -}}\n"
+    )
+
+    parts.append(
+        _comment(
+            "The complete configuration document: the effective tree, then the verbatim escape "
+            "hatch."
+        )
+        + f'{{{{- define "{chart}.configToml" -}}}}\n'
+        + f'{{{{- $config := include "{chart}.effectiveConfig" . | fromYaml -}}}}\n'
+        + '{{- include "common.configToml" (dict "ctx" . "maps" (list $config)) -}}\n'
+        + "{{- end -}}\n"
+    )
+
+    separator = union.dialect.get("nesting_separator", "__")
+    secret_lines = [
+        f"{_file_name(item)}: {{{{ .Values.{item.values_path} | quote }}}}"
+        for item in plan.secrets
+    ]
+    parts.append(
+        _comment(
+            "The credentials this chart manages, each keyed by the file name the loader reads it "
+            f"from: a configuration path with `{separator}` for nesting and no dots, because a "
+            "`.` in the name is refused rather than treated as a separator.",
+        )
+        + f'{{{{- define "{chart}.secretData" -}}}}\n'
+        + ("\n".join(secret_lines) + "\n" if secret_lines else "")
+        + "{{- end -}}\n"
+    )
+
+    parts.append(
+        _comment(
+            "The secret file names this pod projects, as a YAML list. Parse with `fromYamlArray`."
+        )
+        + f'{{{{- define "{chart}.secretKeys" -}}}}\n'
+        + f'{{{{- $data := include "{chart}.secretData" . | fromYaml -}}}}\n'
+        + '{{- include "common.fileConfig.secretKeys" (dict "ctx" . "data" $data) -}}\n'
+        + "{{- end -}}\n"
+    )
+
+    parts.append(_validate_values(chart, plan))
+    return "\n".join(parts)
+
+
+def _validate_values(chart: str, plan: Plan) -> str:
+    """A guard refusing a render that could only produce a container which fails at boot.
+
+    Generated only for credentials, and checked against the *projected key list* rather than
+    against the values: an `existingSecret` supplies the file without the chart being able to see
+    inside it, and a credential the chart cannot see is not the same as one that is missing.
+
+    Required non-secret keys are deliberately not guarded. They carry a default in `values.yaml` —
+    the image's own where it publishes one, a typed empty otherwise — so a render always produces
+    a value for them, and `just check-config` is what holds that value against the contract. A
+    guard would only fire on a values file that had explicitly nulled one, which an operator may
+    do on purpose when a sibling layer supplies it.
+    """
+    required = [item for item in plan.secrets if not item.optional]
+
+    if not required:
+        return (
+            _comment(
+                "No render is refused today: every credential this image declares is optional. "
+                "Kept as a partial so the `configmap.yaml` include has something to call, and so "
+                "the first required credential is one condition rather than a new file.",
+            )
+            + f'{{{{- define "{chart}.validateValues" -}}}}\n{{{{- end -}}}}\n'
+        )
+
+    conditions = "".join(
+        f'{{{{- if not (has "{_file_name(item)}" $projected) -}}}}\n'
+        f'{{{{- fail (printf "\\n\\nVALUES VALIDATION FAILED for chart %q:\\n  - '
+        f"{item.values_path} is required unless existingSecret supplies "
+        f'`{_file_name(item)}`\\n" .Chart.Name) -}}}}\n'
+        "{{- end -}}\n"
+        for item in required
+    )
+    return (
+        _comment(
+            "Refuse a render that could only produce a container which fails at boot.",
+            "",
+            "Checked against the projected key list rather than against the values themselves, so "
+            "an `existingSecret` counts — the chart cannot see inside one, and a credential it "
+            "cannot see is not the same as a credential that is missing.",
+        )
+        + f'{{{{- define "{chart}.validateValues" -}}}}\n'
+        + f'{{{{- $projected := include "{chart}.secretKeys" . | fromYamlArray -}}}}\n'
+        + conditions
+        + "{{- end -}}\n"
+    )
+
+
+# --------------------------------------------------------------------------------------------
+# Rendering `config-contract.yaml`
+# --------------------------------------------------------------------------------------------
+
+
+def render_declaration(
+    chart: str, document: str, contract_file: str, document_key: str, plan: Plan
+) -> str:
+    """The declaration `just check-config` and `just check-config-bindings` read.
+
+    The selector is `app.kubernetes.io/instance`, matching every existing declaration, and the
+    reason is worth repeating where a reader of the generated file will see it: that label is
+    `.Release.Name`, the one identifier neither `nameOverride` nor `fullnameOverride` can move.
+
+    `bindings: true` is written because the scaffold emits a marker for every key it surfaces and
+    an `unbound` entry for every key it does not, so the chart is enrolled and complete from its
+    first commit rather than joining the gate later.
+    """
+    lines = [
+        "# vim: set ft=yaml:",
+        "",
+        "# What this chart's rendered configuration must satisfy, and which image decides that.",
+        "#",
+        "# Scaffolded by `just new-chart`. Per-chart and self-describing, so adding a chart never",
+        "# edits a central file. `just check-config` reads this, unions the contracts of every",
+        "# image listed, and validates the rendered ConfigMap, the container environment and the",
+        "# mounted secret file names against the result.",
+        "",
+        "# Whether `just check-config-bindings` holds this chart's values against the keys below.",
+        "#",
+        "# Declared rather than inferred from the chart carrying markers: a chart that loses them",
+        "# would otherwise drop out of that gate's report without a word.",
+        "bindings: true",
+    ]
+
+    if plan.written_off or plan.secrets:
+        lines += [
+            "",
+            "# Contract keys no chart value binds, each group with the reason it does not.",
+            "#",
+            "# Chart-level: a key nothing surfaces is unsurfaced in every document that declares",
+            "# it. `documents:` would narrow an entry where that is untrue.",
+            "unbound:",
+        ]
+        for group in _write_off_groups(plan):
+            lines.append("  - keys:")
+            lines.extend(f"      - {path}" for path in group[0])
+            lines.append("    reason: >-")
+            lines.extend(wrap(group[1], "      ", WIDTH))
+
+    lines += [
+        "",
+        "documents:",
+        f"  - name: {document}",
+        "",
+        "    # Where the rendered document is, in the output of `helm template`.",
+        "    #",
+        "    # Matched by label rather than by rendered name, and by `app.kubernetes.io/instance`:",
+        "    # that label is `.Release.Name`, the one identifier neither `nameOverride` nor",
+        "    # `fullnameOverride` can move. `just render` names the release after the chart, so",
+        "    # the value below is what every rendered pair carries. A selector matching zero or",
+        "    # several objects is reported rather than resolved.",
+        "    source:",
+        "      kind: ConfigMap",
+        f"      selector: {{ app.kubernetes.io/instance: {chart} }}",
+        f"      key: {document_key}",
+        f"      format: {FORMAT}",
+        "",
+        "    # Every binary that reads this document. One image here, so the union is the",
+        "    # identity.",
+        "    images:",
+        "      - values: image",
+        f"        contract: {contract_file}",
+        "",
+        "    # The pods that mount it, for the environment and secret-file gates.",
+        "    consumers:",
+        f"      - workload: {{ kind: Deployment, selector: {{ app.kubernetes.io/instance: {chart} }} }}",
+        f"        containers: [{chart}]",
+        "",
+        "    # Pairs this document is not fully checked for, each with a reason.",
+        "    exempt: []",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _write_off_groups(plan: Plan) -> list[tuple[list[str], str]]:
+    """Every unsurfaced key, grouped by the reason it is unsurfaced.
+
+    Grouped rather than listed one entry per key for the reason `config_declaration.Unbound`
+    records: `tankovault` has 127 of them, and one entry each turned a handful of sentences into
+    several hundred lines. The keys are still written out individually inside the group, so an
+    image release that adds one turns the gate red until somebody puts it in a list on purpose.
+    """
+    reasons: dict[str, list[str]] = {}
+
+    for item in plan.secrets:
+        reason = (
+            "Delivered as a file in the secrets directory — from the Secret this chart renders, "
+            f"or from `existingSecret` under the file name `{_file_name(item)}` — and never "
+            "written into the configuration document, because a credential in a ConfigMap is "
+            f"readable by anything that can read the namespace. `{item.values_path}` is the value "
+            "that carries it, so the binding does exist; it simply does not run through the "
+            "document the markers describe. `just check-config-secrets` is what reconciles that "
+            "channel, and it does it from the rendered manifests rather than from a comment."
+        )
+        reasons.setdefault(reason, []).append(item.path)
+
+    for item in plan.written_off:
+        reasons.setdefault(item.reason, []).append(item.path)
+
+    return [(sorted(paths), reason) for reason, paths in reasons.items()]
+
+
+# --------------------------------------------------------------------------------------------
+# Rendering `contract-tests.yaml`
+# --------------------------------------------------------------------------------------------
+
+
+def render_enrolment(chart: str, document: str, plan: Plan) -> str:
+    """The round-trip enrolment, with a prerequisite for every credential the render demands.
+
+    A prerequisite is a chart value every generated case has to carry before the chart will render
+    at all, and the only ones this scaffold knows of are the credentials `validateValues` guards.
+    Nothing here may name a path under `config`: a prerequisite is never dropped for the case it
+    collides with, the way a baseline is, so one written into the tree the cases probe could supply
+    the very value a case exists to prove the chart delivered. The generator refuses one outright.
+    """
+    required = [item for item in plan.secrets if not item.optional]
+
+    lines = [
+        "# vim: set ft=yaml:",
+        "",
+        "# Enrols this chart in the generated configuration round-trip suites.",
+        "#",
+        "# `just check-config` proves the rendered document satisfies the image's contract. It",
+        "# cannot prove the round trip: that a setting written into `config` arrives in that",
+        "# document, at the path the image reads it from, carrying the value that was asked for.",
+        "# A document missing a setting entirely satisfies the contract perfectly — every key it",
+        "# does contain is legal — so a typo in a template helper passes every gate and the",
+        "# container runs on a compiled default nobody chose.",
+        "#",
+        "# `just contract-tests` reads this file and `config-contract.yaml`, and writes one suite",
+        "# per declared document under `tests/`. The presence of this file is the enrolment.",
+        "documents:",
+        f"  - name: {document}",
+    ]
+
+    if not required:
+        lines += [
+            "",
+            "    # No `prerequisites` and no `baseline`: this chart renders without any value",
+            "    # being set, so every generated case can stand on the chart's own defaults.",
+        ]
+        return "\n".join(lines) + "\n"
+
+    lines += [
+        "",
+        "    # The chart values every generated case carries. This chart's `validateValues`",
+        "    # fails the template before a ConfigMap exists for any case to assert against, so",
+        "    # there is no case here that can do without them.",
+        "    #",
+        "    # Flat dotted paths, exactly as the helm-unittest `set` block they become spells",
+        "    # them. Nothing here may name a path under `config`.",
+        "    prerequisites:",
+        "      values:",
+    ]
+    for item in required:
+        lines.append(f"        {item.values_path}: {values_scalar(_probe_credential(item))}")
+
+    lines += ["", "      reason: >-"]
+    lines.extend(
+        wrap(
+            f"`{chart}.validateValues` refuses a render that projects no "
+            + ", ".join(f"`{_file_name(item)}`" for item in required)
+            + " file, and it runs from `configmap.yaml`, so without one there is no document for "
+            "any case to assert against. The guard reads the projected key list rather than the "
+            "value, so `existingSecret` would satisfy it as well; the first-class value is used "
+            "instead because it keeps the enrolment to one line and leaves the chart's Secret "
+            "rendering on the path every other case exercises. These occupy `secret: true` "
+            "contract keys, which the generator refuses to invent a probe for on the grounds that "
+            "a credential-shaped value in a test file is a credential — so they are written here "
+            "rather than synthesised, and the values are placeholders that can never authenticate "
+            "anywhere.",
+            "        ",
+            WIDTH,
+        )
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _probe_credential(placement: Placement) -> str:
+    """A placeholder for a required credential that cannot authenticate anywhere.
+
+    `.invalid` is reserved by RFC 2606 and can never resolve, so a value built on it is inert
+    wherever it ends up — which is the property that makes writing one into a committed test file
+    defensible at all.
+    """
+    constraint = placement.key.get("constraint") or {}
+    if "pattern" in constraint:
+        raise ScaffoldError(
+            f"the required credential {placement.path!r} constrains its text with a pattern, so a "
+            "placeholder cannot be invented for it; write the `prerequisites` entry by hand"
+        )
+    return f"scaffolded-placeholder.{placement.path.replace('.', '-')}.invalid"
+
+
+# --------------------------------------------------------------------------------------------
+# Rendering the fixtures
+# --------------------------------------------------------------------------------------------
+
+
+def render_ci_values(chart: str, surface: Surface) -> str:
+    """`ci/test-values.yaml`: the least a fixture has to set for `ct install` to get a running pod.
+
+    Only the credentials the render guard demands. Everything else has a default — the image's own
+    where the contract publishes one — and a fixture that restated those defaults would be a
+    second place they are written, drifting the first time one of them changed.
+
+    A plain chart has no guard and no contract to read a default out of, so the fixture is empty
+    and says so. `ct` needs one file; what belongs in it is the first deliberate deviation from
+    the chart's defaults, and only the chart's author knows what that is.
+    """
+    if not surface.contracted:
+        return (
+            f"# The default values install {chart} as they are.\n"
+            "#\n"
+            "# This chart's image publishes no configuration contract, so nothing here was\n"
+            "# derived from one. `ct` needs at least one fixture, and this is the place to put\n"
+            "# the first deliberate deviation from the chart's defaults.\n"
+            "{}\n"
+        )
+
+    required = [item for item in surface.plan.secrets if not item.optional]
+    if not required:
+        return (
+            f"# The default values install {chart} as they are: every setting the image requires\n"
+            "# carries a default and every credential it declares is optional. This file exists\n"
+            "# because `ct` needs at least one fixture, and it is the place to put the first\n"
+            "# deliberate deviation from the defaults.\n"
+            "{}\n"
+        )
+
+    lines = [
+        "# The credentials this chart's render guard demands, and nothing else.",
+        "#",
+        "# Everything else has a default — the image's own where the contract publishes one — and",
+        "# restating those here would be a second place they are written.",
+        "#",
+        "# `.invalid` is reserved by RFC 2606 and can never resolve, so these values are inert",
+        "# wherever the installed pod ends up sending them.",
+        "",
+    ]
+    tree: dict[str, Any] = {}
+    for item in required:
+        node = tree
+        segments = item.values_path.split(".")
+        for segment in segments[:-1]:
+            node = node.setdefault(segment, {})
+        node[segments[-1]] = _probe_credential(item)
+    lines.extend(_plain_yaml(tree))
+    return "\n".join(lines) + "\n"
+
+
+def _plain_yaml(tree: dict[str, Any], indent: str = "") -> list[str]:
+    """A nested mapping of scalars as YAML. Enough for a fixture; not a general emitter."""
+    lines: list[str] = []
+    for name in sorted(tree):
+        node = tree[name]
+        if isinstance(node, dict):
+            lines.append(f"{indent}{name}:")
+            lines.extend(_plain_yaml(node, indent + "  "))
+        else:
+            lines.append(f"{indent}{name}: {values_scalar(node)}")
+    return lines
+
+
+def render_unit_test(chart: str, document_key: str, plan: Plan) -> str:
+    """A first hand-written suite: the ConfigMap renders, and it is the document it claims to be.
+
+    Deliberately thin, and deliberately not overlapping the generated round-trip suite. That one
+    proves every contract key arrives at the path the image reads it from, key by key, and
+    regenerates when the contract moves. What it cannot assert is the shape of the object around
+    the document — that a ConfigMap exists at all, that it carries the chart's labels, that the
+    escape hatch reaches the file — because none of that is in the contract. This is where those
+    go, and where a person adds the assertions only they know are worth making.
+    """
+    required = [item for item in plan.secrets if not item.optional]
+    set_block = ""
+    if required:
+        set_block = "\n".join(
+            [
+                "    set:",
+                *(
+                    f"      {item.values_path}: {values_scalar(_probe_credential(item))}"
+                    for item in required
+                ),
+            ]
+        )
+
+    lines = [
+        f"suite: {chart} configmap",
+        "templates:",
+        "  - configmap.yaml",
+        "",
+        "# Scaffolded by `just new-chart`, and yours to extend. The generated",
+        f"# `contract_roundtrip_*_test.yaml` beside it proves each contract key arrives at the",
+        "# path the image reads it from; this file is for everything the contract cannot say —",
+        "# the shape of the object, the labels, the escape hatches.",
+        "tests:",
+        "  - it: renders a ConfigMap carrying the configuration document",
+    ]
+    if set_block:
+        lines.append(set_block)
+    lines += [
+        "    asserts:",
+        "      - hasDocuments:",
+        "          count: 1",
+        "      - isKind:",
+        "          of: ConfigMap",
+        "      - exists:",
+        f"          path: data['{document_key}']",
+        "",
+        "  - it: appends configExtraToml verbatim, after the rendered configuration",
+        "    set:",
+        *([f"      {item.values_path}: {values_scalar(_probe_credential(item))}"
+           for item in required]),
+        "      configExtraToml: |",
+        "        [scaffolded]",
+        '        marker = "verbatim"',
+        "    asserts:",
+        "      - matchRegex:",
+        f"          path: data['{document_key}']",
+        '          pattern: "\\\\[scaffolded\\\\]"',
+    ]
+    return "\n".join(lines) + "\n"

--- a/.github/scripts/config_scaffold.py
+++ b/.github/scripts/config_scaffold.py
@@ -91,7 +91,6 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any
 
 import config_bindings as cb
@@ -1102,7 +1101,8 @@ def render_declaration(
         "",
         "    # The pods that mount it, for the environment and secret-file gates.",
         "    consumers:",
-        f"      - workload: {{ kind: Deployment, selector: {{ app.kubernetes.io/instance: {chart} }} }}",
+        f"      - workload: {{ kind: Deployment, selector: "
+        f"{{ app.kubernetes.io/instance: {chart} }} }}",
         f"        containers: [{chart}]",
         "",
         "    # Pairs this document is not fully checked for, each with a reason.",
@@ -1331,7 +1331,7 @@ def render_unit_test(chart: str, document_key: str, plan: Plan) -> str:
         "  - configmap.yaml",
         "",
         "# Scaffolded by `just new-chart`, and yours to extend. The generated",
-        f"# `contract_roundtrip_*_test.yaml` beside it proves each contract key arrives at the",
+        "# `contract_roundtrip_*_test.yaml` beside it proves each contract key arrives at the",
         "# path the image reads it from; this file is for everything the contract cannot say —",
         "# the shape of the object, the labels, the escape hatches.",
         "tests:",

--- a/.github/scripts/config_secrets.py
+++ b/.github/scripts/config_secrets.py
@@ -70,17 +70,24 @@ cannot yet diverge; if that changes, it changes in `config_contract.py` first.
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable
-
-import yaml
+from typing import Any
 
 import config_contract as cc
-from config_declaration import Binding, Declaration, Document, bind, load_declaration
+from config_declaration import (
+    Binding,
+    Declaration,
+    Document,
+    bind,
+    declared,
+    vendored_for,
+)
 from config_gate_container import ContainerView
 from config_gate_document import parse_document
 from config_manifests import containers_of, digest_of, load_manifests, pod_spec, select
+from config_paths import read_yaml
 
 # The four ways a value can reach the loader, named as the report prints them. The rendered
 # document is among them and is not a mistake: a key written into the plaintext ConfigMap *is*
@@ -151,22 +158,15 @@ class Credential:
 
 def contracted_charts(charts: Path) -> list[tuple[Path, Declaration]]:
     """Every chart that declares at least one document, in directory order."""
-    found: list[tuple[Path, Declaration]] = []
-    for chart_dir in sorted(charts.iterdir()):
-        if not (chart_dir / "Chart.yaml").is_file():
-            continue
-        declaration = load_declaration(chart_dir)
-        if declaration is not None and declaration.documents:
-            found.append((chart_dir, declaration))
-    return found
+    return list(declared(charts, documents_only=True))
 
 
 def declared_secrets(chart_dir: Path, declaration: Declaration) -> list[Declared]:
     """Every `secret: true` key of every contract one chart vendors."""
     found: list[Declared] = []
     for document in declaration.documents:
-        for reference in document.images:
-            vendored = cc.load_vendored(chart_dir / reference.contract)
+        for item in vendored_for(chart_dir, document):
+            vendored = item.vendored
             app = (vendored.contract.get("app") or {}).get("name") or vendored.image
             for key in vendored.contract["schema"]["keys"]:
                 if not key.get("secret"):
@@ -175,7 +175,7 @@ def declared_secrets(chart_dir: Path, declaration: Declaration) -> list[Declared
                     Declared(
                         chart=declaration.chart,
                         document=document.name,
-                        contract=f"{declaration.chart}/{reference.contract}",
+                        contract=item.label,
                         image=str(app),
                         path=str(key["path"]),
                         secrets_file=str(key.get("secrets_file") or ""),
@@ -398,8 +398,8 @@ class Reconciler:
     # -- one chart ---------------------------------------------------------------------------
 
     def reconcile(self, chart_dir: Path, declaration: Declaration) -> None:
-        values = _read_yaml(chart_dir / "values.yaml")
-        app_version = _read_yaml(chart_dir / "Chart.yaml").get("appVersion")
+        values = read_yaml(chart_dir / "values.yaml")
+        app_version = read_yaml(chart_dir / "Chart.yaml").get("appVersion")
 
         bindings: dict[str, Binding] = {}
         for document in declaration.documents:
@@ -506,7 +506,7 @@ class Reconciler:
             return
         try:
             instance = parse_document(text, document.source.format)
-        except Exception:  # noqa: BLE001 — an unparseable document is gate 1's finding, not ours
+        except Exception:
             return
 
         present = document_paths(instance)
@@ -763,5 +763,3 @@ def _short(label: str) -> str:
     return Path(label).stem
 
 
-def _read_yaml(path: Path) -> dict[str, Any]:
-    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}

--- a/.github/scripts/config_testgen.py
+++ b/.github/scripts/config_testgen.py
@@ -364,6 +364,37 @@ def probe_for(key: dict[str, Any]) -> tuple[Probe | None, str | None]:
     )
 
 
+def satisfying(key: dict[str, Any]) -> Any | None:
+    """Any value one key's `constraint` accepts, or `None` when nothing here can synthesise one.
+
+    The candidate walk without `probe_for`'s two extra demands. A probe has to *differ* from the
+    published default — otherwise the case proves the chart delivered a value it would have got
+    anyway — and it has to survive the environment spelling as well, so that what it asserts is a
+    value the deployment could actually carry both ways. Neither applies to a caller that simply
+    needs a legal value: `config_scaffold` writes one into a new chart's `values.yaml` for a
+    required key whose image publishes no default, where "differs from the default" is vacuous
+    and the environment layer is not involved at all.
+
+    Public rather than left to a caller reaching for `_candidates`: the walk knows about
+    `multipleOf`, exclusive bounds and the choice vocabulary, and a second implementation of it
+    would be wrong in exactly the places this one was fixed.
+    """
+    constraint = key.get("constraint") or {}
+    if out_of_vocabulary(constraint):
+        return None
+    try:
+        form = cc.text_form(key)
+    except cc.ContractError:
+        return None
+    if form not in PROBED_FORMS:
+        return None
+
+    for candidate in _candidates(form, str(key.get("path") or ""), key, constraint):
+        if unmet(candidate, constraint) is None:
+            return candidate
+    return None
+
+
 def _candidates(
     form: str, path: str, key: dict[str, Any], constraint: dict[str, Any]
 ) -> list[Any]:

--- a/.github/scripts/config_testgen.py
+++ b/.github/scripts/config_testgen.py
@@ -109,8 +109,9 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
-from typing import Any, Iterable, Sequence
+from typing import Any
 
 import config_contract as cc
 
@@ -203,16 +204,6 @@ class TestGenError(Exception):
 # Checking a candidate against what the contract will accept
 # --------------------------------------------------------------------------------------------
 
-_TYPES: dict[str, tuple[type, ...]] = {
-    "string": (str,),
-    "integer": (int,),
-    "number": (int, float),
-    "boolean": (bool,),
-    "array": (list,),
-    "object": (dict,),
-}
-
-
 def unmet(value: Any, schema: dict[str, Any] | None) -> str | None:
     """The first assertion of a flat constraint the value fails, or `None` when it satisfies it.
 
@@ -237,8 +228,8 @@ def unmet(value: Any, schema: dict[str, Any] | None) -> str | None:
 
 def _unmet_keyword(value: Any, keyword: str, expected: Any) -> str | None:
     if keyword == "type":
-        wanted = expected if isinstance(expected, list) else [expected]
-        if not any(_is_type(value, name) for name in wanted):
+        if not cc.is_type(value, expected):
+            wanted = expected if isinstance(expected, list) else [expected]
             return f"type {'/'.join(str(name) for name in wanted)}"
         return None
 
@@ -273,19 +264,6 @@ def _unmet_keyword(value: Any, keyword: str, expected: Any) -> str | None:
         return None if satisfied else f"{keyword} {expected}"
 
     return f"the assertion {keyword!r}, which this generator does not implement"
-
-
-def _is_type(value: Any, name: str) -> bool:
-    if name == "null":
-        return value is None
-    types = _TYPES.get(name)
-    if types is None:
-        return False
-    # `True` is an `int` in Python and is not one in JSON Schema, so a boolean has to be excluded
-    # from every numeric type explicitly or `true` would satisfy a `u64` bound.
-    if name in ("integer", "number") and isinstance(value, bool):
-        return False
-    return isinstance(value, types)
 
 
 def out_of_vocabulary(schema: dict[str, Any] | None) -> list[str]:

--- a/.github/scripts/contract-diff.py
+++ b/.github/scripts/contract-diff.py
@@ -52,10 +52,10 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-import config_diff as cd  # noqa: E402
-from config_report import Report, error  # noqa: E402
+import config_diff as cd
+from config_paths import CHARTS_DIR
+from config_report import Report, error
 
-CHARTS_DIR = Path("charts")
 DEFAULT_REF = "origin/main"
 
 # The JSON's own version, on the same reasoning as `terrace_contract`: a consumer that does not

--- a/.github/scripts/explain-config.py
+++ b/.github/scripts/explain-config.py
@@ -72,20 +72,18 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-import yaml
-
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-import config_contract as cc  # noqa: E402
-from config_declaration import (  # noqa: E402
+import config_contract as cc
+from config_declaration import (
     Declaration,
     DeclarationError,
     bind,
+    declared,
     load_declaration,
 )
-from config_report import Report, warning  # noqa: E402
-
-CHARTS_DIR = Path("charts")
+from config_paths import CHARTS_DIR, read_yaml
+from config_report import Report, warning
 
 # The contracts' prose is UTF-8 and uses it — em dashes, arrows, typographic quotes — and this
 # repository is developed from Git Bash on Windows, where Python's default console encoding is the
@@ -274,8 +272,8 @@ def collect(chart_dir: Path, declaration: Declaration, report: Report) -> Surfac
     provenance, so the contracts are re-read afterwards for the image reference and the app
     version. That is a second read of a file already proven, not a second opinion about it.
     """
-    values = _read_yaml(chart_dir / "values.yaml")
-    app_version = _read_yaml(chart_dir / "Chart.yaml").get("appVersion")
+    values = read_yaml(chart_dir / "values.yaml")
+    app_version = read_yaml(chart_dir / "Chart.yaml").get("appVersion")
 
     surface = Surface(chart=declaration.chart)
     by_contract: dict[str, list[str]] = {}
@@ -757,7 +755,10 @@ def print_surface(surface: Surface, args: argparse.Namespace, out) -> int:
         print("\n\n".join(blocks), file=out)
 
     if external:
-        print("\n==> external variables — read by the image, and nobody's configuration\n", file=out)
+        print(
+            "\n==> external variables — read by the image, and nobody's configuration\n",
+            file=out,
+        )
         print(
             "\n".join(
                 prose(
@@ -829,7 +830,9 @@ def as_json(surface: Surface, pattern: str | None) -> dict[str, Any]:
         ],
         "keys": [_setting_json(item, derive=True) for item in select(surface.keys, pattern)],
         "loader": [_setting_json(item) for item in select(surface.loader, pattern)],
-        "external": [_setting_json(item, derive=True) for item in select(surface.external, pattern)],
+        "external": [
+            _setting_json(item, derive=True) for item in select(surface.external, pattern)
+        ],
     }
 
 
@@ -855,20 +858,13 @@ def _setting_json(setting: Setting, derive: bool = False) -> dict[str, Any]:
 # --------------------------------------------------------------------------------------------
 
 
-def _read_yaml(path: Path) -> dict[str, Any]:
-    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-
-
 def charts_with_contracts(charts: Path) -> list[tuple[str, Declaration]]:
-    """Every chart carrying a declaration, whether or not it declares any document."""
-    found = []
-    for chart_dir in sorted(charts.iterdir()):
-        if not (chart_dir / "Chart.yaml").is_file():
-            continue
-        declaration = load_declaration(chart_dir)
-        if declaration is not None:
-            found.append((chart_dir.name, declaration))
-    return found
+    """Every chart carrying a declaration, whether or not it declares any document.
+
+    Not `documents_only`: a chart that opted out explicitly carries a reason, and printing that
+    reason is one of the two things this command exists to do.
+    """
+    return [(chart_dir.name, declaration) for chart_dir, declaration in declared(charts)]
 
 
 def list_charts(charts: Path, out) -> None:
@@ -890,11 +886,17 @@ def list_charts(charts: Path, out) -> None:
 
 
 def describe_opt_out(declaration: Declaration, out) -> None:
-    print(f"==> {declaration.chart} has explicitly opted out of configuration contracts\n", file=out)
+    print(
+        f"==> {declaration.chart} has explicitly opted out of configuration contracts\n",
+        file=out,
+    )
     print("\n".join(prose(str(declaration.reason), "    ")), file=out)
     if declaration.unconfigured:
+        # Values paths, not repository names — `unconfigured` is unioned with every declared
+        # image's `values` and compared against the paths a chart pins. This line used to call
+        # them images, which is how the field came to have two readers that disagreed.
         print(
-            f"\n    images it pins that carry no contract: "
+            f"\n    values paths pinning an image that carries no contract: "
             f"{', '.join(declaration.unconfigured)}",
             file=out,
         )

--- a/.github/scripts/generate-contract-tests.py
+++ b/.github/scripts/generate-contract-tests.py
@@ -65,16 +65,18 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-import config_contract as cc  # noqa: E402
-import config_testgen as tg  # noqa: E402
-from config_declaration import (  # noqa: E402
+import config_contract as cc
+import config_testgen as tg
+from config_declaration import (
     Declaration,
     DeclarationError,
     Document,
     dig,
     load_declaration,
     reject_unknown,
+    union_for,
 )
+from config_paths import CHARTS_DIR
 
 # The file that enrols a chart, and the keys it may carry at each level. Anything else is a typo
 # that would otherwise be ignored in silence — the same rule `config-contract.yaml` is read under,
@@ -411,15 +413,6 @@ def discriminator_for(
     return tuple(sorted(document.source.selector.items()))
 
 
-def union_for(chart_dir: Path, document: Document) -> cc.Union:
-    """The contracts of every image that reads one document, merged."""
-    contracts = []
-    for reference in document.images:
-        vendored = cc.load_vendored(chart_dir / reference.contract)
-        contracts.append((f"{chart_dir.name}/{reference.contract}", vendored.contract))
-    return cc.union_contracts(contracts)
-
-
 def suite_path(chart_dir: Path, document: Document) -> Path:
     return chart_dir / SUITES / f"{SUITE_PREFIX}{document.name}{SUITE_SUFFIX}"
 
@@ -603,9 +596,12 @@ def main(argv: list[str]) -> int:
         help="report drifted suites and exit non-zero instead of writing them",
     )
     parser.add_argument(
-        "--charts", default="charts", type=Path, help="charts directory (default: charts)"
+        "--charts",
+        default=str(CHARTS_DIR),
+        type=Path,
+        help=f"charts directory (default: {CHARTS_DIR})",
     )
-    args = parser.parse_args(argv[1:])
+    args = parser.parse_args(argv)
 
     if not args.charts.is_dir():
         fail(f"{args.charts} is not a directory")
@@ -631,4 +627,4 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv))
+    raise SystemExit(main(sys.argv[1:]))

--- a/.github/scripts/kube-schema-refs.py
+++ b/.github/scripts/kube-schema-refs.py
@@ -131,9 +131,13 @@ def main(argv: list[str]) -> int:
         help="report drifted references and exit non-zero instead of rewriting them",
     )
     parser.add_argument(
+        # The one script here that does not share `config_paths.CHARTS_DIR`, and deliberately:
+        # that module imports PyYAML, and this script is stdlib-only on purpose — `maintain.just`
+        # records that it reuses `resolve_python` "even though this script imports nothing beyond
+        # the standard library". Trading that for one shared constant is the wrong way round.
         "--charts", default="charts", type=Path, help="charts directory (default: charts)"
     )
-    args = parser.parse_args(argv[1:])
+    args = parser.parse_args(argv)
 
     if not VERSION.match(args.version):
         fail(f"{args.version!r} is not a Kubernetes release of the form MAJOR.MINOR.PATCH")
@@ -146,4 +150,4 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv))
+    raise SystemExit(main(sys.argv[1:]))

--- a/.github/scripts/new-chart.py
+++ b/.github/scripts/new-chart.py
@@ -79,24 +79,23 @@ import os
 import shutil
 import sys
 from pathlib import Path
-from typing import Any
 
 import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-import config_contract as cc  # noqa: E402
-import config_scaffold as sc  # noqa: E402
-from config_coverage import first_party_patterns  # noqa: E402
-from config_declaration import DeclarationError, load_declaration  # noqa: E402
+import config_contract as cc
+import config_scaffold as sc
+from config_coverage import first_party_patterns
+from config_declaration import DeclarationError, load_declaration
 
-CHARTS_DIR = Path("charts")
+# `FIRST_PARTY` is the list `just check-contract-coverage` decides from, and it is imported rather
+# than spelt here for the reason the constant is shared at all: whether a chart owes a declaration
+# is that gate's rule, and a scaffold with its own opinion about it would write charts the gate
+# then rejects.
+from config_paths import CHARTS_DIR, FIRST_PARTY
+
 TEMPLATES = Path(".github/templates/chart")
-
-# The list `just check-contract-coverage` decides from. Read here for the same reason it
-# reads it there: whether a chart owes a declaration is that gate's rule, and a scaffold
-# with its own opinion about it would write charts the gate then rejects.
-FIRST_PARTY = Path(".github/configs/first-party-images.txt")
 
 # The library chart every chart here depends on. Read from its own `Chart.yaml` rather than
 # written down, so a library release is not a second edit somebody has to remember.
@@ -365,7 +364,8 @@ def generate(
         text = path.read_text(encoding="utf-8")
         text = text.replace(_shout(name) + "_", union.prefix)
         text = text.replace(f'"prefix" "{_shout(name)}"', f'"prefix" "{sc.env_prefix(union)}"')
-        text = text.replace("`__` for nesting", f"`{union.dialect['nesting_separator']}` for nesting")
+        separator = union.dialect["nesting_separator"]
+        text = text.replace("`__` for nesting", f"`{separator}` for nesting")
         _write(path, text)
 
     return surface
@@ -499,7 +499,7 @@ def next_steps(chart_dir: Path, surface: sc.Surface, out) -> None:
         steps.append(
             "Write the chart's own values, one `@schema` block each, and the templates that "
             "consume them — a ConfigMap, a Secret, a Service, whatever this image needs. "
-            f"`templates/_helpers.tpl` is where anything computed belongs."
+            "`templates/_helpers.tpl` is where anything computed belongs."
         )
         steps.append(
             "If this image ever publishes a configuration contract, re-run without "

--- a/.github/scripts/new-chart.py
+++ b/.github/scripts/new-chart.py
@@ -1,0 +1,646 @@
+#!/usr/bin/env python3
+"""Create a new chart: the chassis every chart here shares, and the configuration surface its
+image's contract describes.
+
+A chart in this repository is two things stacked. Underneath is a chassis — around thirty values
+blocks, a handful of templates, a podspec wired to `charts/common` — which is the same in every
+chart because the library owns the logic and these files only name it. On top is the part that is
+about *this* image: the settings it reads, what each one accepts, which of them are credentials,
+and how a chart value reaches each one.
+
+Both halves are hand-copied from a neighbouring chart today, and both go wrong doing it. The
+chassis drifts silently: 2,069 lines of the eight charts' `values.yaml` files are byte-identical to
+another chart's and the rest of each block is not, which is what repeatedly copy-editing one
+neighbour looks like. The configuration half goes wrong differently — it is written by reading a
+400 KB JSON document by hand, so a key gets missed, and a key nothing surfaces is exactly the
+defect `just check-config-bindings` exists to catch after the fact.
+
+This copies the first half and, where there is a contract to read, generates the second.
+
+--------------------------------------------------------------------------------------------
+Two forms
+--------------------------------------------------------------------------------------------
+
+**Contracted** — the default, and the only networked path. The image publishes a contract, so the
+chart gets a values block per setting with the `# @config` marker that binds it, a `_helpers.tpl`
+that projects them into the document, a Secret for every credential, a `config-contract.yaml`, a
+`contract-tests.yaml` and a vendored contract. It passes `just check-config`,
+`just check-config-bindings` and `just check-contract-tests` on its first run.
+
+**Plain** — `--no-contract`. The image publishes nothing to read, so the scaffold asserts nothing
+about its configuration: no `config` escape hatch, no `configMount`, no ConfigMap and no Secret.
+What is left is the chassis and the workload, which is two thirds of every chart here and all of
+what `teamspeak` and `paperless-ngx` are made of. A `config-contract.yaml` is written only when
+the image is *first-party* — the same question `just check-contract-coverage` asks, decided from
+the same list — because a chart pinning `paperless-ngx` owes no declaration and a scaffold that
+gave it one would introduce a file this repository deliberately does not have.
+
+The seam between the two is `config_scaffold.Surface`, and every renderer branches on it rather
+than on a flag threaded through from here.
+
+--------------------------------------------------------------------------------------------
+The one networked step
+--------------------------------------------------------------------------------------------
+
+Generating the configuration surface needs the contract, and the contract lives in the registry
+next to the image. So the contracted form is the second networked recipe in the repository, and it
+uses the first one to do it: the vendoring is `refresh-contracts.py`, unchanged and called as a
+module, so a contract this scaffold writes has been through the same signature verification, the
+same label agreement check and the same `source` envelope as every contract `just contracts` has
+ever written. There is no second path into `charts/*/contracts/`, which is the property worth
+having — a contract that arrived some other way would be trusted by every gate downstream.
+
+`--no-contract` is not a way to skip the network for an image that does publish a contract. It
+produces a chart with no configuration surface at all, which for such an image is strictly less
+than what could have been generated.
+
+--------------------------------------------------------------------------------------------
+What "finished" means
+--------------------------------------------------------------------------------------------
+
+The chart this writes passes `just check` — every offline gate, including the ones that read a
+contract. That is the bar, and it is checked by running them rather than asserted here.
+
+What it is not is *done*, and what is left is printed as an ordered list at the end rather than
+left to be discovered: the chart description and the README prose, which a generator cannot write
+and helm-docs will happily publish as placeholders; whatever the workload needs beyond a
+Deployment, none of which is in a contract; the `unbound` reasons, each generated with a
+defensible sentence and a defensible sentence is not a considered one; and, where the image
+publishes no default for a key it requires, the value this scaffold had to invent.
+
+It does not commit, add a `ci/` fixture beyond the one, or touch the root README — the chart index
+is derived from `Chart.yaml`, so the table picks the chart up on its own.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import config_contract as cc  # noqa: E402
+import config_scaffold as sc  # noqa: E402
+from config_coverage import first_party_patterns  # noqa: E402
+from config_declaration import DeclarationError, load_declaration  # noqa: E402
+
+CHARTS_DIR = Path("charts")
+TEMPLATES = Path(".github/templates/chart")
+
+# The list `just check-contract-coverage` decides from. Read here for the same reason it
+# reads it there: whether a chart owes a declaration is that gate's rule, and a scaffold
+# with its own opinion about it would write charts the gate then rejects.
+FIRST_PARTY = Path(".github/configs/first-party-images.txt")
+
+# The library chart every chart here depends on. Read from its own `Chart.yaml` rather than
+# written down, so a library release is not a second edit somebody has to remember.
+COMMON = "common"
+
+
+class ScaffoldAborted(Exception):
+    """Something the caller has to fix before a chart can be written."""
+
+
+# --------------------------------------------------------------------------------------------
+# Substitution
+# --------------------------------------------------------------------------------------------
+
+
+def substitute(text: str, values: dict[str, str]) -> str:
+    """Replace every `%%NAME%%` placeholder, and refuse a file that still holds one.
+
+    `%%NAME%%` rather than `{{ NAME }}` because these files are Go templates whose braces have to
+    survive into the chart untouched. Refusing a leftover is the point of doing it here rather
+    than with `str.format`: a placeholder nobody substituted would otherwise reach the chart as
+    literal text and render as itself.
+    """
+    for name, value in values.items():
+        text = text.replace(f"%%{name}%%", value)
+    if "%%" in text:
+        marker = text[text.index("%%"):][:40].splitlines()[0]
+        raise ScaffoldAborted(f"a template placeholder was not substituted: {marker}")
+    return text
+
+
+# The template subtrees that are not shared: one per configuration form, selected by `Surface`.
+# Everything outside them is copied into every chart whatever its form.
+FORMS = ("contract", "plain")
+
+# Files under the template root that are not chart files. `values.chassis.yaml` is a fragment the
+# generated `values.yaml` ends with rather than a document of its own; `README.md` documents the
+# directory to whoever edits it.
+NOT_CHART_FILES = frozenset({"values.chassis.yaml", "README.md"})
+
+
+def copy_chassis(chart_dir: Path, values: dict[str, str], templates: Path, form: str) -> None:
+    """Copy the shared files and the form's own, substituting placeholders on the way.
+
+    Two passes over one directory rather than two directories, because the split is between the
+    files a form *replaces* and the files every form keeps — and a reader of the template tree
+    should be able to see at a glance which is which. `templates/serviceaccount.yaml` is shared;
+    `contract/templates/deployment.yaml` and `plain/templates/deployment.yaml` are the same file
+    written two ways, and the second has no ConfigMap to mount.
+    """
+    if form not in FORMS:
+        raise ScaffoldAborted(f"{form!r} is not a configuration form; expected one of {FORMS}")
+
+    excluded = tuple(templates / other for other in FORMS)
+    for root in (templates, templates / form):
+        if not root.is_dir():
+            raise ScaffoldAborted(f"{root}: the scaffold templates are missing")
+        for source in sorted(root.rglob("*")):
+            if source.is_dir() or source.name in NOT_CHART_FILES:
+                continue
+            if root is templates and any(source.is_relative_to(other) for other in excluded):
+                continue
+            _write(
+                chart_dir / source.relative_to(root),
+                substitute(source.read_text(encoding="utf-8"), values),
+            )
+
+
+# --------------------------------------------------------------------------------------------
+# The two forms
+# --------------------------------------------------------------------------------------------
+
+
+def scaffold(
+    charts: Path,
+    templates: Path,
+    name: str,
+    repository: str,
+    app_version: str,
+    description: str,
+    source: str,
+    document: str,
+    document_key: str,
+    contracted: bool,
+) -> Path:
+    """Write the chart, in whichever form was asked for. Returns the chart directory.
+
+    Everything here is what the two forms share plus the form's own templates. On the contracted
+    path two of these files are provisional and `generate` rewrites them, and the order is forced
+    rather than chosen: `refresh-contracts.py` reads the declaration to learn which image to ask,
+    and reads `values.yaml` to resolve it. So the chart has to name its image and its document
+    *before* it can fetch the description of that document.
+
+    On the plain path nothing here is provisional. The chart is finished when this returns.
+    """
+    sc.check_chart_name(name)
+
+    chart_dir = charts / name
+    if chart_dir.exists():
+        raise ScaffoldAborted(f"{chart_dir} already exists; pick another name or remove it")
+
+    library = charts / COMMON / "Chart.yaml"
+    if not library.is_file():
+        raise ScaffoldAborted(f"{library}: cannot read the `common` library's version")
+    common_version = str((yaml.safe_load(library.read_text(encoding="utf-8")) or {})["version"])
+
+    # Before the fetch there is no dialect to read the loader's spellings from, so the chart name
+    # stands in for them. Every use that survives into the rendered chart is rewritten by
+    # `generate` from what the contract actually declares; on the plain path there is no loader to
+    # describe and these reach only comment prose.
+    chart_dir.mkdir(parents=True)
+    copy_chassis(
+        chart_dir,
+        {
+            "CHART": name,
+            "DESCRIPTION": description,
+            "APP_VERSION": app_version,
+            "SOURCE": source,
+            "COMMON_VERSION": common_version,
+            "DOCUMENT_KEY": document_key,
+            "PREFIX": _shout(name) + "_",
+            "ENV_PREFIX": _shout(name),
+            "SEPARATOR": "__",
+        },
+        templates,
+        "contract" if contracted else "plain",
+    )
+
+    provisional = (
+        sc.Surface(
+            union=cc.Union(dialect={"prefix": _shout(name) + "_", "nesting_separator": "__"})
+        )
+        if contracted
+        else sc.plain()
+    )
+    _write(
+        chart_dir / "values.yaml",
+        sc.render_values(
+            name,
+            provisional,
+            repository,
+            app_version,
+            (templates / "values.chassis.yaml").read_text(encoding="utf-8"),
+            document_key,
+        ),
+    )
+    _write(chart_dir / "templates" / "_helpers.tpl", sc.render_helpers(name, provisional))
+    _write(chart_dir / "ci" / "test-values.yaml", sc.render_ci_values(name, provisional))
+
+    if contracted:
+        # The least a declaration can say and still tell the refresh which image to ask.
+        # Rewritten in full by `generate`, once there are keys to write off.
+        _write(
+            chart_dir / sc.DECLARATION,
+            sc.render_declaration(
+                name, document, f"{sc.CONTRACTS}/{document}.json", document_key, sc.Plan()
+            ),
+        )
+
+    return chart_dir
+
+
+def _shout(name: str) -> str:
+    """`netcup-offer-bot` as `NETCUP_OFFER_BOT` — the environment prefix a chart name implies.
+
+    A guess, and only ever used by `--no-contract`, where there is no dialect to read the real one
+    from. Every contract states its own prefix and the contract form uses that instead.
+    """
+    return name.replace("-", "_").upper()
+
+
+def vendor(chart_dir: Path, signer: str) -> Path:
+    """Fetch and verify the contract for the image this chart pins. The one networked step.
+
+    Delegated to `refresh-contracts.py` rather than reimplemented, so a contract written by this
+    scaffold is one `just contracts` would have written: same signature verification, same label
+    agreement check, same envelope. Imported as a module because the file name is hyphenated and
+    a `subprocess` call would hide its exceptions behind an exit code.
+    """
+    module = _refresh_module()
+    client = module.RegistryClient()
+    try:
+        # The library's own check, rather than a second one here: it names both binaries, says
+        # which recipe needs them and names the override variables, and a message this script
+        # wrote instead would drift from it.
+        client.require()
+        module.refresh_chart(chart_dir, client, signer)
+    except module.RefreshError as failure:
+        raise ScaffoldAborted(
+            f"{failure}\n       Scaffold with `--no-contract --reason ...` if this image "
+            "publishes none."
+        ) from failure
+
+    written = sorted((chart_dir / sc.CONTRACTS).glob("*.json"))
+    if len(written) != 1:
+        raise ScaffoldAborted(
+            f"expected one vendored contract under {chart_dir / sc.CONTRACTS}, found "
+            f"{len(written)}"
+        )
+    return written[0]
+
+
+def _refresh_module():
+    """`refresh-contracts.py` as a module.
+
+    Loaded by path because the file name is hyphenated and a plain `import` cannot name it. A
+    `subprocess` call would work too and is worse: it would hide `RefreshError` — which carries
+    the whole signature-verification story — behind an exit code, and this command has to be able
+    to remove the partial chart it just wrote.
+    """
+    import importlib.util
+
+    if "refresh_contracts" in sys.modules:
+        return sys.modules["refresh_contracts"]
+
+    path = Path(__file__).resolve().parent / "refresh-contracts.py"
+    spec = importlib.util.spec_from_file_location("refresh_contracts", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["refresh_contracts"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def generate(
+    chart_dir: Path, templates: Path, document: str, document_key: str, contract: Path
+) -> sc.Surface:
+    """Write the configuration surface: values, helpers, declaration, enrolment and fixtures.
+
+    Everything here overwrites what `scaffold` wrote provisionally. The chart's own image pin is
+    read back out of the file rather than passed in again, so there is one place it is written and
+    a rewrite cannot silently disagree with the contract that was just fetched for it.
+    """
+    vendored = cc.load_vendored(contract)
+    union = cc.union_contracts([(str(contract), vendored.contract)])
+
+    if union.dialect.get("nesting_separator") is None:
+        raise ScaffoldAborted(f"{contract}: the contract declares no nesting separator")
+
+    surface = sc.from_contract(union)
+    plan = surface.plan
+    name = chart_dir.name
+    chassis = (templates / "values.chassis.yaml").read_text(encoding="utf-8")
+
+    values = chart_dir / "values.yaml"
+    repository, tag = _pinned(values)
+
+    _write(values, sc.render_values(name, surface, repository, tag, chassis, document_key))
+    _write(chart_dir / "templates" / "_helpers.tpl", sc.render_helpers(name, surface))
+    _write(
+        chart_dir / sc.DECLARATION,
+        sc.render_declaration(
+            name, document, f"{sc.CONTRACTS}/{contract.name}", document_key, plan
+        ),
+    )
+    _write(chart_dir / sc.ENROLMENT, sc.render_enrolment(name, document, plan))
+    _write(chart_dir / "ci" / "test-values.yaml", sc.render_ci_values(name, surface))
+    _write(
+        chart_dir / "tests" / "configmap_test.yaml",
+        sc.render_unit_test(name, document_key, plan),
+    )
+
+    # The two placeholders the offline pass could only guess at. Rewritten from the dialect the
+    # contract actually declares, which is the whole reason the contract form exists.
+    for template in ("deployment.yaml", "secret.yaml"):
+        path = chart_dir / "templates" / template
+        text = path.read_text(encoding="utf-8")
+        text = text.replace(_shout(name) + "_", union.prefix)
+        text = text.replace(f'"prefix" "{_shout(name)}"', f'"prefix" "{sc.env_prefix(union)}"')
+        text = text.replace("`__` for nesting", f"`{union.dialect['nesting_separator']}` for nesting")
+        _write(path, text)
+
+    return surface
+
+
+def _pinned(values: Path) -> tuple[str, str]:
+    """The repository and tag the scaffolded `values.yaml` already carries."""
+    image = (yaml.safe_load(values.read_text(encoding="utf-8")) or {}).get("image") or {}
+    return str(image.get("repository") or ""), str(image.get("tag") or "")
+
+
+def owes_a_declaration(first_party: Path, repository: str) -> bool:
+    """Whether `just check-contract-coverage` will demand a declaration from this chart.
+
+    The same question the gate asks, asked with the gate's own list and the gate's own pattern
+    matcher rather than a second copy of either. A chart pinning `timschoenle/foo` owes a
+    declaration — a real one, or an explicit opt-out with a reason — and a chart pinning
+    `paperless-ngx` owes nothing, because nobody publishes a contract for it and a file that could
+    only say "no" is a file nobody should be asked to write.
+
+    That distinction is why the plain form does not always write an opt-out. `teamspeak` and
+    `paperless-ngx` carry no `config-contract.yaml` at all, and a scaffold that gave every plain
+    chart one would have introduced a file this repository deliberately does not have.
+    """
+    if not first_party.is_file():
+        raise ScaffoldAborted(
+            f"{first_party}: missing, so whether this chart owes a declaration cannot be decided"
+        )
+    return any(
+        cc.matches_ignore(pattern, repository)
+        for pattern in first_party_patterns(first_party)
+    )
+
+
+def opt_out(chart_dir: Path, reason: str, repository: str) -> None:
+    """The `--no-contract` declaration: an explicit opt-out with a written reason.
+
+    Not the same thing as having no declaration at all. `just check-contract-coverage` demands a
+    file from any chart pinning a first-party image, and this is the form that satisfies it while
+    saying, in a sentence a reviewer reads, that the image publishes nothing to check against.
+    """
+    _write(
+        chart_dir / sc.DECLARATION,
+        "# vim: set ft=yaml:\n"
+        "\n"
+        f"# This chart pins {repository}, which publishes no configuration contract. It says so\n"
+        "# here rather than simply having no file: an empty `documents` is an explicit opt-out,\n"
+        "# and `just check-contract-coverage` reports a first-party image that is accounted for\n"
+        "# by neither a document nor a written reason.\n"
+        "#\n"
+        "# `unconfigured` is deliberately absent. It would be the field for naming an image this\n"
+        "# chart pins and does not describe — but nothing reads it on a chart with no documents,\n"
+        "# and on a chart that has them `config_coverage` compares it against *values paths*\n"
+        "# while `just explain` prints it as a list of images. Adding the first usage of a field\n"
+        "# whose two readers disagree is not this file's job; the reason below names the image.\n"
+        "\n"
+        "documents: []\n"
+        "\n"
+        "reason: >-\n"
+        + "\n".join(sc.wrap(reason, "  ", sc.WIDTH))
+        + "\n",
+    )
+
+
+def _write(path: Path, text: str) -> None:
+    """Write one generated file with LF endings, whatever the platform prefers.
+
+    The same reason `generate-contract-tests.py` gives: this repository is developed from a Git
+    Bash shell on Windows, and Python's text mode would translate every newline to CRLF — leaving
+    a committed file that differs from the one CI writes on every line.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8", newline="\n")
+
+
+# --------------------------------------------------------------------------------------------
+# Saying what is left
+# --------------------------------------------------------------------------------------------
+
+
+def next_steps(chart_dir: Path, surface: sc.Surface, out) -> None:
+    """The ordered list of what a person still has to do, printed rather than left to be found."""
+    name = chart_dir.name
+    plan = surface.plan
+    print(f"\n==> {chart_dir} written\n", file=out)
+
+    if surface.contracted:
+        print(
+            f"    {len(plan.projected)} setting(s) surfaced as chart values, "
+            f"{len(plan.secrets)} credential(s) delivered as files, "
+            f"{len(plan.written_off)} key(s) written off\n",
+            file=out,
+        )
+    else:
+        print(
+            "    No configuration surface: this image publishes no contract, so the chart is the "
+            "chassis and the workload alone.\n",
+            file=out,
+        )
+
+    steps = [
+        f"Write the description in charts/{name}/Chart.yaml and the prose in README.md.gotmpl. "
+        "Both are placeholders, and helm-docs publishes them.",
+    ]
+
+    if surface.contracted:
+        steps.append(
+            "Add whatever the workload needs beyond a Deployment — a Service, an Ingress, a "
+            "PodMonitor, a volume. None of that is in the contract."
+        )
+        guessed = sc.invented(plan)
+        if guessed:
+            steps.append(
+                "Replace the values this scaffold had to invent. These keys are required and "
+                "their image publishes no default, so the value written is merely one the "
+                f"constraint accepts: {', '.join(item.values_path for item in guessed)}."
+            )
+        if plan.secrets or plan.written_off:
+            steps.append(
+                f"Read the `unbound` reasons in charts/{name}/config-contract.yaml. Each is "
+                "defensible and none is considered."
+            )
+        steps.append(
+            "Add this chart to the enrolment census in "
+            "`.github/scripts/tests/test_contract_bindings.py` "
+            "(`test_every_enrolled_chart_passes_the_gate`). That test pins the exact list and "
+            "each chart's key count on purpose — it is how a chart silently dropping out of "
+            "`check-config-bindings` is caught — so a new enrolment is one line there."
+        )
+    else:
+        steps.append(
+            "Write the chart's own values, one `@schema` block each, and the templates that "
+            "consume them — a ConfigMap, a Secret, a Service, whatever this image needs. "
+            f"`templates/_helpers.tpl` is where anything computed belongs."
+        )
+        steps.append(
+            "If this image ever publishes a configuration contract, re-run without "
+            "`--no-contract` in a scratch directory and take the generated surface across."
+        )
+
+    steps += [
+        "just deps && just docs        # resolve the library, generate the schema and README",
+        "just check                    # every offline gate, this chart included",
+    ]
+
+    for number, step in enumerate(steps, start=1):
+        wrapped = sc.wrap(step, "", sc.WIDTH - 7)
+        print(f"    {number}. {wrapped[0]}", file=out)
+        for line in wrapped[1:]:
+            print(f"       {line}", file=out)
+    print(file=out)
+
+
+# --------------------------------------------------------------------------------------------
+# Entry point
+# --------------------------------------------------------------------------------------------
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("name", help="the chart's name, and the directory under charts/")
+    parser.add_argument("repository", help="the image repository, as values.yaml spells it")
+    parser.add_argument("version", help="the image tag, ideally `vX.Y.Z@sha256:...`")
+    parser.add_argument("--charts", default=str(CHARTS_DIR), type=Path)
+    parser.add_argument("--templates", default=str(TEMPLATES), type=Path)
+    parser.add_argument(
+        "--description", default="", help="the chart description; a placeholder when omitted"
+    )
+    parser.add_argument(
+        "--source", default="", help="the upstream repository; derived from the image when omitted"
+    )
+    parser.add_argument(
+        "--document",
+        default="",
+        help="the configuration document's name in config-contract.yaml (default: the chart's)",
+    )
+    parser.add_argument(
+        "--document-key",
+        default=f"config.{sc.FORMAT}",
+        help="the ConfigMap key the document is rendered under",
+    )
+    parser.add_argument(
+        "--no-contract",
+        action="store_true",
+        help="scaffold offline, for an image that publishes no configuration contract",
+    )
+    parser.add_argument(
+        "--reason",
+        default="",
+        help="why there is no contract; required with --no-contract for a first-party image",
+    )
+    parser.add_argument(
+        "--first-party",
+        default=str(FIRST_PARTY),
+        type=Path,
+        help="the image list check-contract-coverage decides from",
+    )
+    parser.add_argument(
+        "--signer",
+        default="",
+        help="the workflow identity a contract must be signed by (default: $CONTRACT_SIGNER)",
+    )
+    args = parser.parse_args(argv)
+
+    document = args.document or args.name
+    description = args.description or (
+        f"TODO: what {args.name} deploys, in one sentence. Written by hand — helm-docs "
+        "publishes this."
+    )
+    source = args.source or f"https://github.com/{args.repository.split('/')[-1]}"
+
+    chart_dir: Path | None = None
+    try:
+        # Asked before anything is written, so a missing reason costs nothing to correct. The
+        # question is the coverage gate's, not this script's: a chart pinning a first-party image
+        # owes a declaration, and an opt-out without a reason is indistinguishable from a chart
+        # nobody got round to declaring. A third-party image owes neither — `teamspeak` carries no
+        # `config-contract.yaml` at all — so demanding a reason there would be asking somebody to
+        # justify a file this repository does not want.
+        owed = args.no_contract and owes_a_declaration(args.first_party, args.repository)
+        if owed and not args.reason:
+            raise ScaffoldAborted(
+                f"{args.repository} is a first-party image, so `just check-contract-coverage` "
+                "will demand a declaration from this chart. Give --reason to write the opt-out, "
+                "or drop --no-contract to vendor the contract it publishes"
+            )
+
+        chart_dir = scaffold(
+            args.charts,
+            args.templates,
+            args.name,
+            args.repository,
+            args.version,
+            description,
+            source,
+            document,
+            args.document_key,
+            contracted=not args.no_contract,
+        )
+
+        if args.no_contract:
+            if owed:
+                opt_out(chart_dir, args.reason, args.repository)
+            next_steps(chart_dir, sc.plain(), sys.stdout)
+            return 0
+
+        signer = args.signer or os.environ.get("CONTRACT_SIGNER", "")
+        if not signer:
+            raise ScaffoldAborted(
+                "no contract signer given; pass --signer or set $CONTRACT_SIGNER, as "
+                "`just contracts` does"
+            )
+
+        contract = vendor(chart_dir, signer)
+        surface = generate(chart_dir, args.templates, document, args.document_key, contract)
+
+        # Read the declaration back through the loader every gate uses. A file this script wrote
+        # and no parser accepted would fail on the contributor's first `just check` rather than
+        # here, with a message about a chart they did not write by hand.
+        if load_declaration(chart_dir) is None:
+            raise ScaffoldAborted(f"{chart_dir / sc.DECLARATION} was written and cannot be read")
+
+        next_steps(chart_dir, surface, sys.stdout)
+        return 0
+
+    except (ScaffoldAborted, sc.ScaffoldError, cc.ContractError, DeclarationError) as failure:
+        print(f"error: {failure}", file=sys.stderr)
+        if chart_dir is not None and chart_dir.is_dir():
+            # A half-written chart is worse than none: it renders, it lints, and it is missing the
+            # one half this command exists to write. Removed rather than left for the caller to
+            # notice, and named so nothing is deleted silently.
+            shutil.rmtree(chart_dir)
+            print(f"       removed the partial chart at {chart_dir}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/scripts/refresh-contracts.py
+++ b/.github/scripts/refresh-contracts.py
@@ -81,7 +81,7 @@ import shutil
 import subprocess
 import sys
 import tarfile
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -89,11 +89,11 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-import config_contract as cc  # noqa: E402
+import config_contract as cc
+from config_paths import CHARTS_DIR, dig
 
 # `check-config.py` owns the declaration format; importing it by file name is not possible, so
 # the two pieces this script needs are re-derived from the same YAML rather than duplicated.
-CHARTS_DIR = Path("charts")
 DECLARATION = "config-contract.yaml"
 
 # The OIDC issuer a GitHub Actions workflow signs under. Paired with `$CONTRACT_SIGNER`, which
@@ -434,7 +434,7 @@ def write_vendored(path: Path, image: str, digest: str, payload: bytes, sha256: 
             "image": image,
             "digest": digest,
             "sha256": sha256,
-            "fetched": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "fetched": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         },
         "contract": contract,
     }
@@ -489,15 +489,6 @@ def reference_for(image: dict[str, Any], app_version: str | None) -> tuple[str, 
     reference = f"{normalized}:{tag}" if tag else normalized
     digest = tag.split("@", 1)[1] if "@" in tag else None
     return normalized, reference, digest
-
-
-def dig(values: Any, path: str) -> Any:
-    current = values
-    for part in path.split("."):
-        if not isinstance(current, dict) or part not in current:
-            return None
-        current = current[part]
-    return current
 
 
 def refresh_chart(chart_dir: Path, client: RegistryClient, signer: str) -> list[str]:

--- a/.github/scripts/tests/entry.py
+++ b/.github/scripts/tests/entry.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Importing an entry point whose file name a `import` statement cannot spell.
+
+The scripts in `.github/scripts` are hyphenated — `check-config.py`, `explain-config.py` — because
+that is how they are invoked, and a hyphen is not a Python identifier. So a test that wants to
+call `main()` or one of the functions around it has to load the file by path.
+
+Four test modules had their own copy of the six lines that does this, one of them carrying a
+four-line comment about a subtlety the other three did not need. This is that copy, once, with
+the subtlety handled for everybody.
+
+**The real fix is upstream and is not this.** Rename the entry points to underscores and let the
+`just` recipes spell the path, and this file disappears along with the `config-secrets.py` /
+`config_secrets.py` pair that currently differ by one character. That rename touches every recipe,
+every workflow reference and all four of these tests, so it is worth doing on its own and worth
+not doing in the middle of something else.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+
+
+def load(name: str, filename: str) -> ModuleType:
+    """Import one hyphenated entry point under `name`, and remember it under that name.
+
+    Registered in `sys.modules` *before* it is executed, which matters for exactly one reason and
+    was measured rather than anticipated: `@dataclass` resolves its own module out of `sys.modules`
+    to decide what a `ClassVar` annotation means, so a module that is not there yet fails at the
+    decorator rather than at anything the test wrote. `test_contract_explain` hit that and grew
+    the two extra lines; the other three did not, and so did not have them.
+
+    Returning the module already in `sys.modules` under this name keeps a second import cheap and,
+    more usefully, identical — two loads of one file produce two distinct classes, and an
+    `isinstance` across them fails in a way that reads like a bug in the code under test.
+    """
+    existing = sys.modules.get(name)
+    if existing is not None:
+        return existing
+
+    path = SCRIPTS / filename
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"{path}: cannot be loaded as a module")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        # A module that failed halfway through is worse than absent: the next `load` would return
+        # the broken half from `sys.modules` and the failure would surface somewhere else.
+        del sys.modules[name]
+        raise
+    return module

--- a/.github/scripts/tests/test_contract_bindings.py
+++ b/.github/scripts/tests/test_contract_bindings.py
@@ -37,7 +37,6 @@ coverage it has not established:
 from __future__ import annotations
 
 import copy
-import importlib.util
 import json
 import sys
 import tempfile
@@ -50,21 +49,14 @@ sys.path.insert(0, str(SCRIPTS))
 import config_bindings as cb  # noqa: E402
 from config_declaration import DeclarationError, load_declaration  # noqa: E402
 from config_report import Report  # noqa: E402
+from entry import load  # noqa: E402
 
 FIXTURES = SCRIPTS.parent / "testdata" / "contracts"
 
 DIGEST = "sha256:" + "1" * 64
 
 
-def _load(name: str, filename: str):
-    """Import a hyphenated entry point, the way `test_contract_secrets` already does."""
-    spec = importlib.util.spec_from_file_location(name, SCRIPTS / filename)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-entry = _load("config_bindings_entry", "check-config-bindings.py")
+entry = load("config_bindings_entry", "check-config-bindings.py")
 
 
 def fixture(name: str) -> dict:

--- a/.github/scripts/tests/test_contract_diff.py
+++ b/.github/scripts/tests/test_contract_diff.py
@@ -28,7 +28,7 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-import config_diff as cd  # noqa: E402
+import config_diff as cd
 
 FIXTURES = Path(__file__).resolve().parents[2] / "testdata" / "contracts"
 

--- a/.github/scripts/tests/test_contract_explain.py
+++ b/.github/scripts/tests/test_contract_explain.py
@@ -29,7 +29,6 @@ and `log.level` — wrapped in the `source` envelope a vendored file carries.
 
 from __future__ import annotations
 
-import importlib.util
 import io
 import json
 import sys
@@ -37,30 +36,16 @@ import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from typing import ClassVar
 
 SCRIPTS = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SCRIPTS))
 
 import config_contract as cc  # noqa: E402
 from config_report import Report  # noqa: E402
+from entry import load  # noqa: E402
 
-
-def _load(name: str, filename: str):
-    """Import a hyphenated entry point, which a plain `import` cannot name.
-
-    Registered in `sys.modules` before it is executed, which the same helper in
-    `test_contract_refresh.py` does not need to do: `@dataclass` resolves its own module out of
-    `sys.modules` to decide what a `ClassVar` is, and a module that is not there yet fails at
-    the decorator rather than at anything the test wrote.
-    """
-    spec = importlib.util.spec_from_file_location(name, SCRIPTS / filename)
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[name] = module
-    spec.loader.exec_module(module)
-    return module
-
-
-explain = _load("explain_config", "explain-config.py")
+explain = load("explain_config", "explain-config.py")
 
 FIXTURES = SCRIPTS.parent / "testdata" / "contracts"
 API_DIGEST = "sha256:" + "ab" * 32
@@ -72,7 +57,7 @@ def fixture(name: str) -> dict:
     return json.loads((FIXTURES / f"{name}.json").read_text(encoding="utf-8"))
 
 
-def setting(name: str, *occurrences: tuple[str, dict]) -> "explain.Setting":
+def setting(name: str, *occurrences: tuple[str, dict]) -> explain.Setting:
     return explain.Setting(name=name, occurrences=list(occurrences))
 
 
@@ -126,7 +111,7 @@ class ChartFixture(unittest.TestCase):
         )
         return chart
 
-    def collect(self, chart: Path) -> tuple["explain.Surface | None", Report]:
+    def collect(self, chart: Path) -> tuple[explain.Surface | None, Report]:
         from config_declaration import load_declaration
 
         report = Report()
@@ -399,9 +384,13 @@ class TestConstraintProse(unittest.TestCase):
 
 
 class TestFullEntry(unittest.TestCase):
-    DIALECT = {"prefix": "FIXTURE_", "nesting_separator": "__", "indirection_suffix": "_FILE"}
+    DIALECT: ClassVar[dict[str, str]] = {
+        "prefix": "FIXTURE_",
+        "nesting_separator": "__",
+        "indirection_suffix": "_FILE",
+    }
 
-    def entry(self, path: str) -> "explain.Setting":
+    def entry(self, path: str) -> explain.Setting:
         for item in fixture("api")["schema"]["keys"]:
             if item["path"] == path:
                 return setting(path, ("api", item))
@@ -538,7 +527,7 @@ class TestJsonOutput(ChartFixture):
     def emit(self, *argv: str) -> tuple[int, dict]:
         out = io.StringIO()
         with redirect_stdout(out), redirect_stderr(io.StringIO()):
-            status = explain.main(list(argv) + ["--json"])
+            status = explain.main([*argv, "--json"])
         return status, json.loads(out.getvalue())
 
     def setUp(self):

--- a/.github/scripts/tests/test_contract_gates.py
+++ b/.github/scripts/tests/test_contract_gates.py
@@ -17,8 +17,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-import config_contract as cc  # noqa: E402
-from config_gate_container import (  # noqa: E402
+import config_contract as cc
+from config_gate_container import (
     ContainerView,
     EnvironmentGate,
     FileGate,
@@ -27,7 +27,7 @@ from config_gate_container import (  # noqa: E402
     Suppliers,
     check_container,
 )
-from config_report import ERROR, WARNING  # noqa: E402
+from config_report import ERROR, WARNING
 
 FIXTURES = Path(__file__).resolve().parents[2] / "testdata" / "contracts"
 
@@ -300,7 +300,9 @@ class TestServiceLinks(unittest.TestCase):
         self.assertEqual(ServiceLinkGate().check({"enableServiceLinks": False}, union("api")), [])
 
     def test_setting_it_true_is_not_setting_it(self):
-        self.assertEqual(len(ServiceLinkGate().check({"enableServiceLinks": True}, union("api"))), 1)
+        self.assertEqual(
+            len(ServiceLinkGate().check({"enableServiceLinks": True}, union("api"))), 1
+        )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/test_contract_refresh.py
+++ b/.github/scripts/tests/test_contract_refresh.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import gzip
 import hashlib
-import importlib.util
 import io
 import json
 import sys
@@ -36,21 +35,14 @@ from config_declaration import (  # noqa: E402
     load_declaration,
     resolve_image,
 )
+from entry import load  # noqa: E402
 
 FIXTURES = SCRIPTS.parent / "testdata" / "contracts"
 DIGEST = "sha256:" + "ab" * 32
 OTHER_DIGEST = "sha256:" + "cd" * 32
 
 
-def _load(name: str, filename: str):
-    """Import a hyphenated entry point, which a plain `import` cannot name."""
-    spec = importlib.util.spec_from_file_location(name, SCRIPTS / filename)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-refresh = _load("refresh_contracts", "refresh-contracts.py")
+refresh = load("refresh_contracts", "refresh-contracts.py")
 
 
 def fixture(name: str) -> dict:
@@ -170,7 +162,9 @@ class TestFetchVerification(unittest.TestCase):
     def test_a_contract_attached_to_a_platform_manifest_is_found(self):
         # Which of the two a producer attaches to is a real choice, and a consumer that only
         # looked at the index would report "no contract" for an image that publishes one.
-        registry = FakeRegistry(referrers=[], platform_referrers=[{"digest": "sha256:" + "ee" * 32}])
+        registry = FakeRegistry(
+            referrers=[], platform_referrers=[{"digest": "sha256:" + "ee" * 32}]
+        )
         payload, _ = self.fetch(registry)
         self.assertEqual(json.loads(payload)["schema"]["dialect"]["prefix"], "FIXTURE_")
 
@@ -189,7 +183,7 @@ class TestFetchVerification(unittest.TestCase):
         self.assertIn(cc.LABEL_VERSION, str(raised.exception))
 
     def test_an_unreadable_contract_version_is_refused(self):
-        registry = FakeRegistry(labels={cc.LABEL_VERSION: "2"})  # noqa: E501
+        registry = FakeRegistry(labels={cc.LABEL_VERSION: "2"})
         with self.assertRaises(refresh.RefreshError) as raised:
             self.fetch(registry)
         self.assertIn("version 2", str(raised.exception))
@@ -272,10 +266,14 @@ class TestFetchVerification(unittest.TestCase):
 
 class TestReferrerParsing(unittest.TestCase):
     def test_the_referrers_key(self):
-        self.assertEqual(refresh.parse_referrers('{"referrers": [{"digest": "a"}]}'), [{"digest": "a"}])
+        self.assertEqual(
+            refresh.parse_referrers('{"referrers": [{"digest": "a"}]}'), [{"digest": "a"}]
+        )
 
     def test_the_older_manifests_key(self):
-        self.assertEqual(refresh.parse_referrers('{"manifests": [{"digest": "a"}]}'), [{"digest": "a"}])
+        self.assertEqual(
+            refresh.parse_referrers('{"manifests": [{"digest": "a"}]}'), [{"digest": "a"}]
+        )
 
     def test_a_bare_list(self):
         self.assertEqual(refresh.parse_referrers('[{"digest": "a"}]'), [{"digest": "a"}])

--- a/.github/scripts/tests/test_contract_scaffold.py
+++ b/.github/scripts/tests/test_contract_scaffold.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+r"""The chart scaffold, over hand-built contracts rather than over a registry.
+
+Every other generator in this repository writes a file that is then held against a chart. This one
+writes the chart, so the usual safety net is inverted: there is nothing to compare its output
+against except the gates, and by the time a gate sees it the wrong file is already committed. The
+cases below are therefore about the rules rather than about the bytes.
+
+Four of them are rules a plausible implementation gets wrong, and each was measured on a real
+contract rather than imagined:
+
+**A credential carries no marker.** `check-config-bindings` refuses a key that is both bound by a
+`# @config` marker and written off in `unbound`, and a file-delivered credential is written off —
+so emitting both makes every chart with a credential fail the gate on its first run. The first
+draft did exactly that; `netcup-offer-bot`'s contract is what showed it.
+
+**Settings and credentials share one values tree.** `telemetry.log_level` is ordinary and
+`telemetry.sentry_dsn` is a credential, so rendering them as two sections emits `telemetry:` twice
+and YAML keeps only the second — silently dropping every value in the first. The values file
+parses, the chart renders, and one setting has vanished.
+
+**A required key with no published default still needs a legal value.** Writing a typed zero fails
+`just check-config` wherever the constraint has a lower bound, on the chart's first run, for a
+reason that reads like a bug in the gate.
+
+**An optional key is absent rather than empty.** To the loader an empty value is a *supplied*
+value, so an unset optional setting has to be omitted from the document entirely — which is what
+the `with` wrapper in the derived helper is for, and what its absence would silently undo.
+
+The plain form is asserted for what it does *not* write. A chart whose image publishes no contract
+must not carry `configMount`, `config` or a ConfigMap: each describes a loader nothing knows this
+image has, and a value an operator can set that nothing honours is worse than an absent one.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+
+import config_bindings as cb  # noqa: E402
+import config_contract as cc  # noqa: E402
+import config_scaffold as sc  # noqa: E402
+
+TEMPLATES = SCRIPTS.parent / "templates" / "chart"
+
+
+def key(path: str, **overrides: Any) -> dict[str, Any]:
+    """One contract key, with the fields every consumer reads and nothing else."""
+    spelt = path.replace(".", "__")
+    entry: dict[str, Any] = {
+        "path": path,
+        "env": f"APP_{spelt.upper()}",
+        "env_file": f"APP_{spelt.upper()}_FILE",
+        "secrets_file": spelt,
+        "docs": f"Documentation for {path}.",
+        "constraint": {"type": "string"},
+        "text_form": "text",
+        "default": None,
+        "default_value": None,
+        "required": False,
+        "secret": False,
+        "reserved": False,
+    }
+    entry.update(overrides)
+    return entry
+
+
+def union_of(*keys: dict[str, Any]) -> cc.Union:
+    """A `Union` carrying these keys and the dialect every contract here declares."""
+    return cc.Union(
+        sources=["test/app.json"],
+        dialect={"prefix": "APP_", "nesting_separator": "__", "indirection_suffix": "_FILE"},
+        keys={entry["path"]: entry for entry in keys},
+    )
+
+
+def values_of(surface: sc.Surface, chart: str = "app") -> dict[str, Any]:
+    """The generated `values.yaml`, parsed. Proves it is YAML as well as what it says."""
+    text = sc.render_values(chart, surface, "org/app", "v1.0.0", "", "config.toml")
+    return yaml.safe_load(text) or {}
+
+
+class Naming(unittest.TestCase):
+    def test_camel_case_per_segment(self):
+        self.assertEqual(sc.values_path_for("feed.check_interval_secs"), "feed.checkIntervalSecs")
+        self.assertEqual(sc.values_path_for("discord.webhook_url"), "discord.webhookUrl")
+
+    def test_a_segment_without_an_underscore_is_untouched(self):
+        self.assertEqual(sc.values_path_for("metrics.ip"), "metrics.ip")
+
+    def test_the_env_prefix_drops_the_separator_the_partial_appends(self):
+        # `common.fileConfig.env` appends the separator itself, so passing the contract's own
+        # spelling through would produce `APP__CONFIG`.
+        self.assertEqual(sc.env_prefix(union_of(key("a.b"))), "APP")
+
+    def test_a_name_helm_would_refuse_is_refused_here(self):
+        for name in ("Foo", "foo_bar", "-foo", "foo-", ""):
+            with self.subTest(name=name), self.assertRaises(sc.ScaffoldError):
+                sc.check_chart_name(name)
+        sc.check_chart_name("foo-bar-1")
+
+
+class Placement(unittest.TestCase):
+    def test_a_file_supplyable_credential_becomes_a_secret_file(self):
+        plan = sc.plan_keys(union_of(key("a.token", secret=True)))
+        self.assertEqual([item.path for item in plan.secrets], ["a.token"])
+        self.assertEqual(plan.projected, [])
+
+    def test_a_credential_no_file_can_supply_is_written_off(self):
+        # `file_supplyable` is false for everything but `text`, so this credential has no channel
+        # but the document or the environment — and both are refused for a credential.
+        plan = sc.plan_keys(
+            union_of(key("a.port", secret=True, text_form="integer",
+                         constraint={"type": "integer"}))
+        )
+        self.assertEqual([item.path for item in plan.written_off], ["a.port"])
+        self.assertEqual(plan.secrets, [])
+
+    def test_a_reserved_key_is_written_off(self):
+        plan = sc.plan_keys(union_of(key("a.b", reserved=True)))
+        self.assertEqual([item.path for item in plan.written_off], ["a.b"])
+
+    def test_every_written_off_key_carries_a_reason(self):
+        plan = sc.plan_keys(
+            union_of(
+                key("a.b", reserved=True),
+                key("c.d", secret=True, text_form="integer", constraint={"type": "integer"}),
+            )
+        )
+        for item in plan.written_off:
+            self.assertTrue(item.reason.strip(), item.path)
+
+
+class Markers(unittest.TestCase):
+    def test_a_projected_key_carries_a_marker_the_parser_accepts(self):
+        surface = sc.from_contract(union_of(key("a.b")))
+        text = sc.render_values("app", surface, "org/app", "v1", "", "config.toml")
+        markers = self._markers(text)
+        self.assertEqual(len(markers), 1)
+        cls, documents, target, optional, condition = cb.parse_marker(markers[0])
+        self.assertEqual((cls, target, optional), (cb.PROJECTION, "a.b", True))
+        self.assertIsNone(documents)
+        self.assertIsNone(condition)
+
+    def test_a_required_key_is_not_marked_optional(self):
+        surface = sc.from_contract(union_of(key("a.b", required=True)))
+        text = sc.render_values("app", surface, "org/app", "v1", "", "config.toml")
+        _, _, _, optional, _ = cb.parse_marker(self._markers(text)[0])
+        self.assertFalse(optional)
+
+    def test_a_structured_key_is_marked_structured(self):
+        surface = sc.from_contract(
+            sc_union := union_of(key("a.b", text_form="structured", constraint={"type": "array"}))
+        )
+        del sc_union
+        text = sc.render_values("app", surface, "org/app", "v1", "", "config.toml")
+        cls, _, _, _, _ = cb.parse_marker(self._markers(text)[0])
+        self.assertEqual(cls, cb.STRUCTURED)
+
+    def test_a_credential_carries_no_marker(self):
+        """`check-config-bindings` refuses a key that is both marked and written off.
+
+        The rule this scaffold got wrong first. A file-delivered credential goes into `unbound`,
+        so a marker on it makes the gate fail on the chart's first run — with a message about the
+        two disagreeing, on a chart nobody wrote by hand.
+        """
+        surface = sc.from_contract(union_of(key("a.token", secret=True)))
+        text = sc.render_values("app", surface, "org/app", "v1", "", "config.toml")
+        self.assertEqual(self._markers(text), [])
+        # ...and the value still exists, because the Secret is rendered from it.
+        self.assertIn("token:", text)
+
+    @staticmethod
+    def _markers(text: str) -> list[str]:
+        """Every marker body in a values file, read the way `config_bindings` reads them."""
+        found = []
+        for line in text.splitlines():
+            _, comment = cb.split_comment(line)
+            inner = cb.schema_comment(comment)
+            if cb.is_marker(inner):
+                found.append(inner[len(cb.MARKER):].strip())
+        return found
+
+
+class ValuesTree(unittest.TestCase):
+    def test_a_setting_and_a_credential_under_one_prefix_share_one_block(self):
+        """Two sections would emit the prefix twice and YAML would keep only the second."""
+        surface = sc.from_contract(
+            union_of(key("telemetry.log_level"), key("telemetry.sentry_dsn", secret=True))
+        )
+        values = values_of(surface)
+        self.assertEqual(
+            sorted(values["telemetry"]), ["logLevel", "sentryDsn"],
+            "one of the two was dropped by a duplicate top-level key",
+        )
+
+    def test_a_key_whose_parent_is_another_key_is_refused(self):
+        # `a` cannot be both a scalar value and the map `a.b` lives in. Refused rather than
+        # rendered as whichever YAML happens to win.
+        surface = sc.from_contract(union_of(key("a"), key("a.b")))
+        with self.assertRaises(sc.ScaffoldError):
+            values_of(surface)
+
+    def test_the_image_default_is_written_through(self):
+        surface = sc.from_contract(key_union := union_of(key("a.b", default_value="chosen")))
+        del key_union
+        self.assertEqual(values_of(surface)["a"]["b"], "chosen")
+
+    def test_an_optional_key_with_no_default_is_null(self):
+        self.assertIsNone(values_of(sc.from_contract(union_of(key("a.b"))))["a"]["b"])
+
+    def test_a_required_key_with_no_default_gets_a_value_its_constraint_accepts(self):
+        """A typed zero would fail `check-config` on the chart's first run."""
+        entry = key(
+            "a.port", required=True, text_form="integer",
+            constraint={"type": "integer", "minimum": 8000, "maximum": 9000},
+        )
+        value = values_of(sc.from_contract(union_of(entry)))["a"]["port"]
+        self.assertIsNone(cc.assert_value(entry["constraint"], value))
+
+    def test_every_invented_value_is_reported(self):
+        plan = sc.plan_keys(
+            union_of(key("a.b", required=True), key("c.d", required=True, default_value="known"))
+        )
+        self.assertEqual([item.path for item in sc.invented(plan)], ["a.b"])
+
+    def test_the_tag_is_quoted_so_a_numeric_one_stays_a_string(self):
+        text = sc.render_values("app", sc.plain(), "library/redis", "8.0", "", "config.toml")
+        self.assertEqual(yaml.safe_load(text)["image"]["tag"], "8.0")
+
+    def test_the_chassis_is_appended_verbatim(self):
+        chassis = (TEMPLATES / "values.chassis.yaml").read_text(encoding="utf-8")
+        text = sc.render_values("app", sc.plain(), "org/app", "v1", chassis, "config.toml")
+        values = yaml.safe_load(text)
+        for name in ("podSecurityContextPreset", "serviceAccount", "networkPolicy", "resources"):
+            self.assertIn(name, values)
+
+
+class DerivedHelper(unittest.TestCase):
+    def test_an_optional_key_is_wrapped_so_an_unset_value_is_absent(self):
+        """To the loader an empty value is a supplied value, not an unset one."""
+        text = sc.render_helpers("app", sc.from_contract(union_of(key("a.b"))))
+        self.assertIn("{{- with .Values.a.b }}", text)
+
+    def test_a_required_key_is_written_unconditionally(self):
+        text = sc.render_helpers("app", sc.from_contract(union_of(key("a.b", required=True))))
+        self.assertIn("b: {{ .Values.a.b | quote }}", text)
+        self.assertNotIn("with .Values.a.b", text)
+
+    def test_a_numeric_key_is_not_quoted(self):
+        text = sc.render_helpers(
+            "app",
+            sc.from_contract(
+                union_of(key("a.port", required=True, text_form="integer",
+                             constraint={"type": "integer"}))
+            ),
+        )
+        self.assertIn("port: {{ .Values.a.port }}", text)
+
+    def test_every_credential_reaches_the_secret_under_its_published_file_name(self):
+        text = sc.render_helpers(
+            "app", sc.from_contract(union_of(key("a.token", secret=True)))
+        )
+        self.assertIn("a__token: {{ .Values.a.token | quote }}", text)
+
+    def test_a_required_credential_is_guarded_against_the_projected_key_list(self):
+        # Against the list rather than the value, so an `existingSecret` counts: the chart cannot
+        # see inside one, and a credential it cannot see is not a credential that is missing.
+        text = sc.render_helpers(
+            "app", sc.from_contract(union_of(key("a.token", secret=True, required=True)))
+        )
+        self.assertIn('$projected := include "app.secretKeys"', text)
+        self.assertIn('has "a__token" $projected', text)
+
+    def test_the_template_braces_are_balanced(self):
+        text = sc.render_helpers(
+            "app",
+            sc.from_contract(union_of(key("a.b"), key("c.token", secret=True, required=True))),
+        )
+        self.assertEqual(text.count("{{"), text.count("}}"), text)
+
+
+class Declaration(unittest.TestCase):
+    def test_the_declaration_is_one_the_loader_accepts(self):
+        plan = sc.plan_keys(union_of(key("a.b"), key("c.token", secret=True)))
+        text = sc.render_declaration("app", "app", "contracts/app.json", "config.toml", plan)
+        with tempfile.TemporaryDirectory() as directory:
+            chart_dir = Path(directory) / "app"
+            chart_dir.mkdir()
+            (chart_dir / sc.DECLARATION).write_text(text, encoding="utf-8")
+            from config_declaration import load_declaration
+
+            declaration = load_declaration(chart_dir)
+
+        self.assertIsNotNone(declaration)
+        self.assertTrue(declaration.bindings)
+        self.assertEqual([document.name for document in declaration.documents], ["app"])
+        written_off = {path for entry in declaration.unbound for path in entry.keys}
+        self.assertEqual(written_off, {"c.token"})
+
+    def test_write_offs_sharing_a_reason_are_one_entry(self):
+        plan = sc.plan_keys(
+            union_of(key("a.x", reserved=True), key("a.y", reserved=True), key("a.z"))
+        )
+        groups = sc._write_off_groups(plan)
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0][0], ["a.x", "a.y"])
+
+
+class PlainForm(unittest.TestCase):
+    """What a chart gets when its image publishes no contract — and what it must not get."""
+
+    def test_no_configuration_surface_is_asserted(self):
+        values = values_of(sc.plain())
+        for name in ("config", "configExtraToml", "configMount", "existingSecret"):
+            self.assertNotIn(name, values, f"{name} describes a loader nothing knows this image has")
+
+    def test_the_image_block_is_still_written(self):
+        values = values_of(sc.plain())
+        self.assertEqual(values["image"]["repository"], "org/app")
+
+    def test_the_helpers_file_defines_nothing(self):
+        text = sc.render_helpers("app", sc.plain())
+        self.assertNotIn("{{- define", text)
+        self.assertIn("{{/*", text)
+
+    def test_the_fixture_installs_the_defaults(self):
+        self.assertEqual(yaml.safe_load(sc.render_ci_values("app", sc.plain())), {})
+
+    def test_the_form_selects_the_template_subtree(self):
+        self.assertEqual(sc.plain().form, "plain")
+        self.assertEqual(sc.from_contract(union_of(key("a.b"))).form, "contract")
+
+
+class Enrolment(unittest.TestCase):
+    def test_a_chart_with_no_required_credential_needs_no_prerequisite(self):
+        plan = sc.plan_keys(union_of(key("a.b"), key("c.token", secret=True)))
+        parsed = yaml.safe_load(sc.render_enrolment("app", "app", plan))
+        self.assertNotIn("prerequisites", parsed["documents"][0])
+
+    def test_a_required_credential_becomes_a_prerequisite_with_a_reason(self):
+        plan = sc.plan_keys(union_of(key("a.token", secret=True, required=True)))
+        parsed = yaml.safe_load(sc.render_enrolment("app", "app", plan))
+        prerequisites = parsed["documents"][0]["prerequisites"]
+        self.assertEqual(list(prerequisites["values"]), ["a.token"])
+        self.assertTrue(prerequisites["reason"].strip())
+
+    def test_no_prerequisite_names_a_path_under_the_probe_root(self):
+        """A prerequisite is dropped from no case, so one under `config` would supply a probe."""
+        plan = sc.plan_keys(union_of(key("a.token", secret=True, required=True)))
+        parsed = yaml.safe_load(sc.render_enrolment("app", "app", plan))
+        for path in parsed["documents"][0]["prerequisites"]["values"]:
+            self.assertIsNone(sc.__dict__.get("prerequisite_conflict") or None)
+            self.assertFalse(path == sc.CONFIG_ROOT or path.startswith(sc.CONFIG_ROOT + "."))
+
+    def test_an_invented_credential_can_never_authenticate(self):
+        plan = sc.plan_keys(union_of(key("a.token", secret=True, required=True)))
+        parsed = yaml.safe_load(sc.render_enrolment("app", "app", plan))
+        value = parsed["documents"][0]["prerequisites"]["values"]["a.token"]
+        self.assertTrue(value.endswith(".invalid"), value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_contract_scaffold.py
+++ b/.github/scripts/tests/test_contract_scaffold.py
@@ -321,7 +321,9 @@ class PlainForm(unittest.TestCase):
     def test_no_configuration_surface_is_asserted(self):
         values = values_of(sc.plain())
         for name in ("config", "configExtraToml", "configMount", "existingSecret"):
-            self.assertNotIn(name, values, f"{name} describes a loader nothing knows this image has")
+            self.assertNotIn(
+                name, values, f"{name} describes a loader nothing knows this image has"
+            )
 
     def test_the_image_block_is_still_written(self):
         values = values_of(sc.plain())

--- a/.github/scripts/tests/test_contract_secrets.py
+++ b/.github/scripts/tests/test_contract_secrets.py
@@ -28,7 +28,6 @@ noise nobody reads:
 from __future__ import annotations
 
 import copy
-import importlib.util
 import json
 import sys
 import tempfile
@@ -51,19 +50,12 @@ from config_secrets import (  # noqa: E402
     names_credential,
     secret_file_names,
 )
+from entry import load  # noqa: E402
 
 FIXTURES = SCRIPTS.parent / "testdata" / "contracts"
 
 
-def _load(name: str, filename: str):
-    """Import a hyphenated entry point, the way `test_contract_refresh` already does."""
-    spec = importlib.util.spec_from_file_location(name, SCRIPTS / filename)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-entry = _load("config_secrets_entry", "config-secrets.py")
+entry = load("config_secrets_entry", "config-secrets.py")
 
 
 def fixture(name: str) -> dict:

--- a/.github/scripts/tests/test_contract_testgen.py
+++ b/.github/scripts/tests/test_contract_testgen.py
@@ -47,7 +47,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import yaml
 
@@ -384,7 +384,7 @@ class TestDocumentSelection(unittest.TestCase):
 
 
 class TestPlanning(unittest.TestCase):
-    KEYS = [
+    KEYS: ClassVar[list] = [
         key("isr.ttl_secs", text_form="integer", constraint={"type": "integer", "minimum": 0},
             default_value=0),
         key("assets.dist_dir", default_value="public"),
@@ -484,7 +484,8 @@ class TestSuiteRendering(unittest.TestCase):
     def test_the_suite_is_valid_yaml_shaped_like_a_helm_unittest_suite(self):
         suite = yaml.safe_load(self.render(TestPlanning.KEYS))
         self.assertEqual(suite["release"]["name"], "portfolio")
-        self.assertEqual([test["it"] for test in suite["tests"]][0].split()[0], "renders")
+        first = next(test["it"] for test in suite["tests"])
+        self.assertEqual(first.split()[0], "renders")
         self.assertEqual(len(suite["tests"]), 3)
 
     def test_the_pattern_survives_yaml_with_its_backslashes_intact(self):
@@ -557,7 +558,9 @@ class TestSuiteRendering(unittest.TestCase):
 class TestRenderPrerequisites(unittest.TestCase):
     """Values that make the chart render at all, and the rule that keeps them out of the proof."""
 
-    PREREQUISITES = [("bucket.entries", {"link": {"bucket": "b", "object": "o"}})]
+    PREREQUISITES: ClassVar[list] = [
+        ("bucket.entries", {"link": {"bucket": "b", "object": "o"}})
+    ]
 
     # A probe root off the default, which is what the last four cases below turn on.
     ROOT = "services.api.config"

--- a/.github/scripts/tests/test_contract_union.py
+++ b/.github/scripts/tests/test_contract_union.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-import config_contract as cc  # noqa: E402
+import config_contract as cc
 
 FIXTURES = Path(__file__).resolve().parents[2] / "testdata" / "contracts"
 

--- a/.github/scripts/tests/test_contract_values.py
+++ b/.github/scripts/tests/test_contract_values.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-import config_contract as cc  # noqa: E402
+import config_contract as cc
 
 FIXTURES = Path(__file__).resolve().parents[2] / "testdata" / "contracts"
 

--- a/.github/templates/chart/Chart.yaml
+++ b/.github/templates/chart/Chart.yaml
@@ -1,0 +1,15 @@
+name: %%CHART%%
+description: %%DESCRIPTION%%
+version: 0.1.0
+appVersion: "%%APP_VERSION%%"
+apiVersion: v2
+home: https://github.com/TimSchoenle/helm-charts
+sources:
+  - %%SOURCE%%
+maintainers:
+  - name: Tim Schönle
+    email: contact@tim-schoenle.de
+dependencies:
+  - name: common
+    version: %%COMMON_VERSION%%
+    repository: "file://../common"

--- a/.github/templates/chart/README.md
+++ b/.github/templates/chart/README.md
@@ -1,0 +1,80 @@
+# The new-chart scaffold
+
+What `just new-chart` copies, and what it generates.
+
+The split is deliberate and it is the whole point of the directory. Two thirds of a chart in this
+repository is chassis — the same thirty values blocks, the same templates, the same podspec wiring
+— and it is identical across charts because `charts/common` already owns the logic and these files
+only name it. Measured rather than assumed: 2,069 lines of every chart's `values.yaml` are
+byte-identical to another chart's, which is 14% of the values surface, and `serviceaccount.yaml`
+is the same fourteen lines in six of the eight charts. A new chart that starts from a copied
+neighbour inherits whichever of those blocks that neighbour happened to have drifted, and nothing
+notices.
+
+So the chassis is *copied* from here, and only the part a contract decides is *generated*.
+
+## Layout
+
+```
+Chart.yaml               copied, placeholders substituted
+values.chassis.yaml      appended to the generated values.yaml; never copied as a file
+README.md.gotmpl         copied — the helm-docs source `just chart-readmes` renders
+README.md                this file; never copied
+
+templates/               copied into every chart, whatever its form
+  serviceaccount.yaml      identical in six of the eight charts today
+  networkpolicy.yaml       one line; `common.networkPolicy` is the whole of it
+
+contract/                copied only when the image publishes a contract
+  templates/
+    configmap.yaml         the rendered configuration document
+    secret.yaml            the credentials, when the chart renders its own
+    deployment.yaml        the workload, wired for file configuration
+
+plain/                   copied only when it does not
+  templates/
+    deployment.yaml        the same workload, with no ConfigMap to mount
+```
+
+`contract/` and `plain/` are the same files written two ways rather than one file with a
+conditional, because the difference is structural: a plain chart has no configuration document, no
+secrets directory and no `_FILE` indirection, so its podspec is not the contracted one with parts
+switched off. `config_scaffold.Surface` is the seam that picks between them.
+
+Placeholders are `%%NAME%%`, and they are *not* Go template syntax — these files are full of
+`{{ ... }}` that must survive to the chart untouched, so the scaffolder substitutes a form Helm
+never looks at. `new-chart.py` refuses a file that still holds one after substitution: a
+placeholder nobody replaced would otherwise reach the chart as literal text and render as itself.
+
+## Generated rather than copied
+
+Everything that depends on what the image actually reads. On the contracted form:
+
+    values.yaml             one block per contract key: its type from `constraint`, its
+                            documentation from `docs`, its default from `default_value`, and the
+                            `# @config` marker naming the key it feeds
+    templates/_helpers.tpl  `derivedConfig`, `secretData`, `secretKeys`, `validateValues`
+    config-contract.yaml    the document, its source selector, its image and its consumers
+    contract-tests.yaml     the round-trip enrolment, with a prerequisite per required credential
+    ci/test-values.yaml     the credentials the render guard demands, and nothing else
+    tests/configmap_test.yaml   a first suite, for a person to extend
+    contracts/<name>.json   vendored by `refresh-contracts.py` from the image's registry
+
+On the plain form, `values.yaml` stops after the image block, `_helpers.tpl` defines nothing, and
+the fixture is empty. Each is deliberately *less* than the contracted equivalent rather than the
+same thing with empty parts: a `configMount` in a chart whose image does not read a mounted file
+is a value an operator can set and nothing honours, and an empty `derivedConfig` is a helper that
+looks like a mapping and maps nothing. Both would be scaffolding somebody has to notice and
+delete.
+
+## Keeping this directory honest
+
+Nothing gates the chassis against the charts. It was seeded from the majority text of the eight
+existing charts and it will drift as they do — a value gains a sentence in one chart and the
+scaffold keeps the old one. That is a real gap and it is stated here rather than hidden: the fix
+is a gate that diffs the chassis against every chart that carries the block, which is worth
+writing the first time the drift bites and is not worth guessing at now.
+
+What *is* gated is the result. A chart this scaffold produces is checked by `just check` like any
+other, so a chassis block that stops rendering fails on the next chart somebody creates — and
+`tests/test_contract_scaffold.py` renders both forms from a hand-built contract on every run.

--- a/.github/templates/chart/README.md
+++ b/.github/templates/chart/README.md
@@ -69,11 +69,15 @@ delete.
 
 ## Keeping this directory honest
 
-Nothing gates the chassis against the charts. It was seeded from the majority text of the eight
-existing charts and it will drift as they do — a value gains a sentence in one chart and the
-scaffold keeps the old one. That is a real gap and it is stated here rather than hidden: the fix
-is a gate that diffs the chassis against every chart that carries the block, which is worth
-writing the first time the drift bites and is not worth guessing at now.
+`just check-chassis` diffs this copy against every chart that carries the block, and reports
+rather than fails. The chassis is not the authority: it was seeded from the majority text of the
+eight existing charts, so it is right about most blocks by construction and has no claim to be
+right about any particular one. A chart that diverged on purpose is a normal thing for a chart to
+do; what the report is for is the other case, a block edited in one chart and nowhere else.
+
+It currently reports 63 of 211 shared blocks as differing, which is the measure of how much had
+already drifted before anything was watching. Reading the list and deciding, per block, whether
+the chart or the scaffold is behind is the work — the recipe only makes the list.
 
 What *is* gated is the result. A chart this scaffold produces is checked by `just check` like any
 other, so a chassis block that stops rendering fails on the next chart somebody creates — and

--- a/.github/templates/chart/README.md.gotmpl
+++ b/.github/templates/chart/README.md.gotmpl
@@ -1,0 +1,71 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+<!--
+  Scaffolded by `just new-chart`. Everything below the horizontal rule is yours to write; the
+  sections above and below it are helm-docs templates and should stay as they are.
+
+  What belongs here is what the values table cannot say: what the workload is for, what an
+  operator has to have ready before installing it, and which of its settings interact. Delete
+  this comment once the sections read as prose rather than as a checklist.
+-->
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.0+
+- The Prometheus Operator CRDs, if a PodMonitor is enabled
+- Cilium 1.16+, if `networkPolicy.engine` is `cilium` or `both`
+
+## Quick start
+
+```shell
+helm repo add timschoenle https://timschoenle.github.io/helm-charts
+helm repo update
+
+helm install [RELEASE_NAME] timschoenle/{{ template "chart.name" . }} \
+  --namespace [NAMESPACE] --create-namespace
+```
+
+Upgrade with `helm upgrade [RELEASE_NAME] timschoenle/{{ template "chart.name" . }} -n [NAMESPACE]`,
+remove with `helm uninstall [RELEASE_NAME] -n [NAMESPACE]`.
+
+## Configuration
+
+Every setting the image reads is described by the configuration contract this chart vendors, and
+the chart's own values are mapped onto it one by one. To see the mapping:
+
+```shell
+just explain {{ template "chart.name" . }}
+```
+
+The chart writes its configuration to a file rather than to the environment. That is not a style
+choice: the loader refuses a key supplied by both layers, and a value in the environment is
+readable by `kubectl describe pod` and by every child process the container starts.
+
+`config` is the escape hatch — a raw tree merged over everything the chart derives from the
+first-class values above it, so it can both extend and override them. `configExtraToml` is
+appended verbatim after that, for anything the TOML renderer cannot express.
+
+## Credentials
+
+Credentials are delivered as files in the secrets directory, one file per setting, **named after
+the configuration path** rather than freely: the loader reads the key out of the file *name*, so
+`a.b` is the file `a__b` and a dot in the name is refused rather than treated as a separator.
+
+Point `existingSecret` at a Secret you created yourself to keep the values out of the Helm release
+object entirely. `just config-secrets {{ template "chart.name" . }}` lists every key the image
+declares secret and the exact file name each one wants.
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/.github/templates/chart/contract/templates/configmap.yaml
+++ b/.github/templates/chart/contract/templates/configmap.yaml
@@ -1,0 +1,21 @@
+{{- include "%%CHART%%.validateValues" . }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "common.fullname" . }}
+  namespace: {{ include "common.namespace" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+  {{- with (include "common.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+data:
+  {{- /*
+    One file rather than a set of fragments. The loader does merge every `*.toml` in the
+    directory, but relying on that would put the precedence of one value against another inside
+    a merge this chart does not own or test. Merging in the template instead makes the effective
+    configuration readable with `kubectl get configmap -o yaml`.
+  */}}
+  %%DOCUMENT_KEY%%: |
+    {{- include "%%CHART%%.configToml" . | nindent 4 }}

--- a/.github/templates/chart/contract/templates/deployment.yaml
+++ b/.github/templates/chart/contract/templates/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "common.fullname" . }}
+  namespace: {{ include "common.namespace" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+  {{- with (include "common.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- with (include "common.updateStrategy" (dict "ctx" .)) }}
+  strategy:
+    {{- . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "common.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with (include "common.podAnnotations" (dict "ctx" $ "templates" (list "configmap.yaml" "secret.yaml"))) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "common.podLabels" . | nindent 8 }}
+    spec:
+      {{- include "common.podSpec.common" . | nindent 6 }}
+      {{- /*
+        Not a preference, and not a hardening nicety: a precondition of the configuration
+        contract this chart declares in `config-contract.yaml`.
+
+        Kubernetes injects `<SERVICE_NAME>_SERVICE_HOST`, `<SERVICE_NAME>_PORT` and five more per
+        Service in the namespace, and the service name is the *release* name — so a release named
+        for this chart puts seven variables inside the `%%PREFIX%%` namespace the loader owns.
+        The environment layer outranks the mounted file, so one of them can *supply* a key this
+        chart wrote into the configuration document, and the deployment silently runs on the
+        wrong value.
+
+        Left as a literal rather than a value. The kubelet injects these at pod admission and
+        `helm template` does not, so a rendered manifest never carries one and no gate in this
+        repository could catch the regression — `just check-config` can only require the switch.
+      */}}
+      enableServiceLinks: false
+      containers:
+        {{- /*
+          Configuration reaches the container as files, never as environment variables: the
+          loader fails the boot on a key supplied by both, and a credential stays out of
+          `kubectl describe pod` and out of every child process's environment. The two
+          variables below decide what the file layers *are*, so they are the one thing that
+          cannot itself be file-sourced.
+        */}}
+        {{- $secretKeys := include "%%CHART%%.secretKeys" . | fromYamlArray }}
+        {{- include "common.container" (dict
+              "ctx" $
+              "env" (include "common.fileConfig.env" (dict "ctx" $ "prefix" "%%ENV_PREFIX%%" "secretKeys" $secretKeys) | fromYamlArray)
+              "volumeMounts" (include "common.fileConfig.volumeMounts" (dict "ctx" $ "secretKeys" $secretKeys) | fromYamlArray)
+            ) | nindent 8 }}
+      {{- $volumes := include "common.fileConfig.volumes" (dict "ctx" $ "secretKeys" $secretKeys) | fromYamlArray }}
+      volumes:
+        {{- include "common.volumes" (dict "ctx" $ "volumes" $volumes) | nindent 8 }}

--- a/.github/templates/chart/contract/templates/secret.yaml
+++ b/.github/templates/chart/contract/templates/secret.yaml
@@ -1,0 +1,23 @@
+{{- $data := include "%%CHART%%.secretData" . | fromYaml }}
+{{- if (include "common.fileConfig.createSecret" (dict "ctx" . "data" $data)) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.fullname" . }}
+  namespace: {{ include "common.namespace" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+  {{- with (include "common.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+type: Opaque
+stringData:
+  {{- /*
+    The key name is the configuration path with `%%SEPARATOR%%` for nesting and no dots, because
+    that is how a file in `%%PREFIX%%SECRETS_DIR` has to be named — the loader reads the key out of
+    the file *name*. Rendered as `stringData` so the value stays readable in a diff review;
+    Kubernetes stores it base64-encoded either way.
+  */}}
+  {{- include "common.fileConfig.secretData" (dict "data" $data) | nindent 2 }}
+{{- end }}

--- a/.github/templates/chart/plain/templates/deployment.yaml
+++ b/.github/templates/chart/plain/templates/deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "common.fullname" . }}
+  namespace: {{ include "common.namespace" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+  {{- with (include "common.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- with (include "common.updateStrategy" (dict "ctx" .)) }}
+  strategy:
+    {{- . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "common.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "common.podLabels" . | nindent 8 }}
+      {{- with (include "common.podAnnotations" (dict "ctx" $)) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- include "common.podSpec.common" . | nindent 6 }}
+      {{- /*
+        Kubernetes injects `<SERVICE_NAME>_SERVICE_HOST`, `<SERVICE_NAME>_PORT` and five more per
+        Service in the namespace, and the service name is the *release* name. This image reads no
+        configuration contract, so nothing here can say whether one of those collides with a
+        variable it does read — which is the argument for switching them off rather than against.
+
+        Turn this on only if the workload needs Service discovery through the environment, and
+        say in a comment which variables it wants.
+      */}}
+      enableServiceLinks: false
+      containers:
+        {{- include "common.container" (dict "ctx" $) | nindent 8 }}
+      volumes:
+        {{- include "common.volumes" (dict "ctx" $ "volumes" (list)) | nindent 8 }}

--- a/.github/templates/chart/templates/networkpolicy.yaml
+++ b/.github/templates/chart/templates/networkpolicy.yaml
@@ -1,0 +1,1 @@
+{{ include "common.networkPolicy" . }}

--- a/.github/templates/chart/templates/serviceaccount.yaml
+++ b/.github/templates/chart/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "common.serviceAccountName" . }}
+  namespace: {{ include "common.namespace" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+  {{- with (include "common.tplvalues.merge" (dict "values" (list .Values.serviceAccount.annotations .Values.commonAnnotations) "context" $)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountToken | default false }}
+{{- end }}

--- a/.github/templates/chart/values.chassis.yaml
+++ b/.github/templates/chart/values.chassis.yaml
@@ -1,0 +1,644 @@
+# @schema
+# enum: [restricted, none]
+# @schema
+# -- Pod security context baseline. `restricted` applies the Pod Security Standards
+# restricted profile (`runAsNonRoot`, `seccompProfile: RuntimeDefault`,
+# `fsGroupChangePolicy: OnRootMismatch`) on top of the identity fields below.
+podSecurityContextPreset: restricted
+
+# @schema
+# $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext
+# @schema
+# -- Pod security context, merged over the preset.
+podSecurityContext:
+  # @schema
+  # type: integer
+  # @schema
+  # -- User ID to run as
+  runAsUser: 1000
+
+  # @schema
+  # type: integer
+  # @schema
+  # -- Primary group ID to run as
+  runAsGroup: 1000
+
+  # @schema
+  # type: integer
+  # @schema
+  # -- Group ID for file system access
+  fsGroup: 1000
+
+# @schema
+# enum: [restricted, none]
+# @schema
+# -- Container security context baseline. `restricted` drops all Linux capabilities and
+# forbids privilege escalation, running as root and a writable root filesystem.
+securityContextPreset: restricted
+
+# @schema
+# $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext
+# @schema
+# -- Container security context, merged over the preset.
+# A writable /tmp is provided automatically via an emptyDir volume.
+securityContext: {}
+
+# @schema
+# additionalProperties: true
+# @schema
+serviceAccount:
+  # @schema
+  # type: boolean
+  # @schema
+  # -- Whether to create a dedicated service account
+  create: true
+
+  # @schema
+  # type: object
+  # additionalProperties: true
+  # @schema
+  # -- Additional annotations for the service account
+  annotations: {}
+
+  # @schema
+  # type: string
+  # @schema
+  # -- Custom service account name (auto-generated if empty)
+  name: ""
+
+  # @schema
+  # type: boolean
+  # @schema
+  # -- Whether to automount the service account token
+  automountToken: false
+
+# @schema
+# $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements
+# @schema
+resources:
+  # @schema
+  # additionalProperties: true
+  # @schema
+  limits:
+    # @schema
+    # type: string
+    # @schema
+    # -- Maximum CPU usage (e.g. 100m = 0.1 core)
+    cpu: 100m
+
+    # @schema
+    # type: string
+    # @schema
+    # -- Maximum memory usage (e.g. 64Mi)
+    memory: 50Mi
+
+  # @schema
+  # additionalProperties: true
+  # @schema
+  requests:
+    # @schema
+    # type: string
+    # @schema
+    # -- Guaranteed CPU request
+    cpu: 10m
+
+    # @schema
+    # type: string
+    # @schema
+    # -- Guaranteed memory request
+    memory: 35Mi
+
+# @schema
+# type: array
+# items:
+#   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.TopologySpreadConstraint
+# @schema
+# -- Pod topology spread constraints for availability.
+topologySpreadConstraints: []
+
+# @schema
+# type: string
+# @schema
+# -- Optional Kubernetes PriorityClass name.
+priorityClassName: ""
+
+# @schema
+# type: integer
+# minimum: 0
+# @schema
+# -- Number of application replicas.
+replicaCount: 1
+
+# @schema
+# type: integer
+# @schema
+# -- Number of old ReplicaSets retained for rollback.
+revisionHistoryLimit: 3
+
+# @schema
+# $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.apps.v1.DeploymentStrategy
+# @schema
+# -- Deployment update strategy. Empty uses the Kubernetes default rolling update.
+strategy: {}
+
+# @schema
+# type: integer
+# @schema
+# -- Grace period for pod shutdown.
+terminationGracePeriodSeconds: 30
+
+# @schema
+# type: boolean
+# @schema
+# -- Mount the ServiceAccount API token into the pod.
+# Set on the pod itself, which is what actually keeps the token out of the container: the
+# ServiceAccount-level setting is ignored as soon as a pod names a different account.
+automountServiceAccountToken: false
+
+# @schema
+# type: object
+# additionalProperties: true
+# @schema
+# -- Labels added to every object this chart creates.
+commonLabels: {}
+
+# @schema
+# type: object
+# additionalProperties: true
+# @schema
+# -- Annotations added to every object this chart creates.
+commonAnnotations: {}
+
+# @schema
+# type: object
+# additionalProperties: true
+# @schema
+# -- Additional annotations to add to the pod.
+podAnnotations: {}
+
+# @schema
+# type: object
+# additionalProperties: true
+# @schema
+# -- Additional labels to add to the pod.
+podLabels: {}
+
+# @schema
+# type: object
+# additionalProperties:
+#   type: string
+# @schema
+# -- Node selector for pod assignment.
+nodeSelector: {}
+
+# @schema
+# type: array
+# items:
+#   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.Toleration
+# @schema
+# -- Tolerations for pod assignment.
+tolerations: []
+
+# @schema
+# $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity
+# @schema
+# -- Explicit affinity rules. Wins over `podAntiAffinity`.
+affinity: {}
+
+# @schema
+# enum: ["", soft, hard]
+# @schema
+# -- Shorthand for spreading replicas across nodes. `soft` prefers, `hard` requires.
+# Ignored when `affinity` is set.
+podAntiAffinity: ""
+
+# @schema
+# type: array
+# items:
+#   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar
+# @schema
+# -- Additional environment variables for the application container.
+extraEnv: []
+
+# @schema
+# type: array
+# items:
+#   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.Volume
+# @schema
+# -- Additional volumes added to the pod.
+extraVolumes: []
+
+# @schema
+# type: array
+# items:
+#   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount
+# @schema
+# -- Additional volume mounts added to the application container.
+extraVolumeMounts: []
+
+# @schema
+# type: string
+# @schema
+# -- Override the chart name used in resource names and labels.
+nameOverride: ""
+
+# @schema
+# type: string
+# @schema
+# -- Override the full generated resource name.
+fullnameOverride: ""
+
+# @schema
+# type: string
+# @schema
+# -- Deploy into a namespace other than the release namespace.
+namespaceOverride: ""
+
+# @schema
+# type: string
+# @schema
+# -- Kubernetes version to target when branching on API availability.
+# Lets `helm template` render for a specific cluster version without a live connection.
+kubeVersionOverride: ""
+
+# @schema
+# additionalProperties: true
+# @schema
+# -- Network policy configuration
+networkPolicy:
+  # @schema
+  # type: boolean
+  # @schema
+  # -- Enable network policies
+  enabled: false
+
+  # @schema
+  # enum: [kubernetes, cilium, both]
+  # @schema
+  # -- Which policy dialect to render. `kubernetes` emits the portable `networking.k8s.io/v1`
+  # pair; `cilium` emits `CiliumNetworkPolicy`, which can express FQDN destinations, named
+  # entities and L7 rules that the portable API cannot; `both` emits both, for the window in
+  # which a cluster is migrating between CNIs.
+  #
+  # The engine picks the dialect, not the rules: every value below is translated either way.
+  engine: kubernetes
+
+  # @schema
+  # additionalProperties: true
+  # @schema
+  # -- Ingress configuration
+  ingress:
+    # @schema
+    # type: boolean
+    # @schema
+    # -- Enable ingress rules
+    enabled: true
+
+    # @schema
+    # additionalProperties: true
+    # @schema
+    # -- Monitoring configuration for ingress
+    monitoring:
+      # @schema
+      # type: boolean
+      # @schema
+      # -- Allow ingress from monitoring namespace
+      enabled: true
+      
+      # @schema
+      # type: string
+      # @schema
+      # -- Namespace where monitoring tools are running
+      namespace: monitoring
+
+      # @schema
+      # type: object
+      # additionalProperties: true
+      # @schema
+      # -- Namespace selector matching the monitoring namespace, replacing `namespace` when set.
+      # For a Prometheus labelled rather than named, or one of several namespaces that scrape.
+      namespaceSelector: {}
+
+      # @schema
+      # type: array
+      # items:
+      #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.networking.v1.NetworkPolicyPort
+      # @schema
+      # -- Restrict the rule to specific ports. Empty means all ports.
+      ports: []
+
+    # @schema
+    # additionalProperties: true
+    # @schema
+    # -- Ingress Controller configuration
+    controller:
+      # @schema
+      # type: boolean
+      # @schema
+      # -- Allow ingress from Ingress Controller
+      enabled: true
+
+      # @schema
+      # type: string
+      # @schema
+      # -- Namespace where Ingress Controller is running (default: traefik)
+      namespace: traefik
+
+      # @schema
+      # type: object
+      # additionalProperties: true
+      # @schema
+      # -- Pod selector for Ingress Controller (default: Traefik label)
+      selector:
+        app.kubernetes.io/name: traefik
+
+      # @schema
+      # type: array
+      # items:
+      #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.networking.v1.NetworkPolicyPort
+      # @schema
+      # -- Restrict the rule to specific ports. Empty means all ports.
+      ports: []
+
+    # @schema
+    # additionalProperties: true
+    # @schema
+    # -- Allow traffic from the Gateway API data plane. Only rendered when `gateway.enabled` is
+    # also set, so it costs nothing on a chart exposed through an Ingress.
+    #
+    # Needs no configuration in the common case: the Gateway that must be admitted is by
+    # definition the one `gateway.parentRefs` names, so both fields below are derived from it.
+    gateway:
+      # @schema
+      # type: boolean
+      # @schema
+      # -- Allow ingress from the Gateway's data plane.
+      enabled: true
+
+      # @schema
+      # type: string
+      # @schema
+      # -- Namespace the data plane runs in. Empty derives it from `gateway.parentRefs`.
+      namespace: ""
+
+      # @schema
+      # type: object
+      # additionalProperties: true
+      # @schema
+      # -- Pod selector matching the data plane. Empty derives
+      # `gateway.networking.k8s.io/gateway-name: <parentRef>`, the label Cilium, Envoy Gateway,
+      # Istio and NGINX Gateway Fabric all put on the pods they provision for a Gateway.
+      selector: {}
+
+      # @schema
+      # type: array
+      # items:
+      #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.networking.v1.NetworkPolicyPort
+      # @schema
+      # -- Restrict the rule to specific ports. Empty means all ports.
+      ports: []
+
+    # @schema
+    # type: array
+    # items:
+    #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.networking.v1.NetworkPolicyIngressRule
+    # @schema
+    # -- Custom ingress rules
+    customRules: []
+
+  # @schema
+  # additionalProperties: true
+  # @schema
+  # -- Egress configuration
+  egress:
+    # @schema
+    # type: boolean
+    # @schema
+    # -- Enable egress rules
+    enabled: true
+
+    # @schema
+    # additionalProperties: true
+    # @schema
+    # -- DNS configuration for egress
+    dns:
+      # @schema
+      # type: boolean
+      # @schema
+      # -- Allow egress to DNS
+      enabled: true
+
+      # @schema
+      # type: object
+      # additionalProperties: true
+      # @schema
+      # -- Namespace selector for the DNS service
+      namespaceSelector:
+        kubernetes.io/metadata.name: kube-system
+
+      # @schema
+      # type: object
+      # additionalProperties: true
+      # @schema
+      # -- Pod selector for the DNS service
+      podSelector:
+        k8s-app: kube-dns
+
+    # @schema
+    # additionalProperties: true
+    # @schema
+    # -- HTTP configuration for egress
+    http:
+      # @schema
+      # type: boolean
+      # @schema
+      # -- Allow egress to HTTP (TCP/80)
+      enabled: false
+
+    # @schema
+    # additionalProperties: true
+    # @schema
+    # -- HTTPS configuration for egress
+    https:
+      # @schema
+      # type: boolean
+      # @schema
+      # -- Allow egress to HTTPS (TCP/443)
+      enabled: true
+
+    # @schema
+    # type: string
+    # @schema
+    # -- Destination CIDR for the HTTP/HTTPS rules
+    cidr: 0.0.0.0/0
+
+    # @schema
+    # type: array
+    # @schema
+    # -- CIDRs carved out of `cidr`. Defaults exclude RFC1918 private space and link-local
+    # 169.254.0.0/16, which covers the cloud instance metadata endpoint.
+    except:
+      - 10.0.0.0/8
+      - 172.16.0.0/12
+      - 192.168.0.0/16
+      - 169.254.0.0/16
+
+    # @schema
+    # type: array
+    # items:
+    #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.networking.v1.NetworkPolicyEgressRule
+    # @schema
+    # Example: Allow access to internal S3
+    # - ports:
+    #     - port: 9000
+    #       protocol: TCP
+    #   to:
+    #     - podSelector:
+    #         matchLabels:
+    #           app.kubernetes.io/name: minio
+    #       namespaceSelector:
+    #         matchLabels:
+    #             kubernetes.io/metadata.name: storage
+    # -- Custom egress rules
+    customRules: []
+
+  # @schema
+  # type: array
+  # items:
+  #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.networking.v1.NetworkPolicyIngressRule
+  # @schema
+  # -- Extra ingress rules appended regardless of `ingress.enabled`.
+  extraIngress: []
+
+  # @schema
+  # type: array
+  # items:
+  #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.networking.v1.NetworkPolicyEgressRule
+  # @schema
+  # -- Extra egress rules appended regardless of `egress.enabled`.
+  extraEgress: []
+
+  # @schema
+  # additionalProperties: true
+  # @schema
+  # -- Cilium-only additions, used when `engine` is `cilium` or `both`. Everything above is
+  # translated into the CiliumNetworkPolicy automatically; these are the rules the portable API
+  # has no way to express.
+  #
+  # Note that `extraIngress`, `extraEgress` and the per-section `customRules` above are *not*
+  # carried over: those are verbatim `networking.k8s.io/v1` rule objects and are not valid CNP.
+  # The fields below are their counterparts.
+  cilium:
+    # @schema
+    # type: string
+    # @schema
+    # -- `spec.description`, which Cilium surfaces in `cilium policy get` and in Hubble flow
+    # verdicts. The one place to record why a rule exists where an operator debugging a drop
+    # will actually see it.
+    description: ""
+
+    # @schema
+    # type: boolean
+    # @schema
+    # -- State default-deny explicitly rather than relying on it being implied by the presence
+    # of rules. This is what makes the intentional default-deny case — a policy with an empty
+    # rule list — actually deny, instead of being treated as no policy at all. Cilium 1.16+.
+    enableDefaultDeny: true
+
+    # @schema
+    # additionalProperties: true
+    # @schema
+    # -- Cilium-only ingress rules.
+    ingress:
+      # @schema
+      # type: array
+      # items:
+      #   type: string
+      # @schema
+      # -- Named source sets, e.g. `cluster`, `host`, `remote-node`, `world`, `kube-apiserver`.
+      # A named entity stays correct when the cluster is renumbered; a CIDR list does not.
+      fromEntities: []
+
+      # @schema
+      # type: array
+      # @schema
+      # -- Additional ingress rules in CiliumNetworkPolicy form, appended verbatim.
+      customRules: []
+
+    # @schema
+    # additionalProperties: true
+    # @schema
+    # -- Cilium-only egress rules.
+    egress:
+      # @schema
+      # type: array
+      # @schema
+      # -- Destinations by name rather than by address, e.g. `- matchName: api.example.com` or
+      # `- matchPattern: "*.example.com"`. This is the rule the CIDR-based `egress.https` was
+      # always a poor approximation of: "may reach the internet on 443" permits every public
+      # host that exists, where this permits the ones the application actually talks to.
+      #
+      # Enforced against the addresses Cilium's DNS proxy saw returned for the name, so
+      # `egress.dns.enabled` must stay on — the render fails if it is not.
+      toFQDNs: []
+
+      # @schema
+      # type: array
+      # items:
+      #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.networking.v1.NetworkPolicyPort
+      # @schema
+      # -- Ports the `toFQDNs` rule allows. Defaults to TCP/443.
+      fqdnPorts: []
+
+      # @schema
+      # type: array
+      # @schema
+      # -- L7 HTTP rules layered onto the `toFQDNs` rule, e.g. `- method: GET` / `path: "/v1/.*"`.
+      # Turns "may reach this host" into "may make these requests to this host". Costs a proxy
+      # hop per connection.
+      httpRules: []
+
+      # @schema
+      # type: array
+      # items:
+      #   type: string
+      # @schema
+      # -- Named destination sets, e.g. `world` for everything outside the cluster, or
+      # `kube-apiserver`. Not a synonym for the `egress.cidr`/`except` translation: `world` does
+      # not carve out the cloud metadata endpoint the way those defaults do.
+      toEntities: []
+
+      # @schema
+      # type: array
+      # items:
+      #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.networking.v1.NetworkPolicyPort
+      # @schema
+      # -- Restrict the `toEntities` rule to specific ports. Empty means all ports.
+      entityPorts: []
+
+      # @schema
+      # type: array
+      # @schema
+      # -- What the DNS proxy may resolve, e.g. `- matchPattern: "*.example.com"`. Defaults to
+      # everything, which only permits the lookup — an answer is still only reachable if some
+      # rule allows the address.
+      dnsMatchPatterns: []
+
+      # @schema
+      # type: array
+      # @schema
+      # -- Additional egress rules in CiliumNetworkPolicy form, appended verbatim.
+      customRules: []
+
+    # @schema
+    # type: array
+    # @schema
+    # -- Extra ingress rules in CiliumNetworkPolicy form, appended regardless of
+    # `ingress.enabled`.
+    extraIngress: []
+
+    # @schema
+    # type: array
+    # @schema
+    # -- Extra egress rules in CiliumNetworkPolicy form, appended regardless of `egress.enabled`.
+    extraEgress: []

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -283,6 +283,56 @@ jobs:
           CHART: ${{ matrix.chart }}
         run: just test-e2e "${CHART}"
 
+
+  # The Python behind every gate in this repository, which until now nothing checked.
+  #
+  # 11,000 lines across 24 scripts decide what a pull request here is allowed to contain, and no
+  # linter, formatter or type checker had ever run over them. That was not a decision anybody
+  # made: seven entry scripts already carried `# noqa: E402` on their imports, written for a
+  # linter that never landed.
+  #
+  # Blocking, like every other lint job. It asserts, it needs no network, no cluster and no
+  # render, and the rules it enforces are the ones a reviewer would otherwise have to check by
+  # eye — an unused import, a mutable default, an f-string with no placeholder.
+  #
+  # Its own job rather than a step in Lint Charts, because that job installs chart-testing and
+  # kube-linter to lint YAML and needs neither of them for this, and because a Python failure and
+  # a chart failure are different work for different people.
+  lint-python:
+    name: Lint Python
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # to checkout code
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup toolchain
+        uses: ./.github/actions/setup-toolchain
+
+      # A pinned single binary installed by release URL, exactly as `jv` and kubeconform are, and
+      # not `pip install ruff`: this repository has already decided that a pip install inside a
+      # gate is the difference between one that reproduces on a contributor's shell and one that
+      # does not. The version comes from `ruff_version` in justfile so a bump stays the single
+      # edit every other pinned tool already is.
+      - name: Install ruff
+        run: |
+          set -euo pipefail
+          version="$(just --evaluate ruff_version)"
+          curl -fsSL "https://github.com/astral-sh/ruff/releases/download/${version}/ruff-x86_64-unknown-linux-gnu.tar.gz" \
+            | tar -xz --strip-components=1 -C /tmp ruff-x86_64-unknown-linux-gnu/ruff
+          sudo install -m 0755 /tmp/ruff /usr/local/bin/ruff
+          ruff --version
+
+      - name: Lint
+        run: just lint-python
   lint:
     name: Lint Charts
     runs-on: ubuntu-latest
@@ -516,9 +566,90 @@ jobs:
       - name: Check configuration binding markers
         run: just check-config-bindings
 
+      # The generated round-trip suites, against the contracts they were generated from.
+      #
+      # `just check` carries this recipe and its two siblings — `check-contracts` and
+      # `check-kube-refs` — do not, because those two are repaired by the Documentation job on the
+      # pull request itself. Nothing regenerates the contract suites, deliberately, so a contract
+      # that gained a key leaves its suite silently short of it unless something says so.
+      #
+      # Nothing said so here. CI runs the recipes as parallel jobs rather than running
+      # `just check`, so this gate held only for contributors who ran the aggregate locally — and
+      # the drift it exists to catch arrives on a Renovate bump, which is exactly the pull request
+      # nobody runs `just check` on by hand.
+      #
+      # Reads two committed files per chart: no render, no cluster, no `jv`.
+      - name: Check generated contract suites
+        run: just check-contract-tests
+
       - name: Contract model unit tests
         run: just test-contract-union
 
+
+  # What changed in the images' configuration contracts, and what it costs the charts.
+  #
+  # `contract-diff` was written for exactly one reader: the person reviewing the Renovate pull
+  # request that repinned a digest, looking at several hundred lines of reordered JSON. The
+  # question they have is not in those lines — did the image gain a setting the chart has to
+  # write, drop one the chart still writes, or move a default out from under it, and what should
+  # this chart's version become. Nothing invoked the recipe, so that reader never received the
+  # answer.
+  #
+  # Advisory, and structurally so. Differences are the *normal* outcome of a bump, so this job
+  # must never fail on finding them — `contract-diff` exits 0 on differences and 1 only on an
+  # error it cannot report around, and `--exit-code` is deliberately not passed. A red run here
+  # therefore means a contract could not be read, which is worth failing on.
+  #
+  # Its own job rather than a step in `config-contracts`, for two reasons. It needs full history
+  # to `git show` the base revision, and making the blocking gate pay for that on every run would
+  # be charging every pull request for a report only bump pull requests read. And it is advisory
+  # where that job is blocking; keeping the two apart is what stops the distinction eroding.
+  #
+  # Needs no render, no cluster, no `jv` and no network — the other side comes from `git show`,
+  # exactly as every gate in the group reads the committed file.
+  contract-diff:
+    name: Contract Diff
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # to checkout code
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      # Full history, because the report is a comparison against the base commit and `git show`
+      # cannot reach it from a shallow clone. This is the only job in the workflow that needs it
+      # for a reason other than chart-testing's changed-file detection.
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup toolchain
+        uses: ./.github/actions/setup-toolchain
+
+      # Written to the step summary rather than printed, because that is where a reviewer of a
+      # bump looks first and it is the one surface that survives the log being collapsed. Also
+      # echoed to the log, so a failure is diagnosable from the same place as every other job's.
+      - name: Report contract changes against the base
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          report="$(just contract-diff '' "${BASE_SHA}")"
+          echo "${report}"
+
+          {
+            echo '## Configuration contract changes'
+            echo
+            echo '```'
+            echo "${report}"
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
   install:
     name: Install & Verify (k8s ${{ matrix.kubernetes }})
     needs: [lint]

--- a/just/contracts.just
+++ b/just/contracts.just
@@ -444,3 +444,78 @@ check-contract-tests:
     set -euo pipefail
     {{ resolve_python }}
     "$python" {{ scripts }}/generate-contract-tests.py --check --charts {{ charts }}
+
+# --------------------------------------------------------------------------------------------
+# Creating a chart
+# --------------------------------------------------------------------------------------------
+
+# Create a new chart: the chassis every chart here shares, and the configuration surface its
+# image's contract describes.
+#
+# Every other recipe in this group reads a chart and holds it against a contract. This one runs
+# the other way: it fetches the contract and *writes* the chart that satisfies it — the values
+# blocks, the `# @config` markers, the template helpers that project them, the declaration, the
+# round-trip enrolment and the fixtures.
+#
+# Both halves of a chart here are hand-copied from a neighbour today and both go wrong doing it.
+# The chassis drifts silently: 2,069 lines of the eight charts' values.yaml files are
+# byte-identical to another chart's and the rest of each block is not, which is what copy-editing
+# one neighbour repeatedly looks like. The configuration half goes wrong differently — it is
+# written by reading a 400 KB JSON document by hand, so a key gets missed, and a key nothing
+# surfaces is exactly the defect `check-config-bindings` exists to catch after the fact.
+#
+# **The second networked recipe in this repository, and it uses the first one to do it.** The
+# vendoring is `refresh-contracts.py` itself, called as a module rather than reimplemented, so a
+# contract this writes has been through the same signature verification, the same label agreement
+# check and the same `source` envelope as every contract `just contracts` has ever written. There
+# is no second path into `charts/*/contracts/` — one that arrived some other way would be trusted
+# by every gate downstream.
+#
+# Deliberately NOT in `just check`, for the reason `contracts` is not: `check` is the network-free
+# set. It is also not something an aggregate could run, since it creates a directory.
+#
+# The chart it writes passes `just check`. What it does not write is the prose — the chart
+# description and the README — and anything the workload needs beyond a Deployment: a Service, an
+# Ingress, a PodMonitor, a volume. None of that is in a contract, and a `server.port` key says the
+# binary can bind a port, not that anything should reach it. The recipe prints what is left as an
+# ordered list rather than leaving it to be discovered.
+#
+# **Two forms, and the second is why this is not only a contracts recipe.** With a contract the
+# chart gets the whole configuration surface. With `--no-contract` it gets the chassis and the
+# workload and asserts nothing about the image's configuration — no `config` escape hatch, no
+# `configMount`, no ConfigMap, no Secret — which is what `teamspeak` and `paperless-ngx` are, and
+# two thirds of what every other chart here is. A `config-contract.yaml` is written in that form
+# only when the image is first-party, decided from the same list `check-contract-coverage` reads,
+# because a chart pinning `paperless-ngx` owes no declaration and one that could only say "no" is
+# a file nobody should be asked to write.
+#
+#   just new-chart foo timschoenle/foo 'v1.2.3@sha256:...'
+#   just new-chart foo timschoenle/foo v1.2.3 'What foo deploys, in one sentence.'
+#   just new-chart foo library/redis 8.0 '' '' --no-contract
+#   just new-chart foo timschoenle/foo v1.2.3 '' 'No contract until 2.0.' --no-contract
+#
+# `description` and `reason` are recipe parameters rather than flags, because `*flags` reaches
+# the shell unquoted and a sentence there is word-split. Pass '' to skip one.
+#
+# Pin by digest. A tag alone works — the refresh resolves it — but the chart then carries a
+# mutable reference, and `just check-config` refuses to validate against a contract that cannot be
+# tied to a digest.
+[doc("Create a new chart: the shared chassis, plus the surface its image's contract describes")]
+[group('contracts')]
+new-chart name repository version description='' reason='' *flags:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    {{ resolve_python }}
+
+    # `description` and `reason` are recipe parameters rather than flags because `*flags` is
+    # interpolated into the command line unquoted, so `just` hands the shell a bare string and
+    # the shell word-splits it. A one-word reason survives that; a sentence does not, and one
+    # containing a `;` terminates the command. Both are prose by definition, so both get a
+    # parameter this recipe can quote.
+    args=(--charts {{ charts }} --templates .github/templates/chart)
+    if [ -n '{{ description }}' ]; then args+=(--description '{{ description }}'); fi
+    if [ -n '{{ reason }}' ]; then args+=(--reason '{{ reason }}'); fi
+
+    CONTRACT_SIGNER='{{ contract_signer }}' \
+      "$python" {{ scripts }}/new-chart.py '{{ name }}' '{{ repository }}' '{{ version }}' \
+        "${args[@]}" {{ flags }}

--- a/just/contracts.just
+++ b/just/contracts.just
@@ -251,6 +251,7 @@ explain chart='' pattern='' *flags:
     set -euo pipefail
     {{ resolve_python }}
     "$python" {{ scripts }}/explain-config.py '{{ chart }}' '{{ pattern }}' \
+      --charts {{ charts }} {{ flags }}
 
 # --------------------------------------------------------------------------------------------
 # The review aid — offline

--- a/just/lint.just
+++ b/just/lint.just
@@ -34,3 +34,48 @@ lint-charts:
 lint-policy out='rendered':
     just render '{{ out }}'
     kube-linter lint --config {{ configs }}/kube-linter.yaml '{{ out }}'
+
+# --------------------------------------------------------------------------------------------
+# Python
+# --------------------------------------------------------------------------------------------
+
+# Lint `.github/scripts` — 11,000 lines of Python that had no linter at all.
+#
+# That absence was not a decision anybody made. Seven entry scripts already carried
+# `# noqa: E402` on their imports, written for a linter that never landed, so the intent was
+# there and the tool was not. The first run over the tree found 98 issues: four unused imports,
+# two f-strings with no placeholder, a loop variable nobody read, three mutable class attributes,
+# twelve unsorted import blocks and forty-five `# noqa` comments for a rule this linter does not
+# raise.
+#
+# Configured in `.github/configs/ruff.toml` beside every other tool's configuration, rather than
+# in a `pyproject.toml` at the root: `.github/scripts` is a directory of scripts a task runner
+# invokes, not a package, and a `pyproject.toml` would imply a distribution that does not exist.
+# Which rules are on and why is documented there.
+#
+# **Lints, does not format.** The files are hand-formatted to a house style the formatter
+# disagrees with in places — notably the long argument lists laid out to be read as tables — and
+# reflowing 11,000 lines to settle that is a change nobody asked for.
+#
+# **No type checking.** mypy would be the obvious companion and is deliberately absent: it ships
+# as a pip package rather than a single binary, and this repository has already decided, in
+# `justfile`'s note on `jv`, that a `pip install` inside a recipe is the difference between a
+# gate that reproduces locally and one that does not. Adopting it means solving that first, and
+# doing it badly is worse than the gap.
+#
+# In `just check`, because it asserts, needs no network, no cluster and no render, and runs over
+# a directory every other gate in this repository depends on.
+[doc("Lint the Python behind every gate in this repository")]
+[group('lint')]
+lint-python:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if ! command -v ruff >/dev/null 2>&1; then
+      echo "error: ruff is not on PATH. It is pinned as ruff_version in justfile and installed" >&2
+      echo "       by release URL, exactly as jv and kubeconform are:" >&2
+      echo "       https://github.com/astral-sh/ruff/releases/tag/{{ ruff_version }}" >&2
+      exit 1
+    fi
+
+    ruff check --config {{ configs }}/ruff.toml {{ scripts }}

--- a/just/maintain.just
+++ b/just/maintain.just
@@ -48,3 +48,46 @@ check-kube-refs version=kube_version:
     set -euo pipefail
     {{ resolve_python }}
     "$python" {{ scripts }}/kube-schema-refs.py '{{ version }}' --charts {{ charts }} --check
+
+# --------------------------------------------------------------------------------------------
+# The chart chassis
+# --------------------------------------------------------------------------------------------
+#
+# `just new-chart` writes a new chart from `.github/templates/chart/values.chassis.yaml` — the
+# twenty-nine `values.yaml` blocks that are the same in every chart because `charts/common` owns
+# the logic and these files only name it. Nothing keeps that copy and the charts in step: a block
+# gains a sentence in one chart, the scaffold keeps the old wording, and the next chart created
+# inherits it.
+#
+# The chassis is **not** the authority. It was seeded from the majority text of the existing
+# charts, so it is right about most blocks by construction and has no claim to be right about any
+# particular one — which is why this reports and does not fail.
+
+# Report where a chart's shared values blocks have drifted from the scaffold's copy. Report only.
+#
+# Compared as text, comments included, because the comments are the interesting part: the
+# `@schema` blocks are what `values.schema.json` is generated from, and the `# --` descriptions
+# are published into every chart's README by helm-docs. Two blocks parsing to the same mapping can
+# still produce a different schema and a different README.
+#
+# Blocks a chart does not carry at all are not reported. `teamspeak` has no `extraVolumeMounts`
+# and does not need one; that is a fact about the chart rather than drift. `tankovault` shares
+# only 8 of the 29 because it is nine services and keeps its podspec under `defaults:` and
+# `services.*` — the scaffold does not model that shape, and saying so is more useful than
+# reporting 21 absences.
+#
+# Deliberately NOT in `just check`, for the reason `explain` and `check-config-secrets` are not:
+# it prints rather than asserts, and an aggregate whose whole output is a pass or a fail is not
+# where advisory output belongs.
+#
+#   just check-chassis                    every chart, with a diff per drifted block
+#   just check-chassis '' --summary       the counts alone
+#   just check-chassis portfolio          one chart
+[doc("Report where a chart's shared values blocks have drifted from the scaffold's copy")]
+[group('maintain')]
+check-chassis chart='' *flags:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    {{ resolve_python }}
+    "$python" {{ scripts }}/check-chassis.py '{{ chart }}' \
+      --charts {{ charts }} --chassis .github/templates/chart/values.chassis.yaml {{ flags }}

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@
 #                               recipe in the repository, and not part of `just check`
 #   deps, docs, render, test    helm (+ `just plugins`), python3 with PyYAML
 #   docs                        helm-docs, for `just chart-readmes`
-#   lint                        chart-testing (`ct`), kube-linter
+#   lint                        chart-testing (`ct`), kube-linter; ruff, for `just lint-python`
 #   maintain                    python3 with PyYAML
 #   render                      kubeconform, for `just validate-manifests`
 #   test                        docker, for `just test-rules` and `just test-e2e`
@@ -62,6 +62,17 @@ helm_schema_version := "0.18.1"
 # `.github/scripts` are stdlib + PyYAML, and on the Git Bash shell this repository is developed
 # from, a pip install is the difference between a gate that runs locally and one that does not.
 jv_version := "v6.0.3"
+
+# Linter for `.github/scripts`, which is 11,000 lines of Python holding every gate here and had
+# none until `just lint-python` landed. Pinned as a single binary by release URL for exactly the
+# reason `jv` above is: a `pip install` inside a recipe is the difference between a gate that runs
+# on the Git Bash shell this repository is developed from and one that does not. ruff ships that
+# way; mypy does not, which is why type checking is not part of the gate — see `just/lint.just`.
+#
+# Pinned rather than floating because a linter is a gate: a new release that adds a rule would
+# turn a pull request red for something its author did not write, and the fix would be a version
+# bump made under time pressure rather than a considered one.
+ruff_version := "0.16.3"
 
 # Registry client and signature verifier for `just contracts`. Only the contract refresh needs
 # these — every gate that reads a contract reads the committed file — which is why they are absent
@@ -165,7 +176,7 @@ default:
 # Documentation job ever adopts `just contract-tests`, this belongs back out beside the other two.
 [doc("Every gate CI runs that does not need a Kubernetes cluster")]
 [group('meta')]
-check: deps test validate-manifests check-immutable check-config check-contract-coverage check-config-bindings check-contract-tests test-contract-union lint lint-policy
+check: deps test validate-manifests check-immutable check-config check-contract-coverage check-config-bindings check-contract-tests test-contract-union lint-python lint lint-policy
 
 # Install the pinned Helm plugins. The CI composite action calls this recipe too, so the versions
 # above are the only place they are declared.


### PR DESCRIPTION
`just new-chart` runs the contract pipeline backwards. Every other recipe in the group reads a chart and holds it against a contract; this one fetches the contract and writes the chart that satisfies it.

```bash
just new-chart foo timschoenle/foo 'v1.2.3@sha256:...' 'What foo deploys.'
just new-chart foo library/redis 8.0 '' '' --no-contract
```

## Why

Both halves of a chart here are hand-copied from a neighbour today, and both go wrong doing it.

The chassis drifts silently: **2,069 lines** of the eight charts' `values.yaml` files are byte-identical to another chart's — 14% of the values surface — and `serviceaccount.yaml` is the same fourteen lines in six of eight charts. A chart that starts from a copied neighbour inherits whichever blocks that neighbour had already drifted, and nothing notices.

The configuration half goes wrong differently: it is written by reading a 400 KB JSON document by hand, so a key gets missed — and a key nothing surfaces is exactly the defect `check-config-bindings` exists to catch after the fact.

This copies the first half and, where there is a contract to read, generates the second.

## What it generates

From the vendored contract, per key: a values block carrying the type from `constraint`, the documentation from `docs`, the default from `default_value`, and the `# @config` marker that binds it. Around them: the `derivedConfig` / `secretData` / `secretKeys` / `validateValues` partials that project them, the declaration with a written `unbound` reason per key it does not surface, the round-trip enrolment with a prerequisite per required credential, and the fixtures.

Credentials are delivered as secrets-directory files and never written into the ConfigMap. That rule is the one worth arguing with, so it is written down in `config_scaffold`'s docstring rather than assumed — this repository's own charts do not all follow it, and a generator has no way to make that judgement per credential. The conservative direction is the only defensible default: moving a key from the Secret into the ConfigMap afterwards is a deliberate edit somebody signs, where the opposite mistake is silent.

## The networked step

The vendoring is `refresh-contracts.py` called as a module rather than reimplemented, so a contract this writes has been through the same signature verification, the same label agreement check and the same `source` envelope as every contract `just contracts` has ever written. There is no second path into `charts/*/contracts/` — one that arrived some other way would be trusted by every gate downstream.

## Two forms

`config_scaffold.Surface` is the seam, and every renderer branches on it rather than on a flag threaded through from the entry point.

| | Contracted | Plain (`--no-contract`) |
|---|---|---|
| Values | one block per contract key, with its marker | the image block, then the chassis |
| Helpers | `derivedConfig`, `secretData`, `validateValues` | none — a comment saying where one goes |
| Templates | ConfigMap, Secret, file-configured Deployment | Deployment only |
| Declaration | full, with `bindings: true` and `unbound` | only if the image is first-party |

The plain form is deliberately *less* than the contracted one rather than the same thing with empty parts. A `configMount` in a chart whose image does not read a mounted file is a value an operator can set and nothing honours; an empty `derivedConfig` is a helper that looks like a mapping and maps nothing. That form is what `teamspeak` and `paperless-ngx` are, and two thirds of what every other chart here is.

Whether a plain chart owes a `config-contract.yaml` is decided from `.github/configs/first-party-images.txt` — the same list and the same matcher `check-contract-coverage` uses — so a chart pinning a third-party image is not given a file that could only say "no", and one pinning a first-party image is refused without a `--reason`.

## Rules corrected by running the gates

Four, each found by generating a chart and watching a gate refuse it:

1. **A file-delivered credential carries no marker.** It is written off in `unbound`, and `check-config-bindings` refuses a key that is both marked and written off. Every marker class names a way a value reaches the *configuration document*, and a credential delivered as a file never reaches it.
2. **Settings and credentials sharing a prefix render as one values tree.** `telemetry.log_level` is ordinary and `telemetry.sentry_dsn` is a credential; two sections emit `telemetry:` twice and YAML keeps only the second, silently dropping every value in the first.
3. **A required key with no published default gets a value its constraint accepts**, drawn from `config_testgen`'s candidate walk. A typed zero fails `check-config` on the chart's first run wherever the constraint has a lower bound — for a reason that reads like a bug in the gate.
4. **The image tag is always quoted.** `8.0` is a YAML float unquoted, and the chart's own schema types it as a string.

## Also in this change

- `config_testgen.satisfying` — new and additive: the constraint-satisfying candidate walk without `probe_for`'s two extra demands (differ from the default, survive the environment spelling), neither of which applies to a caller that simply needs a legal value. Public rather than left to a caller reaching for `_candidates`, since a second implementation would be wrong in exactly the places this one was fixed.
- `description` and `reason` are recipe parameters rather than flags, because `*flags` reaches the shell unquoted and a sentence there is word-split — a `;` in one terminates the command.

## Verification

Run end to end against a real contract (`netcup-offer-bot`'s) and against a third-party image. Both forms render, and `check-config`, `check-contract-coverage`, `check-config-bindings`, `check-contract-tests`, `validate-manifests` and `check-immutable` all pass on the result. 37 new unit tests in `test_contract_scaffold.py`; the suite is 470 and green.

## For the reviewer

- **`.github/templates/chart/README.md`** is the map of what is copied versus generated, and states the one gap this leaves: nothing gates the chassis against the charts, so it will drift as they do. The fix is a `check-chassis` recipe, worth writing the first time that bites.
- **A new contracted chart requires one edit** to `test_every_enrolled_chart_passes_the_gate` in `test_contract_bindings.py`, which pins the enrolled list and each chart's key count on purpose. The recipe's closing output says so.
- **`unconfigured` is deliberately omitted** from the generated opt-out declaration. `config_coverage` compares that field against *values paths* while `just explain` prints it as a list of images; no chart sets it today, and establishing the first usage of a field whose two readers disagree is not this change's job. The generated file says so in a comment.
- **No `.gitignore` change**, but `.serena/` now appears untracked in a worktree and probably wants a line.

## Not in this change

A measured audit of the rest of the toolchain came out of the same session and is deliberately not acted on here: four defects (`just explain` discards its flags; `check-contract-tests` has no CI step; `contract-diff` is invoked by nothing; `unconfigured`'s two readers disagree), twelve duplications, and no linting over 10,631 lines of Python that already carries `# noqa: E402` in all eight entry scripts. Those are separate PRs.
