### PR TITLE
docs: render the root README from the shared payload

### DIFF
--- a/.github/templates/README.md.hbs
+++ b/.github/templates/README.md.hbs
@@ -1,116 +1,216 @@
 <!--
-Template for the repository README. CI renders it on every pull request and commits the
-result to README.md, so edit this file — never README.md itself.
+Generated from .github/templates/README.md.hbs — edit that file, not this one.
 
-Variables come from .github/scripts/chart-index.py, which reads every charts/*/Chart.yaml.
+The Documentation job in .github/workflows/ci.yaml renders it on every pull request and commits
+the result back to the branch. A push to main whose README.md does not match its template fails
+the `readme` job in .github/workflows/docs.yaml.
+
+The chart table comes from one command:
+
+    just chart-index
+
+which reads every charts/*/Chart.yaml. The rest of the payload — repository, branch, the library
+chart's name and version, and the docs index — is derived from charts/common/Chart.yaml and the
+checkout by TimSchoenle/actions/actions/common/readme-variables, so no name, version or
+description below is typed by hand.
+
+Nothing in this comment may contain a mustache that is not a real reference.
 -->
-# Helm Charts
 
-Helm charts for the applications and utilities I run on Kubernetes. Every chart is built on
-the same `common` library, so they share one values contract, one label scheme and one
-security baseline.
+# {{ repo.name }}
 
