### PR TITLE
feat(ci): report contract changes on the pull request that causes them

### DIFF
--- a/.github/configs/ruff.toml
+++ b/.github/configs/ruff.toml
@@ -1,0 +1,85 @@
+# Linting for `.github/scripts`, which is 11,000 lines of Python holding every gate in this
+# repository and, until this file, had no linter at all.
+#
+# That absence was not a decision anybody made. Seven entry scripts already carry `# noqa: E402`
+# on their imports — written for a linter that never landed — so the intent was there and the
+# tool was not.
+#
+# Configured here rather than in a `pyproject.toml` at the root, because there is no Python
+# package here to configure: `.github/scripts` is a directory of scripts a task runner invokes,
+# and a `pyproject.toml` would imply a distribution that does not exist. `.github/configs/` is
+# where every other tool's configuration already lives — `ct.yaml`, `kube-linter.yaml`,
+# `lintconf.yaml`, `render-api-versions.txt` — so this sits beside them.
+
+# The interpreter the recipes resolve to on a CI runner. Not the lowest version that would work:
+# the scripts already use `X | None` unions and `match`-free structural code, and pinning the
+# target to what actually runs them is what lets the linter flag a construct that would break
+# there rather than one that would break on a Python nobody uses.
+target-version = "py311"
+
+# Matches the width the scripts are already written to, and the width `values.yaml`'s comments
+# and the justfile's own prose use. Chosen by measuring the existing files rather than by taking
+# the tool's default of 88, which would have reported several hundred lines that are deliberate.
+line-length = 100
+
+[lint]
+# Deliberately more than the default `E4,E7,E9,F`, and deliberately not `ALL`.
+#
+#   E, W    pycodestyle: the whitespace and layout rules the files already follow
+#   F       pyflakes: unused imports and names, the single highest-value check here — this
+#           repository has already accumulated four of them, each found by hand
+#   I       import sorting, so an added import has one correct position rather than an opinion
+#   B       flake8-bugbear: mutable default arguments, `except` that swallows, loop-variable
+#           capture. Real defects rather than style
+#   UP      pyupgrade: keeps the files on one generation of syntax rather than two
+#   C4      comprehension rewrites, where the rewritten form is plainly clearer
+#   RUF     ruff's own, notably the mutable-dataclass-default check this codebase's many
+#           `@dataclass` types are exposed to
+select = ["E", "W", "F", "I", "B", "UP", "C4", "RUF"]
+
+# E402 — a module-level import after the `sys.path` bootstrap every entry script and every test
+# module needs — is deliberately *not* ignored here. Sixty-six of those imports already carry a
+# per-line `# noqa: E402`, written by hand, and each one marks the exact place the bootstrap makes
+# the import unavoidable. A blanket ignore would make all sixty-six dead comments and would also
+# stop reporting an import that landed after the bootstrap by accident. Keeping the rule on means
+# ruff validates the existing comments — an unused one is an `RUF100` — and a new entry script is
+# told once, at the line, why it needs one.
+ignore = [
+  # RUF002 flags a character in a *docstring* that could be confused with an ASCII one. The rule
+  # exists so a homoglyph cannot hide inside something that gets executed or compared, and a
+  # docstring is neither. This repository's prose is deliberately typographic — em dashes, arrows,
+  # `×8` meaning "eight of them" in `config_bindings`' marker table — and rewriting that to ASCII
+  # would make the tables worse to read in exchange for nothing.
+  #
+  # RUF001 (identifiers and string literals) and RUF003 (comments) stay on, which is where the
+  # rule's premise actually holds.
+  "RUF002",
+]
+
+[lint.isort]
+# The sibling modules are neither standard library nor third-party: they are this directory,
+# imported by name because it is on `sys.path`. Naming them keeps them in their own block rather
+# than mixed into third-party imports where a reader cannot tell them from PyYAML.
+known-first-party = [
+  "config_bindings",
+  "config_contract",
+  "config_coverage",
+  "config_declaration",
+  "config_diff",
+  "config_gate_container",
+  "config_gate_document",
+  "config_manifests",
+  "config_paths",
+  "config_report",
+  "config_scaffold",
+  "config_secrets",
+  "config_testgen",
+  "entry",
+]
+
+[format]
+# Not enabled as a gate. The files are hand-formatted to a house style the formatter disagrees
+# with in places — notably the long argument lists in `config_testgen`'s renderers, which are laid
+# out to be read as tables — and reflowing 11,000 lines to settle that is a change nobody asked
+# for. `just lint-python` lints; it does not format.
+docstring-code-format = false

--- a/.github/scripts/check-chassis.py
+++ b/.github/scripts/check-chassis.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Report where a chart's shared values blocks have drifted from the scaffold's copy.
+
+`just new-chart` writes a new chart from `.github/templates/chart/values.chassis.yaml` — the
+twenty-nine `values.yaml` blocks that are the same in every chart because `charts/common` owns the
+logic and these files only name it. Nothing keeps that copy and the charts in step. A block gains a
+sentence in one chart, the scaffold keeps the old wording, and the next chart created inherits it.
+
+That is the gap this reports, and it is worth being precise about which direction it runs in. The
+scaffold is **not** the authority. It was seeded from the majority text of the eight existing
+charts, which means it is right about most blocks by construction and has no claim to be right
+about any particular one. So this prints differences and exits 0: a chart that has deliberately
+diverged is a normal thing for a chart to do, and a gate that failed on it would be red for a
+decision somebody made on purpose.
+
+What the report is *for* is the other case — a block edited in one chart and nowhere else, which
+is the same drift `just new-chart` exists to stop and which nothing else in this repository can
+see. Reading the list and deciding, per block, whether the chart or the scaffold is behind is the
+work; this only makes the list.
+
+--------------------------------------------------------------------------------------------
+Why the comparison is textual
+--------------------------------------------------------------------------------------------
+
+A block is compared as the lines it occupies, comments included, not as the value it parses to.
+That is deliberate twice over.
+
+The `@schema` blocks *are* the interesting part: they are what `values.schema.json` is generated
+from, so a chart whose `podSecurityContext` block lost a `type: integer` has a materially
+different schema while parsing to the same mapping. And the `# --` descriptions are published —
+helm-docs renders them into every chart's README — so a description that improved in one chart and
+nowhere else is exactly the drift worth seeing.
+
+Whitespace at the end of a line is normalised away and nothing else is. Two blocks that differ
+only in trailing spaces are the same block, and a reader told otherwise would stop reading the
+report.
+
+--------------------------------------------------------------------------------------------
+What is deliberately not reported
+--------------------------------------------------------------------------------------------
+
+**A chart that does not carry a block at all.** `teamspeak` has no `extraVolumeMounts` and does
+not need one; "this chart is missing a block the scaffold writes" is a fact about what the chart
+does, not about drift. Only blocks present on both sides are compared.
+
+**Anything outside the chassis.** A chart's own configuration surface is per image and has no
+shared copy to drift from.
+
+Usage: python3 .github/scripts/check-chassis.py
+       python3 .github/scripts/check-chassis.py --charts charts --chassis <path>
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from config_paths import CHARTS_DIR
+
+CHASSIS = Path(".github/templates/chart/values.chassis.yaml")
+
+# A top-level mapping key in a values file. Anchored at column zero, which is what makes it a
+# *top-level* key and not any of the several hundred nested ones.
+_TOP_LEVEL = re.compile(r"^[A-Za-z][A-Za-z0-9]*:")
+
+# The library chart, which has no chassis: it renders nothing and carries no values of its own.
+LIBRARY = "common"
+
+
+def blocks(text: str) -> dict[str, list[str]]:
+    """Split a values file into its top-level blocks, each with the comment run above its key.
+
+    The comment run is part of the block and not of the one before it, because that run is the
+    `@schema` block and the `# --` description — the two things a reader is comparing. Attaching
+    it to the preceding key would report every difference against the wrong neighbour.
+    """
+    lines = text.splitlines()
+    starts = [index for index, line in enumerate(lines) if _TOP_LEVEL.match(line)]
+
+    found: dict[str, list[str]] = {}
+    for position, start in enumerate(starts):
+        end = starts[position + 1] if position + 1 < len(starts) else len(lines)
+
+        # Give the next block back the comment run and blank lines directly above its own key.
+        while end > start and (lines[end - 1].startswith("#") or not lines[end - 1].strip()):
+            end -= 1
+
+        top = start
+        while top > 0 and lines[top - 1].startswith("#"):
+            top -= 1
+
+        found[lines[start].split(":")[0]] = [line.rstrip() for line in lines[top:end]]
+    return found
+
+
+def compare(chassis: dict[str, list[str]], chart: str, values: dict[str, list[str]]) -> list[str]:
+    """A unified diff per shared block that differs. Empty when the chart matches the scaffold."""
+    report: list[str] = []
+    for name in sorted(chassis):
+        theirs = values.get(name)
+        if theirs is None or theirs == chassis[name]:
+            continue
+        report.extend(
+            difflib.unified_diff(
+                chassis[name],
+                theirs,
+                fromfile=f"scaffold/{name}",
+                tofile=f"{chart}/{name}",
+                lineterm="",
+                n=1,
+            )
+        )
+    return report
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("chart", nargs="?", default="", help="one chart, or every chart")
+    parser.add_argument("--charts", default=str(CHARTS_DIR))
+    parser.add_argument("--chassis", default=str(CHASSIS))
+    parser.add_argument(
+        "--summary", action="store_true", help="count the drifted blocks instead of diffing them"
+    )
+    args = parser.parse_args(argv)
+
+    chassis_path = Path(args.chassis)
+    if not chassis_path.is_file():
+        print(f"error: {chassis_path}: no chassis to compare against", file=sys.stderr)
+        return 1
+
+    chassis = blocks(chassis_path.read_text(encoding="utf-8"))
+    charts = Path(args.charts)
+    if not charts.is_dir():
+        print(f"error: {charts}: no such directory", file=sys.stderr)
+        return 1
+
+    # Walked here rather than through `config_declaration.chart_dirs`, because this reads no
+    # declaration and a chart without one is exactly as interesting to it as a chart with one.
+    directories = [charts / args.chart] if args.chart else sorted(charts.iterdir())
+
+    drifted = 0
+    shared = 0
+    for chart_dir in directories:
+        values_path = chart_dir / "values.yaml"
+        if chart_dir.name == LIBRARY or not values_path.is_file():
+            continue
+
+        values = blocks(values_path.read_text(encoding="utf-8"))
+        present = [name for name in chassis if name in values]
+        shared += len(present)
+        differing = [name for name in present if values[name] != chassis[name]]
+
+        if not differing:
+            print(f"in step: {chart_dir.name} ({len(present)} shared block(s))")
+            continue
+
+        drifted += len(differing)
+        print(
+            f"drifted: {chart_dir.name} "
+            f"({len(differing)} of {len(present)} shared block(s)): {', '.join(differing)}"
+        )
+        if not args.summary:
+            for line in compare(chassis, chart_dir.name, values):
+                print(f"    {line}")
+
+    print(f"\n==> {drifted} of {shared} shared block(s) differ from the scaffold's copy")
+    if drifted:
+        # Report only. The scaffold was seeded from the majority text of the existing charts, so
+        # it is right about most blocks by construction and has no claim to be right about any
+        # particular one — a chart that diverged on purpose is a normal thing, and failing on it
+        # would be red for somebody's decision. Deciding which side is behind is the work; this
+        # only makes the list.
+        print("    Each is a chart or a scaffold that is behind. Read them and decide which.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/scripts/check-config-bindings.py
+++ b/.github/scripts/check-config-bindings.py
@@ -2,7 +2,8 @@
 """Hold every `# @config` marker in a chart's values.yaml against the contract it names.
 
 `just check-contract-coverage` answers a chart-level question — does this chart carry a
-`config-contract.yaml` at all — and its `unconfigured` escape hatch lists *images*. So the
+`config-contract.yaml` at all — and its `unconfigured` escape hatch lists whole *image
+blocks*. So the
 repository's documented recurring failure is invisible to it: an image release adds a setting, the
 automated bump repins the digest and omits everything else, and no gate anywhere notices that the
 new key has no chart value. `check-config` will not catch it either, because a key nothing renders
@@ -110,13 +111,18 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-import config_bindings as cb  # noqa: E402
-import config_contract as cc  # noqa: E402
-from config_declaration import Declaration, DeclarationError, Document  # noqa: E402
-from config_declaration import load_declaration  # noqa: E402
-from config_report import Report  # noqa: E402
-
-CHARTS_DIR = Path("charts")
+import config_bindings as cb
+import config_contract as cc
+from config_declaration import (
+    Declaration,
+    DeclarationError,
+    Document,
+    chart_dirs,
+    load_declaration,
+    union_for,
+)
+from config_paths import CHARTS_DIR
+from config_report import Report
 
 
 class Bound:
@@ -133,12 +139,8 @@ class Bound:
         self.unions: dict[str, cc.Union] = {}
 
         for document in declaration.documents:
-            contracts = []
-            for reference in document.images:
-                vendored = cc.load_vendored(chart_dir / reference.contract)
-                contracts.append((f"{chart_dir.name}/{reference.contract}", vendored.contract))
             self.documents[document.name] = document
-            self.unions[document.name] = cc.union_contracts(contracts)
+            self.unions[document.name] = union_for(chart_dir, document)
 
     def namespace(self, name: str, cls: str) -> dict[str, dict[str, Any]]:
         """The half of one document's contract a marker of this class may name."""
@@ -473,10 +475,7 @@ def run(charts: Path, report: Report) -> list[tuple[str, int, int]]:
     gate = Gate(report)
     enrolled: list[tuple[str, int, int]] = []
 
-    for chart_dir in sorted(charts.iterdir()):
-        if not (chart_dir / "Chart.yaml").is_file():
-            continue
-
+    for chart_dir in chart_dirs(charts):
         counted = gate.check_chart(chart_dir)
         if counted is None:
             continue

--- a/.github/scripts/check-config.py
+++ b/.github/scripts/check-config.py
@@ -59,34 +59,30 @@ import sys
 from pathlib import Path
 from typing import Any
 
-import yaml
-
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-import config_contract as cc  # noqa: E402
-from config_coverage import check_coverage  # noqa: E402
-from config_declaration import (  # noqa: E402
+import config_contract as cc
+from config_coverage import check_coverage
+from config_declaration import (
     Binding,
     Consumer,
     Declaration,
     DeclarationError,
     Document,
     bind,
-    load_declaration,
+    declared,
 )
-from config_gate_container import ServiceLinkGate, check_container  # noqa: E402
-from config_gate_document import DocumentGate  # noqa: E402
-from config_manifests import (  # noqa: E402
+from config_gate_container import ServiceLinkGate, check_container
+from config_gate_document import DocumentGate
+from config_manifests import (
     containers_of,
     digest_of,
     load_manifests,
     pod_spec,
     select,
 )
-from config_report import Report, warning  # noqa: E402
-
-CHARTS_DIR = Path("charts")
-FIRST_PARTY = Path(".github/configs/first-party-images.txt")
+from config_paths import CHARTS_DIR, FIRST_PARTY, read_yaml
+from config_report import Report, warning
 
 
 class Runner:
@@ -102,19 +98,14 @@ class Runner:
     def run(self) -> int:
         """Check every chart that declares a contract; returns how many were checked."""
         checked = 0
-        for chart_dir in sorted(self.charts.iterdir()):
-            if not (chart_dir / "Chart.yaml").is_file():
-                continue
-            declaration = load_declaration(chart_dir)
-            if declaration is None or not declaration.documents:
-                continue
+        for chart_dir, declaration in declared(self.charts, documents_only=True):
             self.check_chart(chart_dir, declaration)
             checked += 1
         return checked
 
     def check_chart(self, chart_dir: Path, declaration: Declaration) -> None:
-        values = _read_yaml(chart_dir / "values.yaml")
-        app_version = _read_yaml(chart_dir / "Chart.yaml").get("appVersion")
+        values = read_yaml(chart_dir / "values.yaml")
+        app_version = read_yaml(chart_dir / "Chart.yaml").get("appVersion")
 
         for document in declaration.documents:
             where = f"{declaration.chart}: {document.name}"
@@ -257,10 +248,6 @@ class Runner:
             self.report.extend(where, check_container(manifests, spec, container, mine, relaxed))
 
         return checked
-
-
-def _read_yaml(path: Path) -> dict[str, Any]:
-    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
 
 
 def find_jv() -> str:

--- a/.github/scripts/check-immutable-fields.py
+++ b/.github/scripts/check-immutable-fields.py
@@ -185,7 +185,9 @@ def render(chart: Path, values: Path, extra: list[str] | None = None) -> list[di
     ]
     result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0:
-        raise RuntimeError(f"helm template failed for {chart.name} / {values.name}:\n{result.stderr}")
+        raise RuntimeError(
+            f"helm template failed for {chart.name} / {values.name}:\n{result.stderr}"
+        )
     return [doc for doc in yaml.safe_load_all(result.stdout) if doc]
 
 
@@ -197,7 +199,10 @@ def bumped_copy(chart: Path, destination: Path) -> Path:
     chart_yaml = target / "Chart.yaml"
     text = chart_yaml.read_text(encoding="utf-8")
     text = re.sub(r"^version: .*$", f"version: {PROBE_VERSION}", text, count=1, flags=re.MULTILINE)
-    text = re.sub(r"^appVersion: .*$", f"appVersion: {PROBE_VERSION}", text, count=1, flags=re.MULTILINE)
+    text = re.sub(
+        r"^appVersion: .*$", f"appVersion: {PROBE_VERSION}", text, count=1,
+        flags=re.MULTILINE,
+    )
     chart_yaml.write_text(text, encoding="utf-8")
     return target
 

--- a/.github/scripts/config-secrets.py
+++ b/.github/scripts/config-secrets.py
@@ -31,10 +31,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-import config_contract as cc  # noqa: E402
-from config_declaration import DeclarationError  # noqa: E402
-from config_report import Report, error, warning  # noqa: E402
-from config_secrets import (  # noqa: E402
+import config_contract as cc
+from config_declaration import DeclarationError
+from config_paths import CHARTS_DIR
+from config_report import Report, error, warning
+from config_secrets import (
     Credential,
     Mount,
     Reconciler,
@@ -43,9 +44,6 @@ from config_secrets import (  # noqa: E402
     credentials,
     declared_secrets,
 )
-
-CHARTS_DIR = Path("charts")
-
 
 # --------------------------------------------------------------------------------------------
 # The inventory
@@ -198,7 +196,9 @@ def report_of(surface: Surface) -> Report:
             ),
         )
 
-    for chart, workload, container, image, files, values_files in _by_container(surface.unclaimed):
+    for chart, workload, container, _image, files, values_files in _by_container(
+        surface.unclaimed
+    ):
         report.add(
             f"unclaimed: {chart}",
             error(

--- a/.github/scripts/config_bindings.py
+++ b/.github/scripts/config_bindings.py
@@ -22,7 +22,8 @@ Why the fact is worth writing down at all, in the order the payoffs arrive:
 
 **1. Key-level coverage — the only one this file serves today.**
 `just check-contract-coverage` is chart-level: it reports whether a chart carries a
-`config-contract.yaml`, and its `unconfigured` escape hatch lists *images*. Nothing in this
+`config-contract.yaml`, and its `unconfigured` escape hatch lists whole *image blocks*.
+Nothing in this
 repository notices when an image release adds a setting that no chart value reaches. That is the
 documented recurring failure here — an automated bump repins the digest and silently omits
 everything else — and a marker per value is what turns "the chart has a contract" into "every key

--- a/.github/scripts/config_contract.py
+++ b/.github/scripts/config_contract.py
@@ -55,9 +55,10 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, Sequence
+from typing import Any
 
 # --------------------------------------------------------------------------------------------
 # What the image publishes
@@ -720,7 +721,7 @@ def assert_value(constraint: dict[str, Any], value: Any) -> str | None:
             f"{', '.join(sorted(unsupported))}"
         )
 
-    if "type" in constraint and not _is_type(value, constraint["type"]):
+    if "type" in constraint and not is_type(value, constraint["type"]):
         return f"expected {constraint['type']}, got {json.dumps(value)}"
     if "enum" in constraint and value not in constraint["enum"]:
         allowed = ", ".join(json.dumps(option) for option in constraint["enum"])
@@ -756,7 +757,14 @@ def assert_value(constraint: dict[str, Any], value: Any) -> str | None:
     return None
 
 
-def _is_type(value: Any, declared: Any) -> bool:
+def is_type(value: Any, declared: Any) -> bool:
+    """Whether a value satisfies a JSON Schema `type`, scalar or list.
+
+    Public because `config_testgen` needs the same answer when it checks a synthesised candidate
+    against the constraint it has to satisfy, and had its own table-driven copy of this until the
+    two were merged. Two implementations of "is this an integer" is one more than the number of
+    places the `bool`-is-an-`int` trap has to be remembered.
+    """
     names = declared if isinstance(declared, list) else [declared]
     for name in names:
         if name == "integer" and isinstance(value, int) and not isinstance(value, bool):
@@ -809,7 +817,11 @@ def _levenshtein(left: str, right: str) -> int:
         current = [index]
         for position, b in enumerate(right, start=1):
             current.append(
-                min(previous[position] + 1, current[position - 1] + 1, previous[position - 1] + (a != b))
+                min(
+                    previous[position] + 1,
+                    current[position - 1] + 1,
+                    previous[position - 1] + (a != b),
+                )
             )
         previous = current
     return previous[-1]

--- a/.github/scripts/config_coverage.py
+++ b/.github/scripts/config_coverage.py
@@ -32,7 +32,7 @@ from typing import Any
 import yaml
 
 import config_contract as cc
-from config_declaration import DECLARATION, DeclarationError, load_declaration
+from config_declaration import DECLARATION, DeclarationError, chart_dirs, load_declaration
 from config_report import Report, warning
 
 
@@ -73,9 +73,12 @@ def check_coverage(charts: Path, first_party: Path, report: Report) -> None:
     covered: list[str] = []
     uncovered: list[tuple[str, list[str]]] = []
 
-    for chart_dir in sorted(charts.iterdir()):
+    for chart_dir in chart_dirs(charts):
+        # A chart with no values.yaml pins no image, so there is nothing here to be covered or
+        # uncovered. Checked here rather than in the shared walk because every other caller
+        # legitimately reads a chart without one.
         values_path = chart_dir / "values.yaml"
-        if not (chart_dir / "Chart.yaml").is_file() or not values_path.is_file():
+        if not values_path.is_file():
             continue
 
         values = yaml.safe_load(values_path.read_text(encoding="utf-8")) or {}
@@ -88,6 +91,8 @@ def check_coverage(charts: Path, first_party: Path, report: Report) -> None:
             continue
 
         declaration = load_declaration(chart_dir)
+        if declaration is not None:
+            check_unconfigured(chart_dir, declaration, values, report)
 
         if declaration is None or not declaration.documents:
             uncovered.append((chart_dir.name, [repository for _, repository in ours]))
@@ -109,6 +114,42 @@ def check_coverage(charts: Path, first_party: Path, report: Report) -> None:
                 )
 
     _report_coverage(covered, uncovered, report)
+
+
+def check_unconfigured(
+    chart_dir: Path, declaration, values: Any, report: Report
+) -> None:
+    """Hold every `unconfigured` entry to being a values path that pins an image.
+
+    **`unconfigured` holds values paths, not repository names**, and that had to be settled
+    because the two readers of the field disagreed. This gate unions it with the `values` of every
+    declared image and compares the result against the paths a chart pins, so a repository name
+    there matched nothing and silently bought no coverage; `just explain` printed the same field
+    as "images it pins that carry no contract", and two module docstrings said the same. No chart
+    in the repository sets it, so nothing was wrong yet — the first one to would have picked a
+    reading at random.
+
+    The values path wins for three reasons. It is the reading the only gate that acts on the field
+    already implements. That gate's own error message offers `unconfigured` as the alternative to
+    "a document's `images`", whose entries are values paths, so the message was already consistent
+    with it. And a repository name is ambiguous where a values path is not: a chart pinning the
+    same repository at two paths could not say which of them it meant.
+
+    Enforced here rather than in `load_declaration`, because deciding this needs the chart's
+    values.yaml and the declaration loader deliberately reads nothing but its own file. This is
+    the one gate that already has both open.
+    """
+    pinned = {path for path, _ in pinned_images(values)}
+    for entry in declaration.unconfigured:
+        if entry in pinned:
+            continue
+        report.fail(
+            f"{chart_dir.name}: {DECLARATION}",
+            f"`unconfigured` names {entry!r}, which is not a values path this chart pins an image "
+            f"at. The field holds values paths — the same spelling a document's `images[].values` "
+            f"uses — and not repository names"
+            + (f"; this chart pins images at {', '.join(sorted(pinned))}" if pinned else ""),
+        )
 
 
 def _report_coverage(

--- a/.github/scripts/config_declaration.py
+++ b/.github/scripts/config_declaration.py
@@ -15,13 +15,15 @@ has anything trustworthy to say.
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 import yaml
 
 import config_contract as cc
+from config_paths import dig
 
 DECLARATION = "config-contract.yaml"
 
@@ -155,6 +157,10 @@ class Declaration:
     path: Path
     documents: list[Document]
     reason: str | None
+    # Values paths — the same spelling a document's `images[].values` uses — at which this
+    # chart pins an image that reads no contract-described configuration. Not repository
+    # names: `config_coverage.check_unconfigured` records why the two readers disagreed,
+    # which reading won, and gates it.
     unconfigured: list[str]
     bindings: bool
     unbound: list[Unbound]
@@ -390,6 +396,47 @@ def _load_unbound(path: Path, entries: Iterable[Any], documents: set[str]) -> li
     return loaded
 
 
+# --------------------------------------------------------------------------------------------
+# Walking the tree
+# --------------------------------------------------------------------------------------------
+
+
+def chart_dirs(charts: Path) -> Iterator[Path]:
+    """Every chart directory under `charts`, in directory order.
+
+    "Is this a chart" is `Chart.yaml` and nothing else — not a name list, not an exclusion set —
+    so a chart added to the tree is picked up by every gate at once with nothing to update. That
+    was already true five times over; this is the one copy of it.
+
+    Sorted, so every report, every failure list and every generated file is ordered by the tree
+    rather than by whatever order the filesystem happened to return.
+    """
+    for chart_dir in sorted(charts.iterdir()):
+        if (chart_dir / "Chart.yaml").is_file():
+            yield chart_dir
+
+
+def declared(charts: Path, *, documents_only: bool = False) -> Iterator[tuple[Path, Declaration]]:
+    """Every chart carrying a declaration, paired with it.
+
+    `documents_only` is the distinction the five hand-written copies of this loop disagreed on,
+    and it is a real one rather than a convenience. A chart with `documents: []` has *opted out*
+    explicitly and carries a reason: `just explain` must see it, because "this chart opted out,
+    and here is why" is an answer somebody ran the command to get. `check-config` and the
+    credential inventory must not, because there is no document for them to read.
+
+    Passed as a keyword because at a call site `declared(charts, True)` says nothing about which
+    of the two it means.
+    """
+    for chart_dir in chart_dirs(charts):
+        declaration = load_declaration(chart_dir)
+        if declaration is None:
+            continue
+        if documents_only and not declaration.documents:
+            continue
+        yield chart_dir, declaration
+
+
 def reject_unknown(path: Path, where: str, mapping: dict, allowed: Iterable[str]) -> None:
     unknown = set(mapping) - set(allowed)
     if unknown:
@@ -412,16 +459,6 @@ class PinnedImage:
     reference: str
     normalized: str
     digest: str | None
-
-
-def dig(values: Any, path: str) -> Any:
-    """Follow a dotted values path, returning `None` at the first missing step."""
-    current = values
-    for part in path.split("."):
-        if not isinstance(current, dict) or part not in current:
-            return None
-        current = current[part]
-    return current
 
 
 def resolve_image(values: dict[str, Any], path: str, app_version: str | None) -> PinnedImage:
@@ -455,6 +492,65 @@ def resolve_image(values: dict[str, Any], path: str, app_version: str | None) ->
 # --------------------------------------------------------------------------------------------
 # Binding a document to the contracts that describe it
 # --------------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Loaded:
+    """One vendored contract, the reference that named it, and the label it is reported under.
+
+    The label is `<chart>/<path>` — `tankovault/contracts/api.json` — and it is built here rather
+    than at each call site because it is the string every message, every union source list and
+    every credential row identifies a contract by. Four callers were spelling it themselves.
+    """
+
+    reference: ImageRef
+    label: str
+    vendored: cc.Vendored
+
+
+def vendored_for(chart_dir: Path, document: Document) -> list[Loaded]:
+    """Load every contract one document binds. **Applies no staleness interlock.**
+
+    The bold part is the whole reason this function exists rather than each caller writing its own
+    three lines. Whether the vendored file is for the digest the chart *currently* pins is a
+    separate question from what the file says, and the four callers legitimately answer it four
+    different ways:
+
+    | Caller                          | Interlock | Why                                          |
+    |---------------------------------|-----------|----------------------------------------------|
+    | `bind`, for the gates           | yes       | a pass it cannot justify is worse than a fail |
+    | `check-config-bindings`         | no        | compares values.yaml against the committed    |
+    |                                 |           | copy; whether that copy is current is         |
+    |                                 |           | `check-contracts`' question                   |
+    | `config-secrets`, the inventory | no        | withholding it during a bump removes the      |
+    |                                 |           | document at the moment it is being read       |
+    | `generate-contract-tests`       | no        | would block regeneration in the window        |
+    |                                 |           | between a bump and the refresh                |
+
+    Each of those three is a considered decision with a paragraph behind it, and each was
+    previously expressed as *the absence* of code — a four-line loop that looked like a helper and
+    was in fact a deliberate bypass. A fifth consumer copying one of them would have inherited the
+    bypass without inheriting the reason. Now the absence has a name, and `bind` is the one that
+    visibly adds something.
+
+    Raises `ContractError` on a file that cannot be read or is not shaped like a contract; that is
+    not an interlock but a parse, and no caller wants to proceed past it.
+    """
+    return [
+        Loaded(
+            reference=reference,
+            label=f"{chart_dir.name}/{reference.contract}",
+            vendored=cc.load_vendored(chart_dir / reference.contract),
+        )
+        for reference in document.images
+    ]
+
+
+def union_for(chart_dir: Path, document: Document) -> cc.Union:
+    """The contracts of every image that reads one document, merged. No interlock — see above."""
+    return cc.union_contracts(
+        [(item.label, item.vendored.contract) for item in vendored_for(chart_dir, document)]
+    )
 
 
 @dataclass(frozen=True)
@@ -494,13 +590,16 @@ def bind(
     contracts: list[tuple[str, dict[str, Any]]] = []
     by_digest: dict[str, cc.Union] = {}
 
-    for reference in document.images:
-        path = chart_dir / reference.contract
-        label = f"{chart_dir.name}/{reference.contract}"
+    try:
+        loaded = vendored_for(chart_dir, document)
+    except cc.ContractError as failure:
+        return None, [str(failure)]
+
+    for item in loaded:
+        reference, label, vendored = item.reference, item.label, item.vendored
 
         try:
             pinned = resolve_image(values, reference.values, app_version)
-            vendored = cc.load_vendored(path)
         except (cc.ContractError, DeclarationError) as failure:
             return None, [str(failure)]
 

--- a/.github/scripts/config_diff.py
+++ b/.github/scripts/config_diff.py
@@ -53,8 +53,9 @@ nothing to collapse and the pass would only ever be dead code.
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field
-from typing import Any, Iterable
+from typing import Any
 
 import config_contract as cc
 

--- a/.github/scripts/config_gate_document.py
+++ b/.github/scripts/config_gate_document.py
@@ -90,7 +90,7 @@ class DocumentGate:
 
         try:
             instance = parse_document(data[source.key], source.format)
-        except Exception as failure:  # noqa: BLE001 — every parser raises its own type
+        except Exception as failure:
             return [error(f"{source.key}: is not valid {source.format}: {failure}")]
 
         schema = cc.strip_internals(union.json_schema)

--- a/.github/scripts/config_paths.py
+++ b/.github/scripts/config_paths.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""The paths and the two-line helpers every script in this directory had its own copy of.
+
+Nothing here is interesting. That is the point: each of these was declared in between two and
+eight files, identically, and an identical declaration in eight files is a fact that can be
+changed in one of them and stay wrong in the other seven — silently, because every copy still
+parses and every test still passes.
+
+Deliberately not a home for anything that decides something. `config_contract` owns the contract
+model, `config_declaration` owns `config-contract.yaml`, `config_manifests` owns the rendered
+objects, and a helper that grows a rule belongs in whichever of those the rule is about. What
+lives here is the answer to "where is `charts/`" and "read this YAML file", which are not rules
+and have no natural owner.
+
+`digest_of` in `config_manifests` is a near-neighbour of `dig` below and is not the same function
+— one splits an image reference, the other walks a values tree — so it stays where it is.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# The chart tree, relative to the repository root. Every entry point takes `--charts` and defaults
+# to this, so a caller can point the whole toolchain at a fixture directory.
+CHARTS_DIR = Path("charts")
+
+# The image repositories this organisation builds, and so the ones that can be expected to publish
+# a configuration contract. Read by `check-contract-coverage` to decide which charts owe a
+# declaration, and by `new-chart` to decide whether to write an opt-out — the two have to agree,
+# which is why neither spells the path itself.
+FIRST_PARTY = Path(".github/configs/first-party-images.txt")
+
+
+def read_yaml(path: Path) -> dict[str, Any]:
+    """One YAML document as a mapping, with an absent or empty file reading as `{}`.
+
+    The `or {}` is the whole reason this is a function rather than a call: `yaml.safe_load` of an
+    empty file returns `None`, and every caller here goes on to `.get()` something out of it. Three
+    files had this exact line; two of them had reached it independently.
+    """
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def dig(values: Any, path: str) -> Any:
+    """Follow a dotted values path, returning `None` at the first missing step.
+
+    Deliberately returns `None` for "not there" rather than raising, because every caller is
+    asking whether a chart happens to declare something — `image.registry`, a per-service image
+    block — and absence is an ordinary answer rather than an error.
+    """
+    current = values
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current

--- a/.github/scripts/config_scaffold.py
+++ b/.github/scripts/config_scaffold.py
@@ -91,7 +91,6 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any
 
 import config_bindings as cb
@@ -1102,7 +1101,8 @@ def render_declaration(
         "",
         "    # The pods that mount it, for the environment and secret-file gates.",
         "    consumers:",
-        f"      - workload: {{ kind: Deployment, selector: {{ app.kubernetes.io/instance: {chart} }} }}",
+        f"      - workload: {{ kind: Deployment, selector: "
+        f"{{ app.kubernetes.io/instance: {chart} }} }}",
         f"        containers: [{chart}]",
         "",
         "    # Pairs this document is not fully checked for, each with a reason.",
@@ -1331,7 +1331,7 @@ def render_unit_test(chart: str, document_key: str, plan: Plan) -> str:
         "  - configmap.yaml",
         "",
         "# Scaffolded by `just new-chart`, and yours to extend. The generated",
-        f"# `contract_roundtrip_*_test.yaml` beside it proves each contract key arrives at the",
+        "# `contract_roundtrip_*_test.yaml` beside it proves each contract key arrives at the",
         "# path the image reads it from; this file is for everything the contract cannot say —",
         "# the shape of the object, the labels, the escape hatches.",
         "tests:",

--- a/.github/scripts/config_secrets.py
+++ b/.github/scripts/config_secrets.py
@@ -70,17 +70,24 @@ cannot yet diverge; if that changes, it changes in `config_contract.py` first.
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable
-
-import yaml
+from typing import Any
 
 import config_contract as cc
-from config_declaration import Binding, Declaration, Document, bind, load_declaration
+from config_declaration import (
+    Binding,
+    Declaration,
+    Document,
+    bind,
+    declared,
+    vendored_for,
+)
 from config_gate_container import ContainerView
 from config_gate_document import parse_document
 from config_manifests import containers_of, digest_of, load_manifests, pod_spec, select
+from config_paths import read_yaml
 
 # The four ways a value can reach the loader, named as the report prints them. The rendered
 # document is among them and is not a mistake: a key written into the plaintext ConfigMap *is*
@@ -151,22 +158,15 @@ class Credential:
 
 def contracted_charts(charts: Path) -> list[tuple[Path, Declaration]]:
     """Every chart that declares at least one document, in directory order."""
-    found: list[tuple[Path, Declaration]] = []
-    for chart_dir in sorted(charts.iterdir()):
-        if not (chart_dir / "Chart.yaml").is_file():
-            continue
-        declaration = load_declaration(chart_dir)
-        if declaration is not None and declaration.documents:
-            found.append((chart_dir, declaration))
-    return found
+    return list(declared(charts, documents_only=True))
 
 
 def declared_secrets(chart_dir: Path, declaration: Declaration) -> list[Declared]:
     """Every `secret: true` key of every contract one chart vendors."""
     found: list[Declared] = []
     for document in declaration.documents:
-        for reference in document.images:
-            vendored = cc.load_vendored(chart_dir / reference.contract)
+        for item in vendored_for(chart_dir, document):
+            vendored = item.vendored
             app = (vendored.contract.get("app") or {}).get("name") or vendored.image
             for key in vendored.contract["schema"]["keys"]:
                 if not key.get("secret"):
@@ -175,7 +175,7 @@ def declared_secrets(chart_dir: Path, declaration: Declaration) -> list[Declared
                     Declared(
                         chart=declaration.chart,
                         document=document.name,
-                        contract=f"{declaration.chart}/{reference.contract}",
+                        contract=item.label,
                         image=str(app),
                         path=str(key["path"]),
                         secrets_file=str(key.get("secrets_file") or ""),
@@ -398,8 +398,8 @@ class Reconciler:
     # -- one chart ---------------------------------------------------------------------------
 
     def reconcile(self, chart_dir: Path, declaration: Declaration) -> None:
-        values = _read_yaml(chart_dir / "values.yaml")
-        app_version = _read_yaml(chart_dir / "Chart.yaml").get("appVersion")
+        values = read_yaml(chart_dir / "values.yaml")
+        app_version = read_yaml(chart_dir / "Chart.yaml").get("appVersion")
 
         bindings: dict[str, Binding] = {}
         for document in declaration.documents:
@@ -506,7 +506,7 @@ class Reconciler:
             return
         try:
             instance = parse_document(text, document.source.format)
-        except Exception:  # noqa: BLE001 — an unparseable document is gate 1's finding, not ours
+        except Exception:
             return
 
         present = document_paths(instance)
@@ -763,5 +763,3 @@ def _short(label: str) -> str:
     return Path(label).stem
 
 
-def _read_yaml(path: Path) -> dict[str, Any]:
-    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}

--- a/.github/scripts/config_testgen.py
+++ b/.github/scripts/config_testgen.py
@@ -109,8 +109,9 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
-from typing import Any, Iterable, Sequence
+from typing import Any
 
 import config_contract as cc
 
@@ -203,16 +204,6 @@ class TestGenError(Exception):
 # Checking a candidate against what the contract will accept
 # --------------------------------------------------------------------------------------------
 
-_TYPES: dict[str, tuple[type, ...]] = {
-    "string": (str,),
-    "integer": (int,),
-    "number": (int, float),
-    "boolean": (bool,),
-    "array": (list,),
-    "object": (dict,),
-}
-
-
 def unmet(value: Any, schema: dict[str, Any] | None) -> str | None:
     """The first assertion of a flat constraint the value fails, or `None` when it satisfies it.
 
@@ -237,8 +228,8 @@ def unmet(value: Any, schema: dict[str, Any] | None) -> str | None:
 
 def _unmet_keyword(value: Any, keyword: str, expected: Any) -> str | None:
     if keyword == "type":
-        wanted = expected if isinstance(expected, list) else [expected]
-        if not any(_is_type(value, name) for name in wanted):
+        if not cc.is_type(value, expected):
+            wanted = expected if isinstance(expected, list) else [expected]
             return f"type {'/'.join(str(name) for name in wanted)}"
         return None
 
@@ -273,19 +264,6 @@ def _unmet_keyword(value: Any, keyword: str, expected: Any) -> str | None:
         return None if satisfied else f"{keyword} {expected}"
 
     return f"the assertion {keyword!r}, which this generator does not implement"
-
-
-def _is_type(value: Any, name: str) -> bool:
-    if name == "null":
-        return value is None
-    types = _TYPES.get(name)
-    if types is None:
-        return False
-    # `True` is an `int` in Python and is not one in JSON Schema, so a boolean has to be excluded
-    # from every numeric type explicitly or `true` would satisfy a `u64` bound.
-    if name in ("integer", "number") and isinstance(value, bool):
-        return False
-    return isinstance(value, types)
 
 
 def out_of_vocabulary(schema: dict[str, Any] | None) -> list[str]:

--- a/.github/scripts/contract-diff.py
+++ b/.github/scripts/contract-diff.py
@@ -52,10 +52,10 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-import config_diff as cd  # noqa: E402
-from config_report import Report, error  # noqa: E402
+import config_diff as cd
+from config_paths import CHARTS_DIR
+from config_report import Report, error
 
-CHARTS_DIR = Path("charts")
 DEFAULT_REF = "origin/main"
 
 # The JSON's own version, on the same reasoning as `terrace_contract`: a consumer that does not

--- a/.github/scripts/explain-config.py
+++ b/.github/scripts/explain-config.py
@@ -72,20 +72,18 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-import yaml
-
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-import config_contract as cc  # noqa: E402
-from config_declaration import (  # noqa: E402
+import config_contract as cc
+from config_declaration import (
     Declaration,
     DeclarationError,
     bind,
+    declared,
     load_declaration,
 )
-from config_report import Report, warning  # noqa: E402
-
-CHARTS_DIR = Path("charts")
+from config_paths import CHARTS_DIR, read_yaml
+from config_report import Report, warning
 
 # The contracts' prose is UTF-8 and uses it — em dashes, arrows, typographic quotes — and this
 # repository is developed from Git Bash on Windows, where Python's default console encoding is the
@@ -274,8 +272,8 @@ def collect(chart_dir: Path, declaration: Declaration, report: Report) -> Surfac
     provenance, so the contracts are re-read afterwards for the image reference and the app
     version. That is a second read of a file already proven, not a second opinion about it.
     """
-    values = _read_yaml(chart_dir / "values.yaml")
-    app_version = _read_yaml(chart_dir / "Chart.yaml").get("appVersion")
+    values = read_yaml(chart_dir / "values.yaml")
+    app_version = read_yaml(chart_dir / "Chart.yaml").get("appVersion")
 
     surface = Surface(chart=declaration.chart)
     by_contract: dict[str, list[str]] = {}
@@ -757,7 +755,10 @@ def print_surface(surface: Surface, args: argparse.Namespace, out) -> int:
         print("\n\n".join(blocks), file=out)
 
     if external:
-        print("\n==> external variables — read by the image, and nobody's configuration\n", file=out)
+        print(
+            "\n==> external variables — read by the image, and nobody's configuration\n",
+            file=out,
+        )
         print(
             "\n".join(
                 prose(
@@ -829,7 +830,9 @@ def as_json(surface: Surface, pattern: str | None) -> dict[str, Any]:
         ],
         "keys": [_setting_json(item, derive=True) for item in select(surface.keys, pattern)],
         "loader": [_setting_json(item) for item in select(surface.loader, pattern)],
-        "external": [_setting_json(item, derive=True) for item in select(surface.external, pattern)],
+        "external": [
+            _setting_json(item, derive=True) for item in select(surface.external, pattern)
+        ],
     }
 
 
@@ -855,20 +858,13 @@ def _setting_json(setting: Setting, derive: bool = False) -> dict[str, Any]:
 # --------------------------------------------------------------------------------------------
 
 
-def _read_yaml(path: Path) -> dict[str, Any]:
-    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-
-
 def charts_with_contracts(charts: Path) -> list[tuple[str, Declaration]]:
-    """Every chart carrying a declaration, whether or not it declares any document."""
-    found = []
-    for chart_dir in sorted(charts.iterdir()):
-        if not (chart_dir / "Chart.yaml").is_file():
-            continue
-        declaration = load_declaration(chart_dir)
-        if declaration is not None:
-            found.append((chart_dir.name, declaration))
-    return found
+    """Every chart carrying a declaration, whether or not it declares any document.
+
+    Not `documents_only`: a chart that opted out explicitly carries a reason, and printing that
+    reason is one of the two things this command exists to do.
+    """
+    return [(chart_dir.name, declaration) for chart_dir, declaration in declared(charts)]
 
 
 def list_charts(charts: Path, out) -> None:
@@ -890,11 +886,17 @@ def list_charts(charts: Path, out) -> None:
 
 
 def describe_opt_out(declaration: Declaration, out) -> None:
-    print(f"==> {declaration.chart} has explicitly opted out of configuration contracts\n", file=out)
+    print(
+        f"==> {declaration.chart} has explicitly opted out of configuration contracts\n",
+        file=out,
+    )
     print("\n".join(prose(str(declaration.reason), "    ")), file=out)
     if declaration.unconfigured:
+        # Values paths, not repository names — `unconfigured` is unioned with every declared
+        # image's `values` and compared against the paths a chart pins. This line used to call
+        # them images, which is how the field came to have two readers that disagreed.
         print(
-            f"\n    images it pins that carry no contract: "
+            f"\n    values paths pinning an image that carries no contract: "
             f"{', '.join(declaration.unconfigured)}",
             file=out,
         )

--- a/.github/scripts/generate-contract-tests.py
+++ b/.github/scripts/generate-contract-tests.py
@@ -65,16 +65,18 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-import config_contract as cc  # noqa: E402
-import config_testgen as tg  # noqa: E402
-from config_declaration import (  # noqa: E402
+import config_contract as cc
+import config_testgen as tg
+from config_declaration import (
     Declaration,
     DeclarationError,
     Document,
     dig,
     load_declaration,
     reject_unknown,
+    union_for,
 )
+from config_paths import CHARTS_DIR
 
 # The file that enrols a chart, and the keys it may carry at each level. Anything else is a typo
 # that would otherwise be ignored in silence — the same rule `config-contract.yaml` is read under,
@@ -411,15 +413,6 @@ def discriminator_for(
     return tuple(sorted(document.source.selector.items()))
 
 
-def union_for(chart_dir: Path, document: Document) -> cc.Union:
-    """The contracts of every image that reads one document, merged."""
-    contracts = []
-    for reference in document.images:
-        vendored = cc.load_vendored(chart_dir / reference.contract)
-        contracts.append((f"{chart_dir.name}/{reference.contract}", vendored.contract))
-    return cc.union_contracts(contracts)
-
-
 def suite_path(chart_dir: Path, document: Document) -> Path:
     return chart_dir / SUITES / f"{SUITE_PREFIX}{document.name}{SUITE_SUFFIX}"
 
@@ -603,9 +596,12 @@ def main(argv: list[str]) -> int:
         help="report drifted suites and exit non-zero instead of writing them",
     )
     parser.add_argument(
-        "--charts", default="charts", type=Path, help="charts directory (default: charts)"
+        "--charts",
+        default=str(CHARTS_DIR),
+        type=Path,
+        help=f"charts directory (default: {CHARTS_DIR})",
     )
-    args = parser.parse_args(argv[1:])
+    args = parser.parse_args(argv)
 
     if not args.charts.is_dir():
         fail(f"{args.charts} is not a directory")
@@ -631,4 +627,4 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv))
+    raise SystemExit(main(sys.argv[1:]))

--- a/.github/scripts/kube-schema-refs.py
+++ b/.github/scripts/kube-schema-refs.py
@@ -131,9 +131,13 @@ def main(argv: list[str]) -> int:
         help="report drifted references and exit non-zero instead of rewriting them",
     )
     parser.add_argument(
+        # The one script here that does not share `config_paths.CHARTS_DIR`, and deliberately:
+        # that module imports PyYAML, and this script is stdlib-only on purpose — `maintain.just`
+        # records that it reuses `resolve_python` "even though this script imports nothing beyond
+        # the standard library". Trading that for one shared constant is the wrong way round.
         "--charts", default="charts", type=Path, help="charts directory (default: charts)"
     )
-    args = parser.parse_args(argv[1:])
+    args = parser.parse_args(argv)
 
     if not VERSION.match(args.version):
         fail(f"{args.version!r} is not a Kubernetes release of the form MAJOR.MINOR.PATCH")
@@ -146,4 +150,4 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv))
+    raise SystemExit(main(sys.argv[1:]))

--- a/.github/scripts/new-chart.py
+++ b/.github/scripts/new-chart.py
@@ -79,24 +79,23 @@ import os
 import shutil
 import sys
 from pathlib import Path
-from typing import Any
 
 import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-import config_contract as cc  # noqa: E402
-import config_scaffold as sc  # noqa: E402
-from config_coverage import first_party_patterns  # noqa: E402
-from config_declaration import DeclarationError, load_declaration  # noqa: E402
+import config_contract as cc
+import config_scaffold as sc
+from config_coverage import first_party_patterns
+from config_declaration import DeclarationError, load_declaration
 
-CHARTS_DIR = Path("charts")
+# `FIRST_PARTY` is the list `just check-contract-coverage` decides from, and it is imported rather
+# than spelt here for the reason the constant is shared at all: whether a chart owes a declaration
+# is that gate's rule, and a scaffold with its own opinion about it would write charts the gate
+# then rejects.
+from config_paths import CHARTS_DIR, FIRST_PARTY
+
 TEMPLATES = Path(".github/templates/chart")
-
-# The list `just check-contract-coverage` decides from. Read here for the same reason it
-# reads it there: whether a chart owes a declaration is that gate's rule, and a scaffold
-# with its own opinion about it would write charts the gate then rejects.
-FIRST_PARTY = Path(".github/configs/first-party-images.txt")
 
 # The library chart every chart here depends on. Read from its own `Chart.yaml` rather than
 # written down, so a library release is not a second edit somebody has to remember.
@@ -365,7 +364,8 @@ def generate(
         text = path.read_text(encoding="utf-8")
         text = text.replace(_shout(name) + "_", union.prefix)
         text = text.replace(f'"prefix" "{_shout(name)}"', f'"prefix" "{sc.env_prefix(union)}"')
-        text = text.replace("`__` for nesting", f"`{union.dialect['nesting_separator']}` for nesting")
+        separator = union.dialect["nesting_separator"]
+        text = text.replace("`__` for nesting", f"`{separator}` for nesting")
         _write(path, text)
 
     return surface
@@ -499,7 +499,7 @@ def next_steps(chart_dir: Path, surface: sc.Surface, out) -> None:
         steps.append(
             "Write the chart's own values, one `@schema` block each, and the templates that "
             "consume them — a ConfigMap, a Secret, a Service, whatever this image needs. "
-            f"`templates/_helpers.tpl` is where anything computed belongs."
+            "`templates/_helpers.tpl` is where anything computed belongs."
         )
         steps.append(
             "If this image ever publishes a configuration contract, re-run without "

--- a/.github/scripts/refresh-contracts.py
+++ b/.github/scripts/refresh-contracts.py
@@ -81,7 +81,7 @@ import shutil
 import subprocess
 import sys
 import tarfile
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -89,11 +89,11 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-import config_contract as cc  # noqa: E402
+import config_contract as cc
+from config_paths import CHARTS_DIR, dig
 
 # `check-config.py` owns the declaration format; importing it by file name is not possible, so
 # the two pieces this script needs are re-derived from the same YAML rather than duplicated.
-CHARTS_DIR = Path("charts")
 DECLARATION = "config-contract.yaml"
 
 # The OIDC issuer a GitHub Actions workflow signs under. Paired with `$CONTRACT_SIGNER`, which
@@ -434,7 +434,7 @@ def write_vendored(path: Path, image: str, digest: str, payload: bytes, sha256: 
             "image": image,
             "digest": digest,
             "sha256": sha256,
-            "fetched": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "fetched": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         },
         "contract": contract,
     }
@@ -489,15 +489,6 @@ def reference_for(image: dict[str, Any], app_version: str | None) -> tuple[str, 
     reference = f"{normalized}:{tag}" if tag else normalized
     digest = tag.split("@", 1)[1] if "@" in tag else None
     return normalized, reference, digest
-
-
-def dig(values: Any, path: str) -> Any:
-    current = values
-    for part in path.split("."):
-        if not isinstance(current, dict) or part not in current:
-            return None
-        current = current[part]
-    return current
 
 
 def refresh_chart(chart_dir: Path, client: RegistryClient, signer: str) -> list[str]:

--- a/.github/scripts/tests/entry.py
+++ b/.github/scripts/tests/entry.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Importing an entry point whose file name a `import` statement cannot spell.
+
+The scripts in `.github/scripts` are hyphenated — `check-config.py`, `explain-config.py` — because
+that is how they are invoked, and a hyphen is not a Python identifier. So a test that wants to
+call `main()` or one of the functions around it has to load the file by path.
+
+Four test modules had their own copy of the six lines that does this, one of them carrying a
+four-line comment about a subtlety the other three did not need. This is that copy, once, with
+the subtlety handled for everybody.
+
+**The real fix is upstream and is not this.** Rename the entry points to underscores and let the
+`just` recipes spell the path, and this file disappears along with the `config-secrets.py` /
+`config_secrets.py` pair that currently differ by one character. That rename touches every recipe,
+every workflow reference and all four of these tests, so it is worth doing on its own and worth
+not doing in the middle of something else.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+
+
+def load(name: str, filename: str) -> ModuleType:
+    """Import one hyphenated entry point under `name`, and remember it under that name.
+
+    Registered in `sys.modules` *before* it is executed, which matters for exactly one reason and
+    was measured rather than anticipated: `@dataclass` resolves its own module out of `sys.modules`
+    to decide what a `ClassVar` annotation means, so a module that is not there yet fails at the
+    decorator rather than at anything the test wrote. `test_contract_explain` hit that and grew
+    the two extra lines; the other three did not, and so did not have them.
+
+    Returning the module already in `sys.modules` under this name keeps a second import cheap and,
+    more usefully, identical — two loads of one file produce two distinct classes, and an
+    `isinstance` across them fails in a way that reads like a bug in the code under test.
+    """
+    existing = sys.modules.get(name)
+    if existing is not None:
+        return existing
+
+    path = SCRIPTS / filename
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"{path}: cannot be loaded as a module")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        # A module that failed halfway through is worse than absent: the next `load` would return
+        # the broken half from `sys.modules` and the failure would surface somewhere else.
+        del sys.modules[name]
+        raise
+    return module

--- a/.github/scripts/tests/test_contract_bindings.py
+++ b/.github/scripts/tests/test_contract_bindings.py
@@ -37,7 +37,6 @@ coverage it has not established:
 from __future__ import annotations
 
 import copy
-import importlib.util
 import json
 import sys
 import tempfile
@@ -50,21 +49,14 @@ sys.path.insert(0, str(SCRIPTS))
 import config_bindings as cb  # noqa: E402
 from config_declaration import DeclarationError, load_declaration  # noqa: E402
 from config_report import Report  # noqa: E402
+from entry import load  # noqa: E402
 
 FIXTURES = SCRIPTS.parent / "testdata" / "contracts"
 
 DIGEST = "sha256:" + "1" * 64
 
 
-def _load(name: str, filename: str):
-    """Import a hyphenated entry point, the way `test_contract_secrets` already does."""
-    spec = importlib.util.spec_from_file_location(name, SCRIPTS / filename)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-entry = _load("config_bindings_entry", "check-config-bindings.py")
+entry = load("config_bindings_entry", "check-config-bindings.py")
 
 
 def fixture(name: str) -> dict:

--- a/.github/scripts/tests/test_contract_diff.py
+++ b/.github/scripts/tests/test_contract_diff.py
@@ -28,7 +28,7 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-import config_diff as cd  # noqa: E402
+import config_diff as cd
 
 FIXTURES = Path(__file__).resolve().parents[2] / "testdata" / "contracts"
 

--- a/.github/scripts/tests/test_contract_explain.py
+++ b/.github/scripts/tests/test_contract_explain.py
@@ -29,7 +29,6 @@ and `log.level` — wrapped in the `source` envelope a vendored file carries.
 
 from __future__ import annotations
 
-import importlib.util
 import io
 import json
 import sys
@@ -37,30 +36,16 @@ import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from typing import ClassVar
 
 SCRIPTS = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SCRIPTS))
 
 import config_contract as cc  # noqa: E402
 from config_report import Report  # noqa: E402
+from entry import load  # noqa: E402
 
-
-def _load(name: str, filename: str):
-    """Import a hyphenated entry point, which a plain `import` cannot name.
-
-    Registered in `sys.modules` before it is executed, which the same helper in
-    `test_contract_refresh.py` does not need to do: `@dataclass` resolves its own module out of
-    `sys.modules` to decide what a `ClassVar` is, and a module that is not there yet fails at
-    the decorator rather than at anything the test wrote.
-    """
-    spec = importlib.util.spec_from_file_location(name, SCRIPTS / filename)
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[name] = module
-    spec.loader.exec_module(module)
-    return module
-
-
-explain = _load("explain_config", "explain-config.py")
+explain = load("explain_config", "explain-config.py")
 
 FIXTURES = SCRIPTS.parent / "testdata" / "contracts"
 API_DIGEST = "sha256:" + "ab" * 32
@@ -72,7 +57,7 @@ def fixture(name: str) -> dict:
     return json.loads((FIXTURES / f"{name}.json").read_text(encoding="utf-8"))
 
 
-def setting(name: str, *occurrences: tuple[str, dict]) -> "explain.Setting":
+def setting(name: str, *occurrences: tuple[str, dict]) -> explain.Setting:
     return explain.Setting(name=name, occurrences=list(occurrences))
 
 
@@ -126,7 +111,7 @@ class ChartFixture(unittest.TestCase):
         )
         return chart
 
-    def collect(self, chart: Path) -> tuple["explain.Surface | None", Report]:
+    def collect(self, chart: Path) -> tuple[explain.Surface | None, Report]:
         from config_declaration import load_declaration
 
         report = Report()
@@ -399,9 +384,13 @@ class TestConstraintProse(unittest.TestCase):
 
 
 class TestFullEntry(unittest.TestCase):
-    DIALECT = {"prefix": "FIXTURE_", "nesting_separator": "__", "indirection_suffix": "_FILE"}
+    DIALECT: ClassVar[dict[str, str]] = {
+        "prefix": "FIXTURE_",
+        "nesting_separator": "__",
+        "indirection_suffix": "_FILE",
+    }
 
-    def entry(self, path: str) -> "explain.Setting":
+    def entry(self, path: str) -> explain.Setting:
         for item in fixture("api")["schema"]["keys"]:
             if item["path"] == path:
                 return setting(path, ("api", item))
@@ -538,7 +527,7 @@ class TestJsonOutput(ChartFixture):
     def emit(self, *argv: str) -> tuple[int, dict]:
         out = io.StringIO()
         with redirect_stdout(out), redirect_stderr(io.StringIO()):
-            status = explain.main(list(argv) + ["--json"])
+            status = explain.main([*argv, "--json"])
         return status, json.loads(out.getvalue())
 
     def setUp(self):

--- a/.github/scripts/tests/test_contract_gates.py
+++ b/.github/scripts/tests/test_contract_gates.py
@@ -17,8 +17,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-import config_contract as cc  # noqa: E402
-from config_gate_container import (  # noqa: E402
+import config_contract as cc
+from config_gate_container import (
     ContainerView,
     EnvironmentGate,
     FileGate,
@@ -27,7 +27,7 @@ from config_gate_container import (  # noqa: E402
     Suppliers,
     check_container,
 )
-from config_report import ERROR, WARNING  # noqa: E402
+from config_report import ERROR, WARNING
 
 FIXTURES = Path(__file__).resolve().parents[2] / "testdata" / "contracts"
 
@@ -300,7 +300,9 @@ class TestServiceLinks(unittest.TestCase):
         self.assertEqual(ServiceLinkGate().check({"enableServiceLinks": False}, union("api")), [])
 
     def test_setting_it_true_is_not_setting_it(self):
-        self.assertEqual(len(ServiceLinkGate().check({"enableServiceLinks": True}, union("api"))), 1)
+        self.assertEqual(
+            len(ServiceLinkGate().check({"enableServiceLinks": True}, union("api"))), 1
+        )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/test_contract_refresh.py
+++ b/.github/scripts/tests/test_contract_refresh.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import gzip
 import hashlib
-import importlib.util
 import io
 import json
 import sys
@@ -36,21 +35,14 @@ from config_declaration import (  # noqa: E402
     load_declaration,
     resolve_image,
 )
+from entry import load  # noqa: E402
 
 FIXTURES = SCRIPTS.parent / "testdata" / "contracts"
 DIGEST = "sha256:" + "ab" * 32
 OTHER_DIGEST = "sha256:" + "cd" * 32
 
 
-def _load(name: str, filename: str):
-    """Import a hyphenated entry point, which a plain `import` cannot name."""
-    spec = importlib.util.spec_from_file_location(name, SCRIPTS / filename)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-refresh = _load("refresh_contracts", "refresh-contracts.py")
+refresh = load("refresh_contracts", "refresh-contracts.py")
 
 
 def fixture(name: str) -> dict:
@@ -170,7 +162,9 @@ class TestFetchVerification(unittest.TestCase):
     def test_a_contract_attached_to_a_platform_manifest_is_found(self):
         # Which of the two a producer attaches to is a real choice, and a consumer that only
         # looked at the index would report "no contract" for an image that publishes one.
-        registry = FakeRegistry(referrers=[], platform_referrers=[{"digest": "sha256:" + "ee" * 32}])
+        registry = FakeRegistry(
+            referrers=[], platform_referrers=[{"digest": "sha256:" + "ee" * 32}]
+        )
         payload, _ = self.fetch(registry)
         self.assertEqual(json.loads(payload)["schema"]["dialect"]["prefix"], "FIXTURE_")
 
@@ -189,7 +183,7 @@ class TestFetchVerification(unittest.TestCase):
         self.assertIn(cc.LABEL_VERSION, str(raised.exception))
 
     def test_an_unreadable_contract_version_is_refused(self):
-        registry = FakeRegistry(labels={cc.LABEL_VERSION: "2"})  # noqa: E501
+        registry = FakeRegistry(labels={cc.LABEL_VERSION: "2"})
         with self.assertRaises(refresh.RefreshError) as raised:
             self.fetch(registry)
         self.assertIn("version 2", str(raised.exception))
@@ -272,10 +266,14 @@ class TestFetchVerification(unittest.TestCase):
 
 class TestReferrerParsing(unittest.TestCase):
     def test_the_referrers_key(self):
-        self.assertEqual(refresh.parse_referrers('{"referrers": [{"digest": "a"}]}'), [{"digest": "a"}])
+        self.assertEqual(
+            refresh.parse_referrers('{"referrers": [{"digest": "a"}]}'), [{"digest": "a"}]
+        )
 
     def test_the_older_manifests_key(self):
-        self.assertEqual(refresh.parse_referrers('{"manifests": [{"digest": "a"}]}'), [{"digest": "a"}])
+        self.assertEqual(
+            refresh.parse_referrers('{"manifests": [{"digest": "a"}]}'), [{"digest": "a"}]
+        )
 
     def test_a_bare_list(self):
         self.assertEqual(refresh.parse_referrers('[{"digest": "a"}]'), [{"digest": "a"}])

--- a/.github/scripts/tests/test_contract_scaffold.py
+++ b/.github/scripts/tests/test_contract_scaffold.py
@@ -321,7 +321,9 @@ class PlainForm(unittest.TestCase):
     def test_no_configuration_surface_is_asserted(self):
         values = values_of(sc.plain())
         for name in ("config", "configExtraToml", "configMount", "existingSecret"):
-            self.assertNotIn(name, values, f"{name} describes a loader nothing knows this image has")
+            self.assertNotIn(
+                name, values, f"{name} describes a loader nothing knows this image has"
+            )
 
     def test_the_image_block_is_still_written(self):
         values = values_of(sc.plain())

--- a/.github/scripts/tests/test_contract_secrets.py
+++ b/.github/scripts/tests/test_contract_secrets.py
@@ -28,7 +28,6 @@ noise nobody reads:
 from __future__ import annotations
 
 import copy
-import importlib.util
 import json
 import sys
 import tempfile
@@ -51,19 +50,12 @@ from config_secrets import (  # noqa: E402
     names_credential,
     secret_file_names,
 )
+from entry import load  # noqa: E402
 
 FIXTURES = SCRIPTS.parent / "testdata" / "contracts"
 
 
-def _load(name: str, filename: str):
-    """Import a hyphenated entry point, the way `test_contract_refresh` already does."""
-    spec = importlib.util.spec_from_file_location(name, SCRIPTS / filename)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-entry = _load("config_secrets_entry", "config-secrets.py")
+entry = load("config_secrets_entry", "config-secrets.py")
 
 
 def fixture(name: str) -> dict:

--- a/.github/scripts/tests/test_contract_testgen.py
+++ b/.github/scripts/tests/test_contract_testgen.py
@@ -47,7 +47,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import yaml
 
@@ -384,7 +384,7 @@ class TestDocumentSelection(unittest.TestCase):
 
 
 class TestPlanning(unittest.TestCase):
-    KEYS = [
+    KEYS: ClassVar[list] = [
         key("isr.ttl_secs", text_form="integer", constraint={"type": "integer", "minimum": 0},
             default_value=0),
         key("assets.dist_dir", default_value="public"),
@@ -484,7 +484,8 @@ class TestSuiteRendering(unittest.TestCase):
     def test_the_suite_is_valid_yaml_shaped_like_a_helm_unittest_suite(self):
         suite = yaml.safe_load(self.render(TestPlanning.KEYS))
         self.assertEqual(suite["release"]["name"], "portfolio")
-        self.assertEqual([test["it"] for test in suite["tests"]][0].split()[0], "renders")
+        first = next(test["it"] for test in suite["tests"])
+        self.assertEqual(first.split()[0], "renders")
         self.assertEqual(len(suite["tests"]), 3)
 
     def test_the_pattern_survives_yaml_with_its_backslashes_intact(self):
@@ -557,7 +558,9 @@ class TestSuiteRendering(unittest.TestCase):
 class TestRenderPrerequisites(unittest.TestCase):
     """Values that make the chart render at all, and the rule that keeps them out of the proof."""
 
-    PREREQUISITES = [("bucket.entries", {"link": {"bucket": "b", "object": "o"}})]
+    PREREQUISITES: ClassVar[list] = [
+        ("bucket.entries", {"link": {"bucket": "b", "object": "o"}})
+    ]
 
     # A probe root off the default, which is what the last four cases below turn on.
     ROOT = "services.api.config"

--- a/.github/scripts/tests/test_contract_union.py
+++ b/.github/scripts/tests/test_contract_union.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-import config_contract as cc  # noqa: E402
+import config_contract as cc
 
 FIXTURES = Path(__file__).resolve().parents[2] / "testdata" / "contracts"
 

--- a/.github/scripts/tests/test_contract_values.py
+++ b/.github/scripts/tests/test_contract_values.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-import config_contract as cc  # noqa: E402
+import config_contract as cc
 
 FIXTURES = Path(__file__).resolve().parents[2] / "testdata" / "contracts"
 

--- a/.github/templates/chart/README.md
+++ b/.github/templates/chart/README.md
@@ -69,11 +69,15 @@ delete.
 
 ## Keeping this directory honest
 
-Nothing gates the chassis against the charts. It was seeded from the majority text of the eight
-existing charts and it will drift as they do — a value gains a sentence in one chart and the
-scaffold keeps the old one. That is a real gap and it is stated here rather than hidden: the fix
-is a gate that diffs the chassis against every chart that carries the block, which is worth
-writing the first time the drift bites and is not worth guessing at now.
+`just check-chassis` diffs this copy against every chart that carries the block, and reports
+rather than fails. The chassis is not the authority: it was seeded from the majority text of the
+eight existing charts, so it is right about most blocks by construction and has no claim to be
+right about any particular one. A chart that diverged on purpose is a normal thing for a chart to
+do; what the report is for is the other case, a block edited in one chart and nowhere else.
+
+It currently reports 63 of 211 shared blocks as differing, which is the measure of how much had
+already drifted before anything was watching. Reading the list and deciding, per block, whether
+the chart or the scaffold is behind is the work — the recipe only makes the list.
 
 What *is* gated is the result. A chart this scaffold produces is checked by `just check` like any
 other, so a chassis block that stops rendering fails on the next chart somebody creates — and

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -535,6 +535,71 @@ jobs:
       - name: Contract model unit tests
         run: just test-contract-union
 
+
+  # What changed in the images' configuration contracts, and what it costs the charts.
+  #
+  # `contract-diff` was written for exactly one reader: the person reviewing the Renovate pull
+  # request that repinned a digest, looking at several hundred lines of reordered JSON. The
+  # question they have is not in those lines — did the image gain a setting the chart has to
+  # write, drop one the chart still writes, or move a default out from under it, and what should
+  # this chart's version become. Nothing invoked the recipe, so that reader never received the
+  # answer.
+  #
+  # Advisory, and structurally so. Differences are the *normal* outcome of a bump, so this job
+  # must never fail on finding them — `contract-diff` exits 0 on differences and 1 only on an
+  # error it cannot report around, and `--exit-code` is deliberately not passed. A red run here
+  # therefore means a contract could not be read, which is worth failing on.
+  #
+  # Its own job rather than a step in `config-contracts`, for two reasons. It needs full history
+  # to `git show` the base revision, and making the blocking gate pay for that on every run would
+  # be charging every pull request for a report only bump pull requests read. And it is advisory
+  # where that job is blocking; keeping the two apart is what stops the distinction eroding.
+  #
+  # Needs no render, no cluster, no `jv` and no network — the other side comes from `git show`,
+  # exactly as every gate in the group reads the committed file.
+  contract-diff:
+    name: Contract Diff
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # to checkout code
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      # Full history, because the report is a comparison against the base commit and `git show`
+      # cannot reach it from a shallow clone. This is the only job in the workflow that needs it
+      # for a reason other than chart-testing's changed-file detection.
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup toolchain
+        uses: ./.github/actions/setup-toolchain
+
+      # Written to the step summary rather than printed, because that is where a reviewer of a
+      # bump looks first and it is the one surface that survives the log being collapsed. Also
+      # echoed to the log, so a failure is diagnosable from the same place as every other job's.
+      - name: Report contract changes against the base
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          report="$(just contract-diff '' "${BASE_SHA}")"
+          echo "${report}"
+
+          {
+            echo '## Configuration contract changes'
+            echo
+            echo '```'
+            echo "${report}"
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
   install:
     name: Install & Verify (k8s ${{ matrix.kubernetes }})
     needs: [lint]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -283,6 +283,56 @@ jobs:
           CHART: ${{ matrix.chart }}
         run: just test-e2e "${CHART}"
 
+
+  # The Python behind every gate in this repository, which until now nothing checked.
+  #
+  # 11,000 lines across 24 scripts decide what a pull request here is allowed to contain, and no
+  # linter, formatter or type checker had ever run over them. That was not a decision anybody
+  # made: seven entry scripts already carried `# noqa: E402` on their imports, written for a
+  # linter that never landed.
+  #
+  # Blocking, like every other lint job. It asserts, it needs no network, no cluster and no
+  # render, and the rules it enforces are the ones a reviewer would otherwise have to check by
+  # eye — an unused import, a mutable default, an f-string with no placeholder.
+  #
+  # Its own job rather than a step in Lint Charts, because that job installs chart-testing and
+  # kube-linter to lint YAML and needs neither of them for this, and because a Python failure and
+  # a chart failure are different work for different people.
+  lint-python:
+    name: Lint Python
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # to checkout code
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup toolchain
+        uses: ./.github/actions/setup-toolchain
+
+      # A pinned single binary installed by release URL, exactly as `jv` and kubeconform are, and
+      # not `pip install ruff`: this repository has already decided that a pip install inside a
+      # gate is the difference between one that reproduces on a contributor's shell and one that
+      # does not. The version comes from `ruff_version` in justfile so a bump stays the single
+      # edit every other pinned tool already is.
+      - name: Install ruff
+        run: |
+          set -euo pipefail
+          version="$(just --evaluate ruff_version)"
+          curl -fsSL "https://github.com/astral-sh/ruff/releases/download/${version}/ruff-x86_64-unknown-linux-gnu.tar.gz" \
+            | tar -xz --strip-components=1 -C /tmp ruff-x86_64-unknown-linux-gnu/ruff
+          sudo install -m 0755 /tmp/ruff /usr/local/bin/ruff
+          ruff --version
+
+      - name: Lint
+        run: just lint-python
   lint:
     name: Lint Charts
     runs-on: ubuntu-latest

--- a/just/lint.just
+++ b/just/lint.just
@@ -34,3 +34,48 @@ lint-charts:
 lint-policy out='rendered':
     just render '{{ out }}'
     kube-linter lint --config {{ configs }}/kube-linter.yaml '{{ out }}'
+
+# --------------------------------------------------------------------------------------------
+# Python
+# --------------------------------------------------------------------------------------------
+
+# Lint `.github/scripts` — 11,000 lines of Python that had no linter at all.
+#
+# That absence was not a decision anybody made. Seven entry scripts already carried
+# `# noqa: E402` on their imports, written for a linter that never landed, so the intent was
+# there and the tool was not. The first run over the tree found 98 issues: four unused imports,
+# two f-strings with no placeholder, a loop variable nobody read, three mutable class attributes,
+# twelve unsorted import blocks and forty-five `# noqa` comments for a rule this linter does not
+# raise.
+#
+# Configured in `.github/configs/ruff.toml` beside every other tool's configuration, rather than
+# in a `pyproject.toml` at the root: `.github/scripts` is a directory of scripts a task runner
+# invokes, not a package, and a `pyproject.toml` would imply a distribution that does not exist.
+# Which rules are on and why is documented there.
+#
+# **Lints, does not format.** The files are hand-formatted to a house style the formatter
+# disagrees with in places — notably the long argument lists laid out to be read as tables — and
+# reflowing 11,000 lines to settle that is a change nobody asked for.
+#
+# **No type checking.** mypy would be the obvious companion and is deliberately absent: it ships
+# as a pip package rather than a single binary, and this repository has already decided, in
+# `justfile`'s note on `jv`, that a `pip install` inside a recipe is the difference between a
+# gate that reproduces locally and one that does not. Adopting it means solving that first, and
+# doing it badly is worse than the gap.
+#
+# In `just check`, because it asserts, needs no network, no cluster and no render, and runs over
+# a directory every other gate in this repository depends on.
+[doc("Lint the Python behind every gate in this repository")]
+[group('lint')]
+lint-python:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if ! command -v ruff >/dev/null 2>&1; then
+      echo "error: ruff is not on PATH. It is pinned as ruff_version in justfile and installed" >&2
+      echo "       by release URL, exactly as jv and kubeconform are:" >&2
+      echo "       https://github.com/astral-sh/ruff/releases/tag/{{ ruff_version }}" >&2
+      exit 1
+    fi
+
+    ruff check --config {{ configs }}/ruff.toml {{ scripts }}

--- a/just/maintain.just
+++ b/just/maintain.just
@@ -48,3 +48,46 @@ check-kube-refs version=kube_version:
     set -euo pipefail
     {{ resolve_python }}
     "$python" {{ scripts }}/kube-schema-refs.py '{{ version }}' --charts {{ charts }} --check
+
+# --------------------------------------------------------------------------------------------
+# The chart chassis
+# --------------------------------------------------------------------------------------------
+#
+# `just new-chart` writes a new chart from `.github/templates/chart/values.chassis.yaml` — the
+# twenty-nine `values.yaml` blocks that are the same in every chart because `charts/common` owns
+# the logic and these files only name it. Nothing keeps that copy and the charts in step: a block
+# gains a sentence in one chart, the scaffold keeps the old wording, and the next chart created
+# inherits it.
+#
+# The chassis is **not** the authority. It was seeded from the majority text of the existing
+# charts, so it is right about most blocks by construction and has no claim to be right about any
+# particular one — which is why this reports and does not fail.
+
+# Report where a chart's shared values blocks have drifted from the scaffold's copy. Report only.
+#
+# Compared as text, comments included, because the comments are the interesting part: the
+# `@schema` blocks are what `values.schema.json` is generated from, and the `# --` descriptions
+# are published into every chart's README by helm-docs. Two blocks parsing to the same mapping can
+# still produce a different schema and a different README.
+#
+# Blocks a chart does not carry at all are not reported. `teamspeak` has no `extraVolumeMounts`
+# and does not need one; that is a fact about the chart rather than drift. `tankovault` shares
+# only 8 of the 29 because it is nine services and keeps its podspec under `defaults:` and
+# `services.*` — the scaffold does not model that shape, and saying so is more useful than
+# reporting 21 absences.
+#
+# Deliberately NOT in `just check`, for the reason `explain` and `check-config-secrets` are not:
+# it prints rather than asserts, and an aggregate whose whole output is a pass or a fail is not
+# where advisory output belongs.
+#
+#   just check-chassis                    every chart, with a diff per drifted block
+#   just check-chassis '' --summary       the counts alone
+#   just check-chassis portfolio          one chart
+[doc("Report where a chart's shared values blocks have drifted from the scaffold's copy")]
+[group('maintain')]
+check-chassis chart='' *flags:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    {{ resolve_python }}
+    "$python" {{ scripts }}/check-chassis.py '{{ chart }}' \
+      --charts {{ charts }} --chassis .github/templates/chart/values.chassis.yaml {{ flags }}

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@
 #                               recipe in the repository, and not part of `just check`
 #   deps, docs, render, test    helm (+ `just plugins`), python3 with PyYAML
 #   docs                        helm-docs, for `just chart-readmes`
-#   lint                        chart-testing (`ct`), kube-linter
+#   lint                        chart-testing (`ct`), kube-linter; ruff, for `just lint-python`
 #   maintain                    python3 with PyYAML
 #   render                      kubeconform, for `just validate-manifests`
 #   test                        docker, for `just test-rules` and `just test-e2e`
@@ -62,6 +62,17 @@ helm_schema_version := "0.18.1"
 # `.github/scripts` are stdlib + PyYAML, and on the Git Bash shell this repository is developed
 # from, a pip install is the difference between a gate that runs locally and one that does not.
 jv_version := "v6.0.3"
+
+# Linter for `.github/scripts`, which is 11,000 lines of Python holding every gate here and had
+# none until `just lint-python` landed. Pinned as a single binary by release URL for exactly the
+# reason `jv` above is: a `pip install` inside a recipe is the difference between a gate that runs
+# on the Git Bash shell this repository is developed from and one that does not. ruff ships that
+# way; mypy does not, which is why type checking is not part of the gate — see `just/lint.just`.
+#
+# Pinned rather than floating because a linter is a gate: a new release that adds a rule would
+# turn a pull request red for something its author did not write, and the fix would be a version
+# bump made under time pressure rather than a considered one.
+ruff_version := "0.16.3"
 
 # Registry client and signature verifier for `just contracts`. Only the contract refresh needs
 # these — every gate that reads a contract reads the committed file — which is why they are absent
@@ -165,7 +176,7 @@ default:
 # Documentation job ever adopts `just contract-tests`, this belongs back out beside the other two.
 [doc("Every gate CI runs that does not need a Kubernetes cluster")]
 [group('meta')]
-check: deps test validate-manifests check-immutable check-config check-contract-coverage check-config-bindings check-contract-tests test-contract-union lint lint-policy
+check: deps test validate-manifests check-immutable check-config check-contract-coverage check-config-bindings check-contract-tests test-contract-union lint-python lint lint-policy
 
 # Install the pinned Helm plugins. The CI composite action calls this recipe too, so the versions
 # above are the only place they are declared.


### PR DESCRIPTION
> Stacked on #468 → #467 → #466.

## The gap

`contract-diff.py` is 360 lines with a stated audience:

> `contracts` runs inside the Renovate pull request that repins the digest, which is the design's whole point and is also why the reviewer is looking at several hundred lines of reordered JSON. The question they have is not in those lines: did the image gain a setting the chart has to write, drop one the chart still writes, or move a default out from under it — and, given the answer, what should this chart's own version be. This recipe is that answer.

It grades severity by what the loader does at boot, suggests a version bump, emits JSON, and offers `--exit-code` so a caller can distinguish "differs" (2) from "failed" (1).

**Nothing calls it.** No workflow, no other recipe. The audience it was written for never receives it.

## The fix

A `Contract Diff` job that writes the report into `$GITHUB_STEP_SUMMARY`, where a reviewer of a bump looks first and which survives the log being collapsed. Also echoed to the log so a failure is diagnosable from the same place as every other job's.

## Design notes

**Advisory, structurally.** Differences are the *normal* outcome of a bump, so a job that failed on them would be red on every pull request it exists to explain. `--exit-code` is deliberately not passed: the recipe exits 0 on differences and 1 only on an error it cannot report around. A red run here therefore means a contract could not be read — which is worth failing on.

**Its own job rather than a step in `config-contracts`.** Two reasons:

1. It needs `fetch-depth: 0` to `git show` the base revision. Adding that to the blocking gate would charge every pull request for history that only this report uses.
2. It is advisory where `config-contracts` is blocking. Keeping them apart is what stops that distinction eroding.

**`if: github.event_name == 'pull_request'`** — the workflow also triggers on `workflow_dispatch`, where there is no base to compare against.

**Compared against `github.event.pull_request.base.sha`**, not `origin/main`. The recipe defaults to `origin/main`, which is right for a local shell and wrong for a PR targeting anything else.

## Verification

`just contract-diff '' origin/main` runs clean against the current tree (`==> no vendored contract differs from origin/main`, exit 0), and the workflow parses with the new job in place. On this stack there are no contract changes, so the summary will say so — the interesting output arrives on the first Renovate bump after merge.