-## TL;DR
+Helm charts for the applications and utilities I run on Kubernetes, built on one shared library.
+
+[![Latest chart](https://img.shields.io/github/v/release/{{ repo.slug }}?sort=date&display_name=tag&label=latest%20chart)]({{ repo.url }}/releases)
+[![Publish](https://img.shields.io/github/actions/workflow/status/{{ repo.slug }}/release.yml?branch={{ repo.branch }}&label=publish)]({{ repo.url }}/actions/workflows/release.yml)
+
+## What this is
+
+Every one of the {{ count charts }} application charts here depends on the `{{ repo.package }}` library chart, which holds the
+shared template partials: the pod spec, both security contexts, the NetworkPolicies, the monitoring
+objects and the file-backed configuration. A change to the security baseline is written once there
+and reaches every chart on its next dependency build.
+
+Packages are published to <https://{{ lower repo.owner }}.github.io/{{ repo.name }}> by chart-releaser, one GitHub
+Release per chart version.
+
+## Quick start
 
 ```bash
-helm repo add timschoenle https://timschoenle.github.io/helm-charts
+helm repo add timschoenle https://{{ lower repo.owner }}.github.io/{{ repo.name }}
 helm repo update
-helm install my-release timschoenle/<chart-name> -f values.yaml
+helm install my-release timschoenle/<chart>
 ```
 
-Requires Kubernetes 1.19+ and Helm 3.0+. CI validates every chart against Helm 3.21 and 4.2.
+Several charts need a credential or an accepted licence that `helm install` cannot invent. Read
+the chart's own README before installing it.
 
-## Charts
+## Table of contents
 
-Each chart's README is the reference for its values, its prerequisites and its migration
-notes. Follow the link before installing — several charts need a credential or an accepted
-licence that `helm install` cannot invent for you.
+- [Features](#features)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Configuration](#configuration)
+- [Compatibility](#compatibility)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [Security](#security)
+
+## Features
+
+### Charts
 
 | Chart | Description |
-|-------|-------------|
-{{#each charts}}
-| [{{name}}](./charts/{{name}}) | {{mdCell description}} |
+| --- | --- |
+{{#each charts}}| [{{ name }}](charts/{{ name }}) | {{ mdCell description }} |
 {{/each}}
 {{#each libraryCharts}}
 
-The [`{{name}}`](./charts/{{name}}) library chart is not published. It holds the shared
-template partials every chart above composes, and is consumed locally via `file://../{{name}}`.
+[`{{ name }}`](charts/{{ name }}) is not published. Consumers pull it from `file://../{{ name }}`, so a
+chart is packaged with the library version its own `Chart.yaml` pinned at release time.
 {{/each}}
 
-Versions are deliberately absent from this table: they change on nearly every pull request,
-and a rendered version column would turn each of those into a merge conflict on this one
-file. Run `helm search repo timschoenle --versions` for what is published.
+Versions are absent from that table on purpose. They change on nearly every pull request, and a
+rendered version column turned this one file into a merge conflict across concurrent bump
+branches. `helm search repo timschoenle --versions` lists what is published.
 
-## What every chart gives you
+### What every chart gives you
 
-**The [restricted Pod Security Standard][pss] by default.** Pods run non-root with no
-privilege escalation, all Linux capabilities dropped, a read-only root filesystem,
-`seccompProfile: RuntimeDefault` and no ServiceAccount token mounted. Relax any of it per
-chart through `podSecurityContextPreset` / `securityContextPreset` and the matching context
-values.
+**The [restricted Pod Security Standard][pss] by default.** Pods run non-root with no privilege
+escalation, all Linux capabilities dropped, a read-only root filesystem,
+`seccompProfile: RuntimeDefault` and no ServiceAccount token mounted. Setting
+`podSecurityContextPreset` or `securityContextPreset` to `none` opts out, and the matching
+`podSecurityContext` and `securityContext` values merge over whichever preset is in force. The
+identity fields stay with the chart, because `runAsUser` has to match the image's own UID.
 
-**NetworkPolicies that actually restrict.** Opt in with `networkPolicy.enabled`. Every
-generated egress rule carries a `to:` selector — DNS to the cluster DNS service, HTTP/HTTPS
-to a configurable CIDR that excludes RFC1918 space and the link-local range covering the
-cloud instance metadata endpoint. A rule with only `ports:` would permit every destination,
-so custom rules must supply their own `to:`.
+NetworkPolicies are opt-in through `networkPolicy.enabled`, and every generated egress rule
+carries a `to:` selector: DNS to the cluster DNS service, HTTP and HTTPS to a configurable CIDR
+that excludes RFC1918 space and `169.254.0.0/16`, the range the cloud instance metadata endpoint
+sits in. The API reads a rule listing only `ports:` as permitting every destination, so a custom
+rule must supply its own `to:`. Set `networkPolicy.engine` to `cilium` for FQDN and L7 rules, or
+to `both` while a cluster migrates between CNIs.
 
-**Optional observability.** Charts that ship metrics render ServiceMonitors or PodMonitors,
-Prometheus rules and Grafana dashboards. All are off by default and all require the relevant
-operator CRDs; when those are missing the chart fails the render rather than installing
-cleanly and leaving you unmonitored.
+**Monitoring objects that fail loudly.** Charts that ship metrics render ServiceMonitors or
+PodMonitors, Prometheus rules and Grafana dashboards. All are off by default and all need the
+operator CRDs; when those are missing the render fails instead of installing cleanly and leaving
+you unmonitored.
+
+Six charts vendor the configuration contract their image publishes and check the rendered
+`config.toml`, every container environment variable and every secret file name against it. A key
+the application stopped reading fails the pull request that bumps the digest, rather than starting
+a pod that runs on a compiled default nobody chose.
 
 [pss]: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
 
-## Reading a chart's documentation
+## Installation
+
+From the published repository:
 
 ```bash
-helm show readme timschoenle/<chart-name>   # the chart README, as published
-helm show values timschoenle/<chart-name>   # every value with its default
+helm repo add timschoenle https://{{ lower repo.owner }}.github.io/{{ repo.name }}
+helm repo update
+helm install my-release timschoenle/<chart> --version <x.y.z> -f values.yaml
 ```
 
-## Upgrading
+From a checkout, which is what CI installs:
 
-A chart's major version bump means its values contract changed. Migration notes live in that
-chart's own README under an `Upgrading` heading; for `tankovault` and `paperless-ngx`, whose
-histories are longer, they live in
-[charts/tankovault/UPGRADING.md](./charts/tankovault/UPGRADING.md) and
-[charts/paperless-ngx/UPGRADING.md](./charts/paperless-ngx/UPGRADING.md).
+```bash
+git clone https://github.com/{{ repo.slug }}.git
+cd {{ repo.name }}
+just deps
+helm install my-release ./charts/<chart> -f values.yaml
+```
 
-Every chart also publishes a `values.schema.json`, so a value that a new major removed or
-renamed fails at render time with the offending key named, rather than being silently
-dropped.
+`just deps` extracts the `{{ repo.package }}` library into each chart. A fresh clone cannot render a
+chart before it has run.
 
-## Working on the charts
+## Usage
 
-`README.md` and `values.schema.json` are generated. Edit the sources instead:
+Read a published chart without cloning it:
+
+```bash
+helm show readme timschoenle/<chart>
+helm show values timschoenle/<chart>
+```
+
+A chart's major version bump means its values contract changed. The migration notes sit in that
+chart's README under `Upgrading`, except for the two whose histories outgrew it:
+[charts/tankovault/UPGRADING.md](charts/tankovault/UPGRADING.md) and
+[charts/paperless-ngx/UPGRADING.md](charts/paperless-ngx/UPGRADING.md).
+
+## Configuration
+
+Values are documented where they are declared. Each key in a chart's `values.yaml` carries an
+`@schema` block and a `-- ` comment, and from those `just schema` generates `values.schema.json`
+while helm-docs generates the chart's README table. A value that a new major renamed or removed
+then fails at render time with the offending key named, instead of being dropped in silence.
+
+The keys `{{ repo.package }}` defines for every chart:
+
+| Key | Purpose |
+| --- | --- |
+| `podSecurityContextPreset`, `securityContextPreset` | `restricted` or `none`, the baseline each security context merges over |
+| `podSecurityContext`, `securityContext` | Kubernetes objects merged over the preset |
+| `networkPolicy.*` | Ingress and egress rules, and which policy dialect renders them |
+| `resources` | Requests and limits, typed against the Kubernetes schema |
+| `metrics.*`, `grafana.*`, `prometheusRule.*` | The monitoring objects, all off by default |
+
+Everything else belongs to the individual chart, whose README lists every value with its default.
+
+## Compatibility
+
+| | Supported |
+| --- | --- |
+| Helm | 3 and 4 |
+| Library chart | `{{ repo.package }}` {{ release.version }} |
+| Kubernetes | No chart declares a `kubeVersion`. The render, validation and install matrices in [.github/workflows/ci.yaml](.github/workflows/ci.yaml) state what is tested. |
+
+## Documentation
+
+Every chart's README is the reference for its values, its prerequisites and its migration notes,
+and `helm show readme` prints the published copy without a clone. The gates are documented beside
+themselves: `justfile` and each file under `just/` open with a header saying what its recipes
+prove and why a recipe is or is not part of `just check`.
+{{#if docs}}
+
+| Document | Purpose |
+| --- | --- |
+{{#each docs}}| [{{ path }}]({{ path }}) | {{ default (mdCell summary) "See the document." }} |
+{{/each}}
+{{/if}}
+
+## Contributing
+
+Issues and pull requests are welcome. Open an issue with the chart name and version, your
+Kubernetes and Helm versions, the values you installed with, and the output of `helm template` or
+the failing pod's logs.
+
+Three files per chart are generated, and CI regenerates and commits all of them on every pull
+request, so contributing a values change needs no toolchain installed:
 
 | Generated | Source |
-|---|---|
+| --- | --- |
 | `charts/<chart>/README.md` | `charts/<chart>/README.md.gotmpl` and `values.yaml` |
-| `charts/<chart>/values.schema.json` | `charts/<chart>/values.yaml` |
-| `README.md` (this file) | `.github/templates/README.md.hbs` |
+| `charts/<chart>/values.schema.json` | the `@schema` blocks in `values.yaml` |
+| `README.md` | `.github/templates/README.md.hbs` |
 
-CI regenerates all three on every pull request and commits the result back to the branch, so
-there is no toolchain to install locally.
-
-Every check CI runs is a [`just`](https://just.systems) recipe, and the workflows invoke those
-same recipes rather than their own copy of the logic — so any gate can be reproduced locally with
-one command:
+Every gate CI runs is a [`just`](https://just.systems) recipe, and the workflows call those
+recipes rather than keeping a second copy of the logic:
 
 ```bash
 just              # list every recipe, grouped
 just deps         # resolve chart dependencies; a fresh clone needs this first
 just test-unit    # helm unittest, every chart
-just test-rules   # promtool tests for charts that ship Prometheus rules
+just test-rules   # promtool tests for the charts that ship Prometheus rules
 just lint         # helm lint the library chart, chart-testing lint the rest
-just check        # everything CI runs that needs no Kubernetes cluster
+just check        # everything CI runs that needs no cluster and no network
 ```
 
-Recipes live in `justfile` and `just/*.just`, one file per group.
+## Security
 
-## Reporting issues
+Report a vulnerability in a chart through
+[GitHub's advisory form]({{ repo.url }}/security/advisories/new)
+rather than in a public issue. There is no separate reporting address.
 
-Open an [issue](https://github.com/timschoenle/helm-charts/issues) with the chart name and
-version, your Kubernetes and Helm versions, the values you installed with, and the output of
-`helm template` or the failing pod's logs.
+A vulnerability in an application one of these charts deploys belongs to that application's own
+repository, which the chart's `Chart.yaml` names under `sources`.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,7 +129,22 @@ jobs:
         run: |
           set -euo pipefail
           index="$(just chart-index)"
-          echo "variables=${index}" >> "$GITHUB_OUTPUT"
+          echo "json=${index}" >> "$GITHUB_OUTPUT"
+
+      # The chart index covers the table and nothing else. Repository, branch, the `common`
+      # library's name and version and the docs index come from the shared action instead, so the
+      # template quotes them rather than repeating them — and every repository in the estate
+      # spells them the same way. `branch` is pinned to the default branch because the input
+      # defaults to `github.ref_name`, which on a pull_request event is `<number>/merge`: left
+      # alone it would write that into the badge URLs here and `main` into the drift gate in
+      # docs.yaml, failing every merge for a reason absent from the diff.
+      - name: Collect the README payload
+        id: variables
+        uses: TimSchoenle/actions/actions/common/readme-variables@b5b5c9e047f00ffa00b7772536c8bdb4f158f706 # tag=actions-common-readme-variables-v1.1.0
+        with:
+          manifest: charts/common/Chart.yaml
+          branch: ${{ github.event.repository.default_branch }}
+          extra: ${{ steps.chart-index.outputs.json }}
 
       - name: Render and commit the root README
         id: readme
@@ -137,7 +152,7 @@ jobs:
         with:
           template: .github/templates/README.md.hbs
           output: README.md
-          variables: ${{ steps.chart-index.outputs.variables }}
+          variables: ${{ steps.variables.outputs.variables }}
           token: ${{ steps.generate_token.outputs.token }}
           commit_message: "docs: update chart index in README"
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,73 @@
+name: Docs
+
+# The drift gate for the root README, and only for it.
+#
+# Rendering happens in the Documentation job of `ci.yaml`, which commits the result back to the
+# pull request branch. That job cannot gate anything: it repairs the file rather than failing on
+# it, and it needs the App token, which a fork does not get. This workflow is the other half —
+# it renders with `check: true`, writes nothing, and fails when the committed README.md does not
+# match its template.
+#
+# Kept out of `ci.yaml` because that workflow is pull-request-only by design and its other jobs
+# build kind clusters. Adding a `push: main` trigger there to reach this one check would run all
+# of them on every merge.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  verify:
+    name: readme
+    # Same-repo pull requests are covered by the Documentation job, which fixes the file instead of
+    # reporting it. Running here as well would fail every pull request that legitimately edits the
+    # template, in the window before that job's commit lands.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # to checkout code
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup toolchain
+        uses: ./.github/actions/setup-toolchain
+
+      # The same two steps `ci.yaml` renders from, in the same order and with the same inputs. A
+      # difference between them would make this gate fail on a README the render job just wrote.
+      - name: Collect chart metadata
+        id: chart-index
+        run: |
+          set -euo pipefail
+          index="$(just chart-index)"
+          echo "json=${index}" >> "$GITHUB_OUTPUT"
+
+      - name: Collect the README payload
+        id: variables
+        uses: TimSchoenle/actions/actions/common/readme-variables@b5b5c9e047f00ffa00b7772536c8bdb4f158f706 # tag=actions-common-readme-variables-v1.1.0
+        with:
+          manifest: charts/common/Chart.yaml
+          branch: ${{ github.event.repository.default_branch }}
+          extra: ${{ steps.chart-index.outputs.json }}
+
+      - name: Verify README.md is current
+        uses: TimSchoenle/actions/actions/common/render-template@3b7d152374ee63e720e7c16bed8b088b40554911 # tag=actions-common-render-template-v1.1.1
+        with:
+          template: .github/templates/README.md.hbs
+          output: README.md
+          variables: ${{ steps.variables.outputs.variables }}
+          check: 'true'

--- a/README.md
+++ b/README.md
@@ -1,119 +1,213 @@
 <!--
-Template for the repository README. CI renders it on every pull request and commits the
-result to README.md, so edit this file — never README.md itself.
+Generated from .github/templates/README.md.hbs — edit that file, not this one.
 
-Variables come from .github/scripts/chart-index.py, which reads every charts/*/Chart.yaml.
+The Documentation job in .github/workflows/ci.yaml renders it on every pull request and commits
+the result back to the branch. A push to main whose README.md does not match its template fails
+the `readme` job in .github/workflows/docs.yaml.
+
+The chart table comes from one command:
+
+    just chart-index
+
+which reads every charts/*/Chart.yaml. The rest of the payload — repository, branch, the library
+chart's name and version, and the docs index — is derived from charts/common/Chart.yaml and the
+checkout by TimSchoenle/actions/actions/common/readme-variables, so no name, version or
+description below is typed by hand.
+
+Nothing in this comment may contain a mustache that is not a real reference.
 -->
-# Helm Charts
 
-Helm charts for the applications and utilities I run on Kubernetes. Every chart is built on
-the same `common` library, so they share one values contract, one label scheme and one
-security baseline.
+# helm-charts
 
-## TL;DR
+Helm charts for the applications and utilities I run on Kubernetes, built on one shared library.
+
+[![Latest chart](https://img.shields.io/github/v/release/TimSchoenle/helm-charts?sort=date&display_name=tag&label=latest%20chart)](https://github.com/TimSchoenle/helm-charts/releases)
+[![Publish](https://img.shields.io/github/actions/workflow/status/TimSchoenle/helm-charts/release.yml?branch=main&label=publish)](https://github.com/TimSchoenle/helm-charts/actions/workflows/release.yml)
+
+## What this is
+
+Every one of the 8 application charts here depends on the `common` library chart, which holds the
+shared template partials: the pod spec, both security contexts, the NetworkPolicies, the monitoring
+objects and the file-backed configuration. A change to the security baseline is written once there
+and reaches every chart on its next dependency build.
+
+Packages are published to <https://timschoenle.github.io/helm-charts> by chart-releaser, one GitHub
+Release per chart version.
+
+## Quick start
 
 ```bash
 helm repo add timschoenle https://timschoenle.github.io/helm-charts
 helm repo update
-helm install my-release timschoenle/<chart-name> -f values.yaml
+helm install my-release timschoenle/<chart>
 ```
 
-Requires Kubernetes 1.19+ and Helm 3.0+. CI validates every chart against Helm 3.21 and 4.2.
+Several charts need a credential or an accepted licence that `helm install` cannot invent. Read
+the chart's own README before installing it.
 
-## Charts
+## Table of contents
 
-Each chart's README is the reference for its values, its prerequisites and its migration
-notes. Follow the link before installing — several charts need a credential or an accepted
-licence that `helm install` cannot invent for you.
+- [Features](#features)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Configuration](#configuration)
+- [Compatibility](#compatibility)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [Security](#security)
+
+## Features
+
+### Charts
 
 | Chart | Description |
-|-------|-------------|
-| [cloudflare-access-webhook-redirect](./charts/cloudflare-access-webhook-redirect) | A Helm chart for deploying the Cloudflare Access Webhook Redirect service. This service acts as an authentication proxy that validates requests using Cloudflare Access Service Auth tokens before forwarding them to target backend services. |
-| [mp-stats-legacy-viewer](./charts/mp-stats-legacy-viewer) | MP Stats Legacy Viewer |
-| [netcup-offer-bot](./charts/netcup-offer-bot) | This chart deploys the Netcup Offer Bot, which monitors https://www.netcup-sonderangebote.de/ RSS feed and sends notifications to Discord webhooks when new offers are available. |
-| [paperless-ngx](./charts/paperless-ngx) | This chart deploys paperless-ngx — a document management system that scans, indexes and archives your paper documents — hardened to the restricted Pod Security Standard, with per-directory persistence, scheduled document_exporter backups and document_importer restores, optional bundled Valkey, PostgreSQL, Gotenberg and Tika, Ingress and Gateway API publishing, Grafana dashboards and Prometheus alerting rules. |
-| [portfolio](./charts/portfolio) | Personal portfolio built with Rust (Yew frontend, Axum server). |
-| [s3-bucket-perma-link](./charts/s3-bucket-perma-link) | This chart deploys a simple web server that provides permanent links to specific S3 bucket resources. It allows you to define static URL paths that always point to specific files in your S3 buckets. |
-| [tankovault](./charts/tankovault) | This chart deploys the full TankoVault manga aggregator stack — frontend, api, control-plane, worker, notifier, sync, challenge-solver and render — hardened to the restricted Pod Security Standard, with file-backed configuration that reloads in place instead of restarting pods, optional bundled PostgreSQL, Valkey, NATS JetStream and TRAWL, and optional Prometheus metrics, alerting rules and Grafana dashboards. |
-| [teamspeak](./charts/teamspeak) | This chart deploys a TeamSpeak 3 server hardened to the restricted Pod Security Standard, with optional persistence, an optional Prometheus metrics exporter sidecar, Grafana dashboards and Prometheus alerting rules. |
+| --- | --- |
+| [cloudflare-access-webhook-redirect](charts/cloudflare-access-webhook-redirect) | A Helm chart for deploying the Cloudflare Access Webhook Redirect service. This service acts as an authentication proxy that validates requests using Cloudflare Access Service Auth tokens before forwarding them to target backend services. |
+| [mp-stats-legacy-viewer](charts/mp-stats-legacy-viewer) | MP Stats Legacy Viewer |
+| [netcup-offer-bot](charts/netcup-offer-bot) | This chart deploys the Netcup Offer Bot, which monitors https://www.netcup-sonderangebote.de/ RSS feed and sends notifications to Discord webhooks when new offers are available. |
+| [paperless-ngx](charts/paperless-ngx) | This chart deploys paperless-ngx — a document management system that scans, indexes and archives your paper documents — hardened to the restricted Pod Security Standard, with per-directory persistence, scheduled document_exporter backups and document_importer restores, optional bundled Valkey, PostgreSQL, Gotenberg and Tika, Ingress and Gateway API publishing, Grafana dashboards and Prometheus alerting rules. |
+| [portfolio](charts/portfolio) | Personal portfolio built with Rust (Yew frontend, Axum server). |
+| [s3-bucket-perma-link](charts/s3-bucket-perma-link) | This chart deploys a simple web server that provides permanent links to specific S3 bucket resources. It allows you to define static URL paths that always point to specific files in your S3 buckets. |
+| [tankovault](charts/tankovault) | This chart deploys the full TankoVault manga aggregator stack — frontend, api, control-plane, worker, notifier, sync, challenge-solver and render — hardened to the restricted Pod Security Standard, with file-backed configuration that reloads in place instead of restarting pods, optional bundled PostgreSQL, Valkey, NATS JetStream and TRAWL, and optional Prometheus metrics, alerting rules and Grafana dashboards. |
+| [teamspeak](charts/teamspeak) | This chart deploys a TeamSpeak 3 server hardened to the restricted Pod Security Standard, with optional persistence, an optional Prometheus metrics exporter sidecar, Grafana dashboards and Prometheus alerting rules. |
 
-The [`common`](./charts/common) library chart is not published. It holds the shared
-template partials every chart above composes, and is consumed locally via `file://../common`.
+[`common`](charts/common) is not published. Consumers pull it from `file://../common`, so a
+chart is packaged with the library version its own `Chart.yaml` pinned at release time.
 
-Versions are deliberately absent from this table: they change on nearly every pull request,
-and a rendered version column would turn each of those into a merge conflict on this one
-file. Run `helm search repo timschoenle --versions` for what is published.
+Versions are absent from that table on purpose. They change on nearly every pull request, and a
+rendered version column turned this one file into a merge conflict across concurrent bump
+branches. `helm search repo timschoenle --versions` lists what is published.
 
-## What every chart gives you
+### What every chart gives you
 
-**The [restricted Pod Security Standard][pss] by default.** Pods run non-root with no
-privilege escalation, all Linux capabilities dropped, a read-only root filesystem,
-`seccompProfile: RuntimeDefault` and no ServiceAccount token mounted. Relax any of it per
-chart through `podSecurityContextPreset` / `securityContextPreset` and the matching context
-values.
+**The [restricted Pod Security Standard][pss] by default.** Pods run non-root with no privilege
+escalation, all Linux capabilities dropped, a read-only root filesystem,
+`seccompProfile: RuntimeDefault` and no ServiceAccount token mounted. Setting
+`podSecurityContextPreset` or `securityContextPreset` to `none` opts out, and the matching
+`podSecurityContext` and `securityContext` values merge over whichever preset is in force. The
+identity fields stay with the chart, because `runAsUser` has to match the image's own UID.
 
-**NetworkPolicies that actually restrict.** Opt in with `networkPolicy.enabled`. Every
-generated egress rule carries a `to:` selector — DNS to the cluster DNS service, HTTP/HTTPS
-to a configurable CIDR that excludes RFC1918 space and the link-local range covering the
-cloud instance metadata endpoint. A rule with only `ports:` would permit every destination,
-so custom rules must supply their own `to:`.
+NetworkPolicies are opt-in through `networkPolicy.enabled`, and every generated egress rule
+carries a `to:` selector: DNS to the cluster DNS service, HTTP and HTTPS to a configurable CIDR
+that excludes RFC1918 space and `169.254.0.0/16`, the range the cloud instance metadata endpoint
+sits in. The API reads a rule listing only `ports:` as permitting every destination, so a custom
+rule must supply its own `to:`. Set `networkPolicy.engine` to `cilium` for FQDN and L7 rules, or
+to `both` while a cluster migrates between CNIs.
 
-**Optional observability.** Charts that ship metrics render ServiceMonitors or PodMonitors,
-Prometheus rules and Grafana dashboards. All are off by default and all require the relevant
-operator CRDs; when those are missing the chart fails the render rather than installing
-cleanly and leaving you unmonitored.
+**Monitoring objects that fail loudly.** Charts that ship metrics render ServiceMonitors or
+PodMonitors, Prometheus rules and Grafana dashboards. All are off by default and all need the
+operator CRDs; when those are missing the render fails instead of installing cleanly and leaving
+you unmonitored.
+
+Six charts vendor the configuration contract their image publishes and check the rendered
+`config.toml`, every container environment variable and every secret file name against it. A key
+the application stopped reading fails the pull request that bumps the digest, rather than starting
+a pod that runs on a compiled default nobody chose.
 
 [pss]: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
 
-## Reading a chart's documentation
+## Installation
+
+From the published repository:
 
 ```bash
-helm show readme timschoenle/<chart-name>   # the chart README, as published
-helm show values timschoenle/<chart-name>   # every value with its default
+helm repo add timschoenle https://timschoenle.github.io/helm-charts
+helm repo update
+helm install my-release timschoenle/<chart> --version <x.y.z> -f values.yaml
 ```
 
-## Upgrading
+From a checkout, which is what CI installs:
 
-A chart's major version bump means its values contract changed. Migration notes live in that
-chart's own README under an `Upgrading` heading; for `tankovault` and `paperless-ngx`, whose
-histories are longer, they live in
-[charts/tankovault/UPGRADING.md](./charts/tankovault/UPGRADING.md) and
-[charts/paperless-ngx/UPGRADING.md](./charts/paperless-ngx/UPGRADING.md).
+```bash
+git clone https://github.com/TimSchoenle/helm-charts.git
+cd helm-charts
+just deps
+helm install my-release ./charts/<chart> -f values.yaml
+```
 
-Every chart also publishes a `values.schema.json`, so a value that a new major removed or
-renamed fails at render time with the offending key named, rather than being silently
-dropped.
+`just deps` extracts the `common` library into each chart. A fresh clone cannot render a
+chart before it has run.
 
-## Working on the charts
+## Usage
 
-`README.md` and `values.schema.json` are generated. Edit the sources instead:
+Read a published chart without cloning it:
+
+```bash
+helm show readme timschoenle/<chart>
+helm show values timschoenle/<chart>
+```
+
+A chart's major version bump means its values contract changed. The migration notes sit in that
+chart's README under `Upgrading`, except for the two whose histories outgrew it:
+[charts/tankovault/UPGRADING.md](charts/tankovault/UPGRADING.md) and
+[charts/paperless-ngx/UPGRADING.md](charts/paperless-ngx/UPGRADING.md).
+
+## Configuration
+
+Values are documented where they are declared. Each key in a chart's `values.yaml` carries an
+`@schema` block and a `-- ` comment, and from those `just schema` generates `values.schema.json`
+while helm-docs generates the chart's README table. A value that a new major renamed or removed
+then fails at render time with the offending key named, instead of being dropped in silence.
+
+The keys `common` defines for every chart:
+
+| Key | Purpose |
+| --- | --- |
+| `podSecurityContextPreset`, `securityContextPreset` | `restricted` or `none`, the baseline each security context merges over |
+| `podSecurityContext`, `securityContext` | Kubernetes objects merged over the preset |
+| `networkPolicy.*` | Ingress and egress rules, and which policy dialect renders them |
+| `resources` | Requests and limits, typed against the Kubernetes schema |
+| `metrics.*`, `grafana.*`, `prometheusRule.*` | The monitoring objects, all off by default |
+
+Everything else belongs to the individual chart, whose README lists every value with its default.
+
+## Compatibility
+
+| | Supported |
+| --- | --- |
+| Helm | 3 and 4 |
+| Library chart | `common` 2.0.0 |
+| Kubernetes | No chart declares a `kubeVersion`. The render, validation and install matrices in [.github/workflows/ci.yaml](.github/workflows/ci.yaml) state what is tested. |
+
+## Documentation
+
+Every chart's README is the reference for its values, its prerequisites and its migration notes,
+and `helm show readme` prints the published copy without a clone. The gates are documented beside
+themselves: `justfile` and each file under `just/` open with a header saying what its recipes
+prove and why a recipe is or is not part of `just check`.
+
+## Contributing
+
+Issues and pull requests are welcome. Open an issue with the chart name and version, your
+Kubernetes and Helm versions, the values you installed with, and the output of `helm template` or
+the failing pod's logs.
+
+Three files per chart are generated, and CI regenerates and commits all of them on every pull
+request, so contributing a values change needs no toolchain installed:
 
 | Generated | Source |
-|---|---|
+| --- | --- |
 | `charts/<chart>/README.md` | `charts/<chart>/README.md.gotmpl` and `values.yaml` |
-| `charts/<chart>/values.schema.json` | `charts/<chart>/values.yaml` |
-| `README.md` (this file) | `.github/templates/README.md.hbs` |
+| `charts/<chart>/values.schema.json` | the `@schema` blocks in `values.yaml` |
+| `README.md` | `.github/templates/README.md.hbs` |
 
-CI regenerates all three on every pull request and commits the result back to the branch, so
-there is no toolchain to install locally.
-
-Every check CI runs is a [`just`](https://just.systems) recipe, and the workflows invoke those
-same recipes rather than their own copy of the logic — so any gate can be reproduced locally with
-one command:
+Every gate CI runs is a [`just`](https://just.systems) recipe, and the workflows call those
+recipes rather than keeping a second copy of the logic:
 
 ```bash
 just              # list every recipe, grouped
 just deps         # resolve chart dependencies; a fresh clone needs this first
 just test-unit    # helm unittest, every chart
-just test-rules   # promtool tests for charts that ship Prometheus rules
+just test-rules   # promtool tests for the charts that ship Prometheus rules
 just lint         # helm lint the library chart, chart-testing lint the rest
-just check        # everything CI runs that needs no Kubernetes cluster
+just check        # everything CI runs that needs no cluster and no network
 ```
 
-Recipes live in `justfile` and `just/*.just`, one file per group.
+## Security
 
-## Reporting issues
+Report a vulnerability in a chart through
+[GitHub's advisory form](https://github.com/TimSchoenle/helm-charts/security/advisories/new)
+rather than in a public issue. There is no separate reporting address.
 
-Open an [issue](https://github.com/timschoenle/helm-charts/issues) with the chart name and
-version, your Kubernetes and Helm versions, the values you installed with, and the output of
-`helm template` or the failing pod's logs.
+A vulnerability in an application one of these charts deploys belongs to that application's own
+repository, which the chart's `Chart.yaml` names under `sources`.


### PR DESCRIPTION
## What changed

The root README is now rendered from `.github/templates/README.md.hbs` against the estate's shared
payload, in the canonical section order. The chart table is unchanged in substance: it still comes
from `just chart-index`, which still reads every `charts/*/Chart.yaml`, and that script is
untouched.

- **The payload.** `.github/scripts/chart-index.py` output is now the `extra` input to
  `TimSchoenle/actions/actions/common/readme-variables`, deep-merged over the derived half. That
  half supplies `repo.*`, `repo.package` and `release.version`, so the repository slug, the library
  chart's name and its version are quoted rather than typed. The manifest is
  `charts/common/Chart.yaml`; the reasoning is under "What to check" below.
- **`branch` is pinned to the default branch.** The action's `branch` input defaults to
  `github.ref_name`, which on a `pull_request` event is `<number>/merge`. Left alone, the render
  job would write `?branch=42/merge` into the badge URLs and the gate would then compare against
  `?branch=main`, failing every merge for a reason absent from its diff.
- **A drift gate.** `.github/workflows/docs.yaml` holds one job, `readme`, which renders with
  `check: true` and writes nothing. It runs on a push to `main` and on fork pull requests.
  Same-repo pull requests are covered by the Documentation job in `ci.yaml`, which repairs the
  file rather than reporting it; running the gate there as well would fail every pull request that
  legitimately edits the template. Make `readme` a required check after this merges.
- **The prose.** Rewritten against the current sources rather than carried over. The old "Requires
  Kubernetes 1.19+" line is gone because no `Chart.yaml` in the tree declares a `kubeVersion`.

`ci.yaml` keeps its job ids, its step order and every pin it already had. The only new pin is
`render-template@3b7d152` (tag v1.1.1), which this repository did not use before because it only
ever rendered-and-committed.

## Rendered, not hand-written

I ran the pinned `readme-variables` and `render-template` dist bundles under node against this
checkout, then re-ran `render-template` with `check: true`; it reported the committed file up to
date. CI's own `readme` job runs the same two actions with the same inputs.

## What to check

1. **The manifest choice.** `readme-variables` requires one, and nothing at the repository root is
   a manifest it reads. I pointed it at `charts/common/Chart.yaml`: the eight application charts
   version independently, so none of them describes the repository, while the library every one of
   them depends on does. The consequence is that `release.version` in the payload is the `common`
   chart's version, which the README states as exactly that, in the Compatibility table. It is not
   presented as a repository version.
2. **No LICENSE and no SECURITY.md.** There is neither file in the tree, and `Chart.yaml` carries
   no licence field, so the License section is omitted rather than invented and the licence badge
   with it. The Security section points at GitHub's private advisory form. Both are worth fixing at
   the repository level, but that is a separate change.
3. **The badges.** Two, both links. `latest chart` reads `github/v/release`, which for this
   repository is a chart-scoped tag such as `tankovault-5.4.0` — the label says so. `publish` is
   `release.yml` on `main`. There is no CI badge because `ci.yaml` never runs on `main`, so a
   branch-filtered badge for it would render "no status" forever.
4. **Factual claims in the new prose**, all read off the sources rather than the old README: the
   egress `except` list in `charts/common/values.yaml` (RFC1918 plus `169.254.0.0/16`), the two
   `restricted`/`none` presets and that the identity fields stay with the chart, the monitoring
   objects failing the render when the operator CRDs are absent, and six charts carrying a
   `contracts/` directory.
5. **Prose contract checks.** Em dashes outside tables, code and numbered lists: 3, against a
   budget of 5, and all three are in the provenance banner. Consecutive `**Bold** —` bullets: 0,
   against a budget of 3. 213 rendered lines, one H1, no skipped heading levels, every fence
   tagged `bash`, every in-repo link resolving.

Repository description, topics and homepage are proposed separately and applied centrally. Do not
merge without the `readme` check green on the follow-up push.
