### PR TITLE
feat(charts): surface optional Sentry reporting across the four releasing charts

### DIFF
--- a/.github/scripts/check-config-bindings.py
+++ b/.github/scripts/check-config-bindings.py
@@ -75,9 +75,9 @@ own topology, sixteen delivered through the secrets directory, and the rest sett
 reads that this chart offers no value for.
 
 Inferring enrolment from "the chart carries at least one marker" is the obvious alternative, and
-it was measured to fail in the direction that matters. Feeding this gate a `portfolio` whose ten
-markers had been rewritten into a spelling the parser does not recognise produced exit 0 and a
-report the chart had simply vanished from — no error, no mention, and the coverage rule it was
+it was measured to fail in the direction that matters. Feeding this gate a `portfolio` whose
+markers had all been rewritten into a spelling the parser does not recognise produced exit 0 and
+a report the chart had simply vanished from — no error, no mention, and the coverage rule it was
 enrolled for silently not run. The same happens to a chart whose markers are deleted. With the
 switch in the declaration, both disagreements are errors: markers without `bindings: true`, and
 `bindings: true` without markers.

--- a/.github/scripts/tests/test_contract_bindings.py
+++ b/.github/scripts/tests/test_contract_bindings.py
@@ -868,12 +868,16 @@ class TestTheEnrolledCharts(unittest.TestCase):
     Between them they carry each shape the format claims to have, which is the point of asserting
     them here rather than only over fixtures:
 
-      `portfolio`               seven pure projections, plus the three `external.env` variables
-                                the Dioxus toolchain and `tracing` own
-      `netcup-offer-bot`        an optional projection, a pair gated on `metrics.enabled`, and a
-                                credential written off rather than marked
-      `s3-bucket-perma-link`    the only `structured` binding in the tree, and two credentials
-                                delivered as files
+      `portfolio`               twenty-one pure projections, plus the three `external.env`
+                                variables the Dioxus toolchain and `tracing` own — and the only
+                                chart whose Sentry block sits outside `telemetry`
+      `netcup-offer-bot`        an optional projection, a pair gated on `metrics.enabled`, a
+                                subtree gated on `telemetry.sentry.enabled`, keys that are
+                                optional *and* gated, and two credentials written off rather
+                                than marked
+      `s3-bucket-perma-link`    the only `structured` binding in the tree, three credentials
+                                delivered as files, and `attach_stacktrace` — singular, where
+                                its three siblings spell the same setting plural
       `mp-stats-legacy-viewer`  the only `composed` one: `server.bind_addr` is `printf` over two
                                 values, and both say so
 
@@ -894,21 +898,37 @@ class TestTheEnrolledCharts(unittest.TestCase):
         marker = self.markers("portfolio")["csp.cloudflare.scriptNonce"]
         self.assertEqual(marker.target, "csp.cloudflare.script_nonce")
 
-    def test_netcup_marks_the_sentry_dsn_optional(self):
-        marker = self.markers("netcup-offer-bot")["telemetry.sentryDsn"]
+    def test_netcup_marks_the_sentry_switch_optional(self):
+        """`enabled: false` is falsy, so the whole block is omitted rather than written off."""
+        marker = self.markers("netcup-offer-bot")["telemetry.sentry.enabled"]
         self.assertTrue(marker.optional)
         self.assertIsNone(marker.condition)
+
+    def test_netcup_gates_the_rest_of_the_sentry_block_on_the_switch(self):
+        """Every key under it is inert while the switch is down, so none is written then."""
+        markers = self.markers("netcup-offer-bot")
+        for path in ("telemetry.sentry.sampleRate", "telemetry.sentry.captureLevel"):
+            self.assertEqual(markers[path].condition, "telemetry.sentry.enabled")
+
+    def test_netcup_marks_the_derived_sentry_tags_optional_and_gated(self):
+        """Both at once: only written when the switch is on, and omitted when left empty."""
+        marker = self.markers("netcup-offer-bot")["telemetry.sentry.environment"]
+        self.assertTrue(marker.optional)
+        self.assertEqual(marker.condition, "telemetry.sentry.enabled")
 
     def test_netcup_gates_the_metrics_subtree(self):
         for path in ("metrics.ip", "metrics.port"):
             marker = self.markers("netcup-offer-bot")[path]
             self.assertEqual(marker.condition, "metrics.enabled")
 
-    def test_netcup_writes_off_the_webhook_rather_than_marking_it(self):
-        self.assertNotIn("discord.webhookUrl", self.markers("netcup-offer-bot"))
+    def test_netcup_writes_off_its_credentials_rather_than_marking_them(self):
+        """Both travel the Secret rather than `config.toml`, so neither carries a marker."""
+        markers = self.markers("netcup-offer-bot")
+        self.assertNotIn("discord.webhookUrl", markers)
+        self.assertNotIn("telemetry.sentry.dsn", markers)
         declaration = load_declaration(self.charts / "netcup-offer-bot")
         [unbound] = declaration.unbound
-        self.assertEqual(unbound.keys, ("discord.webhook_url",))
+        self.assertEqual(unbound.keys, ("discord.webhook_url", "telemetry.sentry.dsn"))
         self.assertTrue(unbound.reason)
 
     def test_the_structured_binding_is_the_bucket_map(self):
@@ -919,8 +939,28 @@ class TestTheEnrolledCharts(unittest.TestCase):
     def test_the_s3_credentials_are_written_off_rather_than_marked(self):
         declaration = load_declaration(self.charts / "s3-bucket-perma-link")
         [unbound] = declaration.unbound
-        self.assertEqual(sorted(unbound.keys), ["s3.access_key", "s3.secret_key"])
+        self.assertEqual(
+            sorted(unbound.keys),
+            ["s3.access_key", "s3.secret_key", "telemetry.sentry.dsn"],
+        )
         self.assertIn("check-config-secrets", unbound.reason)
+
+    def test_s3_spells_the_stacktrace_key_the_way_its_image_does(self):
+        """Singular here and plural in all three sibling charts, which is the trap.
+
+        A plural marker would name a key this contract does not carry and the gate would say so;
+        a plural *projection* with a correct marker would not, so the assertion is worth having
+        next to the one the gate already makes.
+        """
+        marker = self.markers("s3-bucket-perma-link")["telemetry.sentry.attachStacktrace"]
+        self.assertEqual(marker.target, "telemetry.sentry.attach_stacktrace")
+
+    def test_portfolio_keeps_sentry_outside_the_telemetry_namespace(self):
+        """The other three nest it under `telemetry`; this image does not, and copying wins
+        nothing.
+        """
+        marker = self.markers("portfolio")["sentry.enabled"]
+        self.assertEqual(marker.target, "sentry.enabled")
 
     def test_the_composed_pair_is_the_bind_address(self):
         """Two values, one key, and a `printf` between them that no marker claims to reproduce."""
@@ -936,10 +976,10 @@ class TestTheEnrolledCharts(unittest.TestCase):
         self.assertEqual(
             [(chart, keys, external) for chart, keys, external in enrolled],
             [
-                ("mp-stats-legacy-viewer", 8, 0),
-                ("netcup-offer-bot", 5, 0),
-                ("portfolio", 7, 3),
-                ("s3-bucket-perma-link", 7, 0),
+                ("mp-stats-legacy-viewer", 25, 0),
+                ("netcup-offer-bot", 16, 0),
+                ("portfolio", 21, 3),
+                ("s3-bucket-perma-link", 21, 0),
                 ("tankovault", 219, 0),
             ],
         )

--- a/charts/mp-stats-legacy-viewer/Chart.yaml
+++ b/charts/mp-stats-legacy-viewer/Chart.yaml
@@ -1,7 +1,7 @@
 name: mp-stats-legacy-viewer
 description: MP Stats Legacy Viewer
-version: 3.2.3
-appVersion: v0.18.0
+version: 3.3.0
+appVersion: v0.19.0
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts
 sources:

--- a/charts/mp-stats-legacy-viewer/Chart.yaml
+++ b/charts/mp-stats-legacy-viewer/Chart.yaml
@@ -1,7 +1,7 @@
 name: mp-stats-legacy-viewer
 description: MP Stats Legacy Viewer
-version: 3.2.3
-appVersion: v0.18.0
+version: 3.2.4
+appVersion: v0.19.0
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts
 sources:

--- a/charts/mp-stats-legacy-viewer/README.md
+++ b/charts/mp-stats-legacy-viewer/README.md
@@ -1,6 +1,6 @@
 # mp-stats-legacy-viewer
 
-![Version: 3.2.3](https://img.shields.io/badge/Version-3.2.3-informational?style=flat-square) ![AppVersion: v0.18.0](https://img.shields.io/badge/AppVersion-v0.18.0-informational?style=flat-square)
+![Version: 3.2.4](https://img.shields.io/badge/Version-3.2.4-informational?style=flat-square) ![AppVersion: v0.19.0](https://img.shields.io/badge/AppVersion-v0.19.0-informational?style=flat-square)
 
 MP Stats Legacy Viewer
 
@@ -365,11 +365,11 @@ policy pointing at the wrong Gateway looks correct and blocks everything.
 | gateway.tls.enabled | bool | `false` | Add an HTTPS listener. |
 | gateway.tls.mode | string | `"Terminate"` | TLS mode. |
 | gateway.tls.options | object | `{}` | Implementation-specific TLS options. |
-| image | object | `{"pullPolicy":"","registry":"","repository":"timschoenle/mp-stats-legacy-viewer","tag":"v0.18.0@sha256:22aec41fcd9170a7c4799e8170700436332413728ea9c476b7d4d539d284f9fb"}` | Container image the pod runs, composed as `registry/repository:tag`. |
+| image | object | `{"pullPolicy":"","registry":"","repository":"timschoenle/mp-stats-legacy-viewer","tag":"v0.19.0@sha256:115f48976c6091f381668f50c8f8410b26532926c618afbb567bfbd16009adec"}` | Container image the pod runs, composed as `registry/repository:tag`. |
 | image.pullPolicy | string | `""` | The image pull policy. Empty resolves automatically from the tag/digest. |
 | image.registry | string | `""` | Registry host. Empty means Docker Hub. |
 | image.repository | string | `"timschoenle/mp-stats-legacy-viewer"` | The container image repository. |
-| image.tag | string | `"v0.18.0@sha256:22aec41fcd9170a7c4799e8170700436332413728ea9c476b7d4d539d284f9fb"` | The container image tag, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the pull, while the tag stays on as the readable version marker. Defaults to the chart's `appVersion` when empty. |
+| image.tag | string | `"v0.19.0@sha256:115f48976c6091f381668f50c8f8410b26532926c618afbb567bfbd16009adec"` | The container image tag, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the pull, while the tag stays on as the readable version marker. Defaults to the chart's `appVersion` when empty. |
 | imagePullSecrets | list | `[]` | Optional image pull secrets for private registries. |
 | ingress | object | `{"annotations":{},"enabled":false,"hosts":[],"ingressClassName":"nginx","tls":[]}` | The Ingress in front of the Service. Off by default; `gateway` is the Gateway API alternative and the two are independent switches. |
 | ingress.annotations | object | `{}` | Custom annotations for the Ingress resource. Useful for configuring ingress controllers (e.g., cert-manager, rate limits). |

--- a/charts/mp-stats-legacy-viewer/README.md
+++ b/charts/mp-stats-legacy-viewer/README.md
@@ -453,11 +453,11 @@ policy pointing at the wrong Gateway looks correct and blocks everything.
 | gateway.tls.enabled | bool | `false` | Add an HTTPS listener. |
 | gateway.tls.mode | string | `"Terminate"` | TLS mode. |
 | gateway.tls.options | object | `{}` | Implementation-specific TLS options. |
-| image | object | `{"pullPolicy":"","registry":"","repository":"timschoenle/mp-stats-legacy-viewer","tag":"v0.18.0@sha256:22aec41fcd9170a7c4799e8170700436332413728ea9c476b7d4d539d284f9fb"}` | Container image the pod runs, composed as `registry/repository:tag`. |
+| image | object | `{"pullPolicy":"","registry":"","repository":"timschoenle/mp-stats-legacy-viewer","tag":"v0.19.0@sha256:115f48976c6091f381668f50c8f8410b26532926c618afbb567bfbd16009adec"}` | Container image the pod runs, composed as `registry/repository:tag`. |
 | image.pullPolicy | string | `""` | The image pull policy. Empty resolves automatically from the tag/digest. |
 | image.registry | string | `""` | Registry host. Empty means Docker Hub. |
 | image.repository | string | `"timschoenle/mp-stats-legacy-viewer"` | The container image repository. |
-| image.tag | string | `"v0.18.0@sha256:22aec41fcd9170a7c4799e8170700436332413728ea9c476b7d4d539d284f9fb"` | The container image tag, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the pull, while the tag stays on as the readable version marker. Defaults to the chart's `appVersion` when empty. |
+| image.tag | string | `"v0.19.0@sha256:115f48976c6091f381668f50c8f8410b26532926c618afbb567bfbd16009adec"` | The container image tag, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the pull, while the tag stays on as the readable version marker. Defaults to the chart's `appVersion` when empty. |
 | imagePullSecrets | list | `[]` | Optional image pull secrets for private registries. |
 | ingress | object | `{"annotations":{},"enabled":false,"hosts":[],"ingressClassName":"nginx","tls":[]}` | The Ingress in front of the Service. Off by default; `gateway` is the Gateway API alternative and the two are independent switches. |
 | ingress.annotations | object | `{}` | Custom annotations for the Ingress resource. Useful for configuring ingress controllers (e.g., cert-manager, rate limits). |

--- a/charts/mp-stats-legacy-viewer/README.md
+++ b/charts/mp-stats-legacy-viewer/README.md
@@ -1,6 +1,6 @@
 # mp-stats-legacy-viewer
 
-![Version: 3.2.3](https://img.shields.io/badge/Version-3.2.3-informational?style=flat-square) ![AppVersion: v0.18.0](https://img.shields.io/badge/AppVersion-v0.18.0-informational?style=flat-square)
+![Version: 3.3.0](https://img.shields.io/badge/Version-3.3.0-informational?style=flat-square) ![AppVersion: v0.19.0](https://img.shields.io/badge/AppVersion-v0.19.0-informational?style=flat-square)
 
 MP Stats Legacy Viewer
 
@@ -77,6 +77,75 @@ The server does not reload its configuration, so the chart keeps the conventiona
 `checksum/configmap` pod annotation: a configuration change rolls the Deployment, which is the
 only way it takes effect.
 
+## Logging and error reporting
+
+`telemetry.logFilter` is a `RUST_LOG`-style filter — `info,mp_stats_server=debug` — and
+`telemetry.jsonLogs` switches the output from human-readable lines to one JSON object per
+record, which is what a cluster shipping logs to a collector wants. A `RUST_LOG` set in the
+container outranks the filter: it is the one place in this configuration where a bare
+environment variable wins over the layered loader, which makes `extraEnv` the override to reach
+for while a pod is misbehaving.
+
+`telemetry.sentry` reports errors and panics to Sentry, and can record a transaction per
+request. It is off, and inert while it is off: no client, no panic hook, no `tracing` layer and
+no HTTP middleware is installed, so nothing leaves the process and nothing about a rendered
+release changes.
+
+```yaml
+telemetry:
+  sentry:
+    enabled: true
+    dsn: https://<key>@<host>/<project>
+```
+
+The DSN embeds a write key for the project's event stream, so the chart treats it as the
+credential it is: it goes to a Secret under `telemetry__sentry__dsn`, never into the ConfigMap.
+It is the **only** credential this server reads, so switching Sentry on is what gives the pod a
+secrets volume and an `MP_STATS_SECRETS_DIR` at all — expect the pod spec to change shape, not
+just the ConfigMap. Point `existingSecret` at a Secret you created yourself to keep the DSN out
+of `values.yaml` and out of the Helm release object:
+
+```shell
+kubectl create secret generic mp-stats-sentry   --namespace [NAMESPACE]   --from-literal=telemetry__sentry__dsn='https://<key>@<host>/<project>'
+```
+
+```yaml
+existingSecret: mp-stats-sentry
+```
+
+**The key name is the configuration path the server reads, not a free-form name.** The DSN
+arrives as a file in a projected volume and the server takes the key out of the file *name*, so
+`telemetry__sentry__dsn` is required; a Secret spelled any other way mounts cleanly and supplies
+nothing. Switching the feature on with no DSN — neither inline nor in an `existingSecret` — is
+refused at render time, because the server refuses to boot rather than installing a client that
+reports nowhere, and a rejected `helm upgrade` beats a CrashLoopBackOff.
+
+**Check the egress.** The chart never reads the DSN, so it cannot name the ingest host in the
+network policies. The defaults do cover it — `networkPolicy.egress.https` permits TCP/443 to
+`0.0.0.0/0` minus private space — so an out-of-the-box release reaches Sentry without further
+work. A release that narrowed `networkPolicy.egress.cidr`, turned `egress.https` off, or
+replaced the CIDR rule with `networkPolicy.cilium.egress.toFQDNs` has to name the endpoint
+itself. Getting that wrong is silent: an SDK that cannot reach its endpoint queues events and
+then discards them, so the project simply stays empty, which reads as "no errors".
+
+`tracesSampleRate` is `0` — this server starts no traces of its own, which is the right figure
+for a static file server, where a trace per asset request is volume without a question behind
+it. It still continues a trace that arrives already sampled, so one reader action stays readable
+across whatever sits in front of this server.
+
+`sendDefaultPii` stays off. On, every event carries the client IP, the whole request header set
+including `Cookie`, and the resolved user, to a third party — and the same flag is what stops
+the HTTP middleware redacting sensitive headers.
+
+`environment`, `release` and `serverName` are empty by default and the chart writes none of
+them: the server derives the first two — `production` for the release binaries every published
+image is built as, and `mp-stats-legacy-viewer@v<version>` spelled the way the image tag spells
+it — and reports no host tag. A blank value is a *supplied* value to the loader, not an absent
+one, so set them only to say something the server cannot derive.
+
+`captureLevel` and `breadcrumbLevel` both sit *under* `logFilter`: a record the filter drops
+never becomes an issue or a breadcrumb, whatever they say.
+
 ## Content-Security-Policy
 
 The header is derived, not configured: at startup the server reads the `index.html` in
@@ -111,6 +180,24 @@ condition the chart cannot enforce:
 server already sets one.
 
 ## Upgrading
+
+### 3.2 to 3.3
+
+Chart 3.3 tracks the viewer's 0.19.0 release, which adds optional Sentry error reporting and
+tracing and gives the log settings first-class keys. Everything is additive and off, so an
+existing release needs no change.
+
+Two things are worth knowing before switching Sentry on:
+
+- **The pod gains a secrets volume.** The DSN is the only credential this server reads, so
+  today's pods carry no secrets volume and no `MP_STATS_SECRETS_DIR`. Setting
+  `telemetry.sentry.enabled` gives them both, and an `existingSecret` that should carry the DSN
+  needs the key `telemetry__sentry__dsn`.
+- **`telemetry.logFilter` restates a key the mounted file has to carry.** Pointing
+  `MP_STATS_CONFIG` at this chart's mount replaces the image's own `/config.toml`, so the filter
+  is now written explicitly rather than inherited. The default, `info`, is what the image
+  carried; a release that had set a filter through `config.telemetry.log_filter` keeps working —
+  `config` still merges over the derived tree.
 
 ### 2.x to 3.0
 
@@ -332,7 +419,8 @@ policy pointing at the wrong Gateway looks correct and blocks everything.
 | configExtraToml | string | `""` | Verbatim TOML appended after the rendered configuration. The escape hatch for anything the chart's TOML renderer cannot express, notably arrays of tables. |
 | configMount | object | `{"configDir":"/etc/mp-stats/config","secretsDir":"/etc/mp-stats/secrets"}` | Where the rendered configuration and the credential files land in the container. |
 | configMount.configDir | string | `"/etc/mp-stats/config"` | Directory the rendered `config.toml` is mounted at, passed as `MP_STATS_CONFIG`. Pointing this at the mount **replaces** the `/config.toml` the image ships, so everything the image described — the bind address, `dist_dir`, `data_dir` — is restated by the values above. |
-| configMount.secretsDir | string | `"/etc/mp-stats/secrets"` | Directory credential files would be mounted at, passed as `MP_STATS_SECRETS_DIR`. Neither binary reads a secret today, so nothing is mounted and the variable is not set; the value is here for an operator adding one through `extraVolumes`. |
+| configMount.secretsDir | string | `"/etc/mp-stats/secrets"` | Directory credential files are mounted at, passed as `MP_STATS_SECRETS_DIR`. The Sentry DSN is the only credential this chart handles, so the volume and the variable both appear only while `telemetry.sentry.enabled` is set — a release that does not report to Sentry carries neither. |
+| existingSecret | string | `""` | Name of an existing Secret holding the Sentry DSN, which keeps it out of `values.yaml` and out of the Helm release object. **Its key is the configuration path, not a free-form name**: `telemetry__sentry__dsn`, because the file name is what the loader parses. Set, the chart renders no Secret of its own and `telemetry.sentry.dsn` is ignored. It is read only while `telemetry.sentry.enabled` is set — nothing else this server reads is a credential. |
 | extraEnv | list | `[]` | Additional environment variables for the application container. |
 | extraVolumeMounts | list | `[]` | Additional volume mounts added to the application container. |
 | extraVolumes | list | `[]` | Additional volumes added to the pod. |
@@ -500,6 +588,26 @@ policy pointing at the wrong Gateway looks correct and blocks everything.
 | startupProbe.periodSeconds | int | `5` | Probe interval. |
 | startupProbe.timeoutSeconds | int | `3` | Probe timeout. |
 | strategy | object | `{}` | Deployment update strategy. Empty uses the Kubernetes default rolling update. |
+| telemetry | object | `{"jsonLogs":false,"logFilter":"info","sentry":{"attachStacktraces":true,"breadcrumbLevel":"info","captureLevel":"error","debug":false,"dsn":"","enabled":false,"environment":"","httpTransactions":true,"maxBreadcrumbs":100,"release":"","sampleRate":1,"sendDefaultPii":false,"serverName":"","shutdownTimeoutSecs":2,"spanAttributes":false,"tracesSampleRate":0}}` | Logging and error reporting. The log settings are rendered under `telemetry` in the mounted `config.toml`; the Sentry DSN is a credential and goes to the Secret instead. The whole block is read once as the process boots rather than re-read from the mount, so a change to it takes effect on the next rollout. |
+| telemetry.jsonLogs | bool | `false` | Emit one JSON object per record instead of human-readable lines (`telemetry.json_logs`). The image's default suits `docker run` on a terminal; a cluster shipping logs to a collector wants this on. |
+| telemetry.logFilter | string | `"info"` | `RUST_LOG`-style filter deciding which records are emitted at all (`telemetry.log_filter`), for example `info,mp_stats_server=debug`. `RUST_LOG` set in the container outranks this — the one place in this configuration where a bare environment variable wins over the layered loader — so `extraEnv` is the override to reach for while a pod is misbehaving. It governs what reaches Sentry too: a record this filter drops never becomes an issue or a breadcrumb, whatever `sentry.captureLevel` says. |
+| telemetry.sentry | object | `{"attachStacktraces":true,"breadcrumbLevel":"info","captureLevel":"error","debug":false,"dsn":"","enabled":false,"environment":"","httpTransactions":true,"maxBreadcrumbs":100,"release":"","sampleRate":1,"sendDefaultPii":false,"serverName":"","shutdownTimeoutSecs":2,"spanAttributes":false,"tracesSampleRate":0}` | Sentry error reporting and request tracing. **Off**, and wholly inert while it is: no client, no panic hook, no `tracing` layer and no HTTP middleware is installed, and nothing leaves the process.  Two things the chart deliberately does not do for you. It never reads the DSN, so it cannot name the ingest host in the NetworkPolicies. The defaults do happen to cover it — `networkPolicy.egress.https` permits TCP/443 to `0.0.0.0/0` minus private space — but a deployment that narrowed `networkPolicy.egress.cidr`, turned `egress.https` off, or replaced the CIDR rule with `networkPolicy.cilium.egress.toFQDNs` has to name the endpoint itself, and getting that wrong is silent: an SDK that cannot reach its endpoint queues events and then discards them, so the project stays empty, which reads as "no errors". And it configures nothing inside Sentry — the project, its quota and its server-side data-scrubbing rules are yours. |
+| telemetry.sentry.attachStacktraces | bool | `true` | Attach a stack trace to events that carry none of their own (`telemetry.sentry.attach_stacktraces`). |
+| telemetry.sentry.breadcrumbLevel | string | `"info"` | Least severe `tracing` level kept as a breadcrumb, the trail attached to the next issue (`telemetry.sentry.breadcrumb_level`). Records at or above `captureLevel` become issues instead, so this only ever describes the band below it. Quote `"off"`. |
+| telemetry.sentry.captureLevel | string | `"error"` | Least severe `tracing` level reported as a Sentry issue (`telemetry.sentry.capture_level`). Quote `"off"` — unquoted, YAML reads it as the boolean `false`. This and `breadcrumbLevel` both sit *under* `logFilter`, so a record that filter drops never reaches Sentry either. |
+| telemetry.sentry.debug | bool | `false` | Print the SDK's own diagnostics to stderr (`telemetry.sentry.debug`). For proving a DSN works, not for running. |
+| telemetry.sentry.dsn | string | `""` | Ingest URL, `https://<key>@<host>/<project>`. A credential — the embedded key is a bearer token for the project's ingest endpoint — so it is delivered as a file in `MP_STATS_SECRETS_DIR` under `telemetry__sentry__dsn` and never written into the ConfigMap. It is the only credential this chart handles, and switching Sentry on is what gives the pod a secrets volume at all. Leave it empty and put that key in the Secret named by `existingSecret` to keep it out of `helm get values` entirely. |
+| telemetry.sentry.enabled | bool | `false` | Initialise the Sentry client (`telemetry.sentry.enabled`). Off, every other key here is inert. On, the server refuses to boot without a DSN rather than starting with a reporter that reports nowhere, so this and `dsn` are set together. |
+| telemetry.sentry.environment | string | `""` | Environment tag on every event (`telemetry.sentry.environment`). Empty lets the server derive it from the build: `production` for a release binary, which every published image is. Set it for anything in between, such as a staging cluster running that same binary. |
+| telemetry.sentry.httpTransactions | bool | `true` | Record one transaction per request, named by the matched route rather than by the URI (`telemetry.sentry.http_transactions`). Whether a started transaction is kept is `tracesSampleRate`'s decision; this is the switch for a deployment that wants error reporting and no performance data at all. |
+| telemetry.sentry.maxBreadcrumbs | int | `100` | How many breadcrumbs one event carries (`telemetry.sentry.max_breadcrumbs`). |
+| telemetry.sentry.release | string | `""` | Release tag on every event (`telemetry.sentry.release`). Empty uses `mp-stats-legacy-viewer@v<version>`, spelled as the image tag spells it, which is what makes a regression attributable to a deploy — set this only to match a release you create in Sentry under a name of your own. |
+| telemetry.sentry.sampleRate | float | `1` | Fraction of captured events actually sent (`telemetry.sentry.sample_rate`). A blunt volume cap — it drops whole issues, not repetitions of one — so leave it at `1` unless a quota forces otherwise. A value outside the range fails the boot. |
+| telemetry.sentry.sendDefaultPii | bool | `false` | Send personally identifying data with every event: the client IP, the whole request header set — `Cookie` included — and the resolved user (`telemetry.sentry.send_default_pii`). **Off, and worth leaving off** — a reader's IP address is not what makes a crash report actionable, and Sentry is a third party for the purposes of whatever data policy this deployment publishes. It is two controls rather than one, besides: off is also what keeps the HTTP middleware redacting sensitive headers. |
+| telemetry.sentry.serverName | string | `""` | Host tag on every event (`telemetry.sentry.server_name`). Empty reports none, which is the right answer here: the value would be one replica's pod name, gone by the time anyone reads the issue. |
+| telemetry.sentry.shutdownTimeoutSecs | int | `2` | How long process exit waits for queued events to drain (`telemetry.sentry.shutdown_timeout_secs`). Paid on every pod shutdown, so it is time added to every rollout; keep it well inside `terminationGracePeriodSeconds`. |
+| telemetry.sentry.spanAttributes | bool | `false` | Copy `tracing` span fields onto the Sentry span as attributes (`telemetry.sentry.span_attributes`). Off: the span fields here carry request paths, and a transaction is retained for longer than a log line. |
+| telemetry.sentry.tracesSampleRate | float | `0` | Fraction of traces this server **starts** that are recorded (`telemetry.sentry.traces_sample_rate`). `0` starts none, which is the right figure for a static file server — a trace per asset request is volume without a question behind it — and it is what makes the feature free to switch on for error reporting alone. It does not take the server out of a trace that reaches it already sampled: an inbound `sentry-trace` header is continued whatever this says. |
 | terminationGracePeriodSeconds | int | `30` | Grace period for pod shutdown. |
 | tolerations | list | `[]` | Tolerations for pod assignment. |
 | topologySpreadConstraints | list | `[]` | Pod topology spread constraints for availability. |

--- a/charts/mp-stats-legacy-viewer/README.md.gotmpl
+++ b/charts/mp-stats-legacy-viewer/README.md.gotmpl
@@ -79,6 +79,75 @@ The server does not reload its configuration, so the chart keeps the conventiona
 `checksum/configmap` pod annotation: a configuration change rolls the Deployment, which is the
 only way it takes effect.
 
+## Logging and error reporting
+
+`telemetry.logFilter` is a `RUST_LOG`-style filter — `info,mp_stats_server=debug` — and
+`telemetry.jsonLogs` switches the output from human-readable lines to one JSON object per
+record, which is what a cluster shipping logs to a collector wants. A `RUST_LOG` set in the
+container outranks the filter: it is the one place in this configuration where a bare
+environment variable wins over the layered loader, which makes `extraEnv` the override to reach
+for while a pod is misbehaving.
+
+`telemetry.sentry` reports errors and panics to Sentry, and can record a transaction per
+request. It is off, and inert while it is off: no client, no panic hook, no `tracing` layer and
+no HTTP middleware is installed, so nothing leaves the process and nothing about a rendered
+release changes.
+
+```yaml
+telemetry:
+  sentry:
+    enabled: true
+    dsn: https://<key>@<host>/<project>
+```
+
+The DSN embeds a write key for the project's event stream, so the chart treats it as the
+credential it is: it goes to a Secret under `telemetry__sentry__dsn`, never into the ConfigMap.
+It is the **only** credential this server reads, so switching Sentry on is what gives the pod a
+secrets volume and an `MP_STATS_SECRETS_DIR` at all — expect the pod spec to change shape, not
+just the ConfigMap. Point `existingSecret` at a Secret you created yourself to keep the DSN out
+of `values.yaml` and out of the Helm release object:
+
+```shell
+kubectl create secret generic mp-stats-sentry   --namespace [NAMESPACE]   --from-literal=telemetry__sentry__dsn='https://<key>@<host>/<project>'
+```
+
+```yaml
+existingSecret: mp-stats-sentry
+```
+
+**The key name is the configuration path the server reads, not a free-form name.** The DSN
+arrives as a file in a projected volume and the server takes the key out of the file *name*, so
+`telemetry__sentry__dsn` is required; a Secret spelled any other way mounts cleanly and supplies
+nothing. Switching the feature on with no DSN — neither inline nor in an `existingSecret` — is
+refused at render time, because the server refuses to boot rather than installing a client that
+reports nowhere, and a rejected `helm upgrade` beats a CrashLoopBackOff.
+
+**Check the egress.** The chart never reads the DSN, so it cannot name the ingest host in the
+network policies. The defaults do cover it — `networkPolicy.egress.https` permits TCP/443 to
+`0.0.0.0/0` minus private space — so an out-of-the-box release reaches Sentry without further
+work. A release that narrowed `networkPolicy.egress.cidr`, turned `egress.https` off, or
+replaced the CIDR rule with `networkPolicy.cilium.egress.toFQDNs` has to name the endpoint
+itself. Getting that wrong is silent: an SDK that cannot reach its endpoint queues events and
+then discards them, so the project simply stays empty, which reads as "no errors".
+
+`tracesSampleRate` is `0` — this server starts no traces of its own, which is the right figure
+for a static file server, where a trace per asset request is volume without a question behind
+it. It still continues a trace that arrives already sampled, so one reader action stays readable
+across whatever sits in front of this server.
+
+`sendDefaultPii` stays off. On, every event carries the client IP, the whole request header set
+including `Cookie`, and the resolved user, to a third party — and the same flag is what stops
+the HTTP middleware redacting sensitive headers.
+
+`environment`, `release` and `serverName` are empty by default and the chart writes none of
+them: the server derives the first two — `production` for the release binaries every published
+image is built as, and `mp-stats-legacy-viewer@v<version>` spelled the way the image tag spells
+it — and reports no host tag. A blank value is a *supplied* value to the loader, not an absent
+one, so set them only to say something the server cannot derive.
+
+`captureLevel` and `breadcrumbLevel` both sit *under* `logFilter`: a record the filter drops
+never becomes an issue or a breadcrumb, whatever they say.
+
 ## Content-Security-Policy
 
 The header is derived, not configured: at startup the server reads the `index.html` in
@@ -113,6 +182,24 @@ condition the chart cannot enforce:
 server already sets one.
 
 ## Upgrading
+
+### 3.2 to 3.3
+
+Chart 3.3 tracks the viewer's 0.19.0 release, which adds optional Sentry error reporting and
+tracing and gives the log settings first-class keys. Everything is additive and off, so an
+existing release needs no change.
+
+Two things are worth knowing before switching Sentry on:
+
+- **The pod gains a secrets volume.** The DSN is the only credential this server reads, so
+  today's pods carry no secrets volume and no `MP_STATS_SECRETS_DIR`. Setting
+  `telemetry.sentry.enabled` gives them both, and an `existingSecret` that should carry the DSN
+  needs the key `telemetry__sentry__dsn`.
+- **`telemetry.logFilter` restates a key the mounted file has to carry.** Pointing
+  `MP_STATS_CONFIG` at this chart's mount replaces the image's own `/config.toml`, so the filter
+  is now written explicitly rather than inherited. The default, `info`, is what the image
+  carried; a release that had set a filter through `config.telemetry.log_filter` keeps working —
+  `config` still merges over the derived tree.
 
 ### 2.x to 3.0
 

--- a/charts/mp-stats-legacy-viewer/ci/sentry.yaml
+++ b/charts/mp-stats-legacy-viewer/ci/sentry.yaml
@@ -1,0 +1,48 @@
+# Sentry switched on, with the egress rule an already-narrowed deployment would need.
+#
+# A render fixture, not an install fixture: the DSN points at a host that does not exist. `ct
+# install` takes every `ci/*-values.yaml`, while the render and policy jobs glob `ci/*.yaml`.
+#
+# Every key is set away from its default on purpose. The chart writes the whole block through to
+# one document, so a fixture that left the defaults in place would render the same `config.toml`
+# whether the mapping were right or reversed. It is also the only fixture in which this chart
+# renders a Secret and a secrets volume at all — the DSN is the single credential the server
+# reads, so every other render leaves the pod without either.
+#
+# `networkPolicy` is here for the half of this feature the chart cannot derive. The DSN is a
+# credential, so the chart never reads it and cannot name the ingest host. The defaults would
+# already reach it — `egress.https` permits TCP/443 to `0.0.0.0/0` minus private space — so the
+# fixture renders the *explicit* form instead, which is what a deployment that narrowed
+# `egress.cidr` or turned `egress.https` off has to write for itself. It names a CIDR because
+# the portable dialect cannot express a hostname; `ci/cilium.yaml` is where `toFQDNs` is
+# exercised.
+telemetry:
+  logFilter: info,mp_stats_server=debug
+  jsonLogs: true
+  sentry:
+    enabled: true
+    dsn: https://ci0123456789abcdef@sentry.example.com/42
+    environment: ci
+    release: mp-stats-legacy-viewer@v0.19.0
+    serverName: ci-render-fixture
+    sampleRate: 0.5
+    tracesSampleRate: 0.2
+    captureLevel: warn
+    breadcrumbLevel: debug
+    maxBreadcrumbs: 50
+    attachStacktraces: false
+    sendDefaultPii: false
+    httpTransactions: false
+    spanAttributes: true
+    shutdownTimeoutSecs: 5
+    debug: true
+
+networkPolicy:
+  enabled: true
+  extraEgress:
+    - to:
+        - ipBlock:
+            cidr: 34.120.195.249/32
+      ports:
+        - port: 443
+          protocol: TCP

--- a/charts/mp-stats-legacy-viewer/config-contract.yaml
+++ b/charts/mp-stats-legacy-viewer/config-contract.yaml
@@ -15,6 +15,25 @@
 # errors.
 bindings: true
 
+# Contract keys no chart value binds, each group with the reason it does not.
+#
+# Chart-level: a key nothing surfaces is unsurfaced in every document that declares it, and this
+# chart declares one. Secret keys are not exempt by default and each one is written out — the
+# blanket rule "credentials need no marker" cannot tell a key delivered as a file from a key a
+# chart merely forgot, and the second is exactly the regression this gate exists to catch.
+unbound:
+  - keys:
+      - telemetry.sentry.dsn
+    reason: >-
+      Delivered as a file in MP_STATS_SECRETS_DIR — from the Secret this chart renders, or from
+      `existingSecret` under the file name `telemetry__sentry__dsn` — and never written into
+      `config.toml`, because the DSN embeds a bearer key for the project's ingest endpoint and a
+      credential in a ConfigMap is readable by anything that can read the namespace.
+      `telemetry.sentry.dsn` is the value that carries it, so the binding does exist; it simply
+      does not run through the configuration document the markers describe. `just
+      check-config-secrets` is what reconciles that channel, and it does it from the rendered
+      manifests rather than from a comment.
+
 documents:
   - name: viewer
 
@@ -37,7 +56,9 @@ documents:
       - values: image
         contract: contracts/viewer.json
 
-    # The pods that mount it, for the environment and secret-file gates.
+    # The pods that mount it, for the environment and secret-file gates. The secrets volume is
+    # rendered only while `telemetry.sentry.enabled` is set, so on the default render this pod
+    # mounts the ConfigMap alone.
     consumers:
       - workload: { kind: Deployment, selector: { app.kubernetes.io/instance: mp-stats-legacy-viewer } }
         containers: [mp-stats-legacy-viewer]

--- a/charts/mp-stats-legacy-viewer/contracts/viewer.json
+++ b/charts/mp-stats-legacy-viewer/contracts/viewer.json
@@ -1,15 +1,15 @@
 {
   "source": {
     "image": "docker.io/timschoenle/mp-stats-legacy-viewer",
-    "digest": "sha256:22aec41fcd9170a7c4799e8170700436332413728ea9c476b7d4d539d284f9fb",
-    "sha256": "48b8c870b12f53ee37fa9cd6a18fb8dde1fa1d7020cd0e925e09be78bb2248a9",
-    "fetched": "2026-08-25T08:10:26Z"
+    "digest": "sha256:115f48976c6091f381668f50c8f8410b26532926c618afbb567bfbd16009adec",
+    "sha256": "871a8b88c6b07e1412044744b90d077d972b1e6c5e71bb24823ef9413671a518",
+    "fetched": "2026-08-26T14:03:30Z"
   },
   "contract": {
     "terrace_contract": 1,
     "app": {
       "name": "mp-stats-legacy-viewer",
-      "version": "v0.18.0",
+      "version": "v0.19.0",
       "source": "https://github.com/TimSchoenle/mp-stats-legacy-viewer"
     },
     "schema": {
@@ -216,6 +216,496 @@
           "required": false,
           "secret": false,
           "reserved": false
+        },
+        {
+          "path": "telemetry.log_filter",
+          "env": "MP_STATS_TELEMETRY__LOG_FILTER",
+          "env_file": "MP_STATS_TELEMETRY__LOG_FILTER_FILE",
+          "secrets_file": "telemetry__log_filter",
+          "docs": "`RUST_LOG`-style filter deciding which records are emitted at all, for example\n`info,mp_stats_server=debug`.\n\n`RUST_LOG` itself outranks this key when it is set, which is the one place in this\nconfiguration where a bare environment variable wins over the layered loader: it is the\nvariable every Rust operator already reaches for while a container is misbehaving, and a\nfilter is not a value a deployment can be wrong about for long.\n\nIt governs the Sentry sink too — see [`SentryConfig`].",
+          "ty": "String",
+          "values": [],
+          "constraint": {
+            "type": "string"
+          },
+          "text_form": "text",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "info",
+          "default_value": "info",
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.json_logs",
+          "env": "MP_STATS_TELEMETRY__JSON_LOGS",
+          "env_file": "MP_STATS_TELEMETRY__JSON_LOGS_FILE",
+          "secrets_file": "telemetry__json_logs",
+          "docs": "Emit one JSON object per record instead of human-readable lines.\n\nOff by default because the default deployment of this repository is `docker run` on a\nterminal. A cluster shipping logs to a collector wants it on.",
+          "ty": "bool",
+          "values": [],
+          "constraint": {
+            "type": "boolean"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(true|false)\\s*$",
+            "type": "string"
+          },
+          "text_form": "boolean",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "false",
+          "default_value": false,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.enabled",
+          "env": "MP_STATS_TELEMETRY__SENTRY__ENABLED",
+          "env_file": "MP_STATS_TELEMETRY__SENTRY__ENABLED_FILE",
+          "secrets_file": "telemetry__sentry__enabled",
+          "docs": "Initialise the Sentry client. `false` installs no client, no panic hook, no `tracing`\nlayer and no HTTP middleware, so every other key here is inert and nothing leaves the\nprocess.",
+          "ty": "bool",
+          "values": [],
+          "constraint": {
+            "type": "boolean"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(true|false)\\s*$",
+            "type": "string"
+          },
+          "text_form": "boolean",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "false",
+          "default_value": false,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.dsn",
+          "env": "MP_STATS_TELEMETRY__SENTRY__DSN",
+          "env_file": "MP_STATS_TELEMETRY__SENTRY__DSN_FILE",
+          "secrets_file": "telemetry__sentry__dsn",
+          "docs": "Ingest URL, `https://<key>@<host>/<project>`.\n\nA [`SecretString`]: the embedded key is a bearer credential for\nthe project's ingest endpoint, and this struct is nested in a block that is logged with\n`?`. Prefer supplying it through the secrets directory or `_FILE` indirection rather than\nthrough the environment.\n\nAbsent while [`Self::enabled`] is set is a boot failure, not a silent no-op.",
+          "ty": "SecretString",
+          "values": [],
+          "constraint": {
+            "type": "string"
+          },
+          "text_form": "text",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": null,
+          "default_value": null,
+          "note": null,
+          "required": false,
+          "secret": true,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.environment",
+          "env": "MP_STATS_TELEMETRY__SENTRY__ENVIRONMENT",
+          "env_file": "MP_STATS_TELEMETRY__SENTRY__ENVIRONMENT_FILE",
+          "secrets_file": "telemetry__sentry__environment",
+          "docs": "Environment tag on every event.\n\nLeft unset it is derived from the build rather than guessed: `production` for a release\nbinary — which every published image is — and `development` for a debug one. Set it\nexplicitly for anything in between, such as a staging cluster running a release build.",
+          "ty": "String",
+          "values": [],
+          "constraint": {
+            "type": "string"
+          },
+          "text_form": "text",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": null,
+          "default_value": null,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.release",
+          "env": "MP_STATS_TELEMETRY__SENTRY__RELEASE",
+          "env_file": "MP_STATS_TELEMETRY__SENTRY__RELEASE_FILE",
+          "secrets_file": "telemetry__sentry__release",
+          "docs": "Release tag on every event.\n\nDefaults to `mp-stats-legacy-viewer@v<version>`, spelled as the image tag spells it, so a\nregression is attributable to a deploy without an operator having to remember to set it.",
+          "ty": "String",
+          "values": [],
+          "constraint": {
+            "type": "string"
+          },
+          "text_form": "text",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": null,
+          "default_value": null,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.server_name",
+          "env": "MP_STATS_TELEMETRY__SENTRY__SERVER_NAME",
+          "env_file": "MP_STATS_TELEMETRY__SENTRY__SERVER_NAME_FILE",
+          "secrets_file": "telemetry__sentry__server_name",
+          "docs": "Host tag on every event.\n\nLeft unset, Sentry reports none: the hostname of a replica is infrastructure detail that\n[`Self::send_default_pii`] would otherwise gate, and a `scratch` container's hostname\nnames a pod that no longer exists by the time anyone reads the issue.",
+          "ty": "String",
+          "values": [],
+          "constraint": {
+            "type": "string"
+          },
+          "text_form": "text",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": null,
+          "default_value": null,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.sample_rate",
+          "env": "MP_STATS_TELEMETRY__SENTRY__SAMPLE_RATE",
+          "env_file": "MP_STATS_TELEMETRY__SENTRY__SAMPLE_RATE_FILE",
+          "secrets_file": "telemetry__sentry__sample_rate",
+          "docs": "Fraction of captured events actually sent, `0.0`–`1.0`.\n\nA blunt volume cap — it drops whole issues, not repetitions of one — so leave it at `1.0`\nunless a quota forces otherwise. A value outside the range fails the boot.",
+          "ty": "f32",
+          "values": [],
+          "constraint": {
+            "type": "number"
+          },
+          "text_form": "unknown",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "1",
+          "default_value": 1.0,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.traces_sample_rate",
+          "env": "MP_STATS_TELEMETRY__SENTRY__TRACES_SAMPLE_RATE",
+          "env_file": "MP_STATS_TELEMETRY__SENTRY__TRACES_SAMPLE_RATE_FILE",
+          "secrets_file": "telemetry__sentry__traces_sample_rate",
+          "docs": "Fraction of traces this process **starts** that are recorded, `0.0`–`1.0`.\n\n`0.0` (the default) means it starts none of its own, which is the right figure for a\nstatic file server: a trace per asset request is volume without a question it answers.\nIt does **not** mean this process is absent from a trace — a request arriving with a\ntrace already sampled is continued regardless, which is what keeps one reader action\nreadable across whatever sits in front of this server.",
+          "ty": "f32",
+          "values": [],
+          "constraint": {
+            "type": "number"
+          },
+          "text_form": "unknown",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "0",
+          "default_value": 0.0,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.capture_level",
+          "env": "MP_STATS_TELEMETRY__SENTRY__CAPTURE_LEVEL",
+          "env_file": "MP_STATS_TELEMETRY__SENTRY__CAPTURE_LEVEL_FILE",
+          "secrets_file": "telemetry__sentry__capture_level",
+          "docs": "Least severe `tracing` level reported as a Sentry **issue**.",
+          "ty": "SentryLevel",
+          "values": [
+            "off",
+            "error",
+            "warn",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "constraint": {
+            "enum": [
+              "off",
+              "error",
+              "warn",
+              "info",
+              "debug",
+              "trace"
+            ],
+            "type": "string"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(off|error|warn|info|debug|trace)\\s*$",
+            "type": "string"
+          },
+          "text_form": "choice",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "error",
+          "default_value": "error",
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.breadcrumb_level",
+          "env": "MP_STATS_TELEMETRY__SENTRY__BREADCRUMB_LEVEL",
+          "env_file": "MP_STATS_TELEMETRY__SENTRY__BREADCRUMB_LEVEL_FILE",
+          "secrets_file": "telemetry__sentry__breadcrumb_level",
+          "docs": "Least severe `tracing` level kept as a **breadcrumb** — the trail attached to the next\nissue.\n\nRecords at or above [`Self::capture_level`] become issues instead, so this threshold only\never describes the band below it.",
+          "ty": "SentryLevel",
+          "values": [
+            "off",
+            "error",
+            "warn",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "constraint": {
+            "enum": [
+              "off",
+              "error",
+              "warn",
+              "info",
+              "debug",
+              "trace"
+            ],
+            "type": "string"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(off|error|warn|info|debug|trace)\\s*$",
+            "type": "string"
+          },
+          "text_form": "choice",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "info",
+          "default_value": "info",
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.max_breadcrumbs",
+          "env": "MP_STATS_TELEMETRY__SENTRY__MAX_BREADCRUMBS",
+          "env_file": "MP_STATS_TELEMETRY__SENTRY__MAX_BREADCRUMBS_FILE",
+          "secrets_file": "telemetry__sentry__max_breadcrumbs",
+          "docs": "How many breadcrumbs one event carries.",
+          "ty": "usize",
+          "values": [],
+          "constraint": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*\\+?[0-9]+\\s*$",
+            "type": "string"
+          },
+          "text_form": "integer",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "100",
+          "default_value": 100,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.attach_stacktraces",
+          "env": "MP_STATS_TELEMETRY__SENTRY__ATTACH_STACKTRACES",
+          "env_file": "MP_STATS_TELEMETRY__SENTRY__ATTACH_STACKTRACES_FILE",
+          "secrets_file": "telemetry__sentry__attach_stacktraces",
+          "docs": "Attach a stack trace to events that carry none of their own.",
+          "ty": "bool",
+          "values": [],
+          "constraint": {
+            "type": "boolean"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(true|false)\\s*$",
+            "type": "string"
+          },
+          "text_form": "boolean",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "true",
+          "default_value": true,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.send_default_pii",
+          "env": "MP_STATS_TELEMETRY__SENTRY__SEND_DEFAULT_PII",
+          "env_file": "MP_STATS_TELEMETRY__SENTRY__SEND_DEFAULT_PII_FILE",
+          "secrets_file": "telemetry__sentry__send_default_pii",
+          "docs": "Send personally identifying data with every event: the client IP, the full request header\nset (`Cookie` included) and the resolved user.\n\n**Off, and worth leaving off.** A reader's IP address is exactly what a crash report does\nnot need in order to be actionable, and Sentry is a third party for the purposes of\nwhatever data policy this deployment publishes. On, it also widens what the HTTP\nmiddleware records, because the Sentry tower layer reads this same flag to decide whether\nto redact sensitive headers.",
+          "ty": "bool",
+          "values": [],
+          "constraint": {
+            "type": "boolean"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(true|false)\\s*$",
+            "type": "string"
+          },
+          "text_form": "boolean",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "false",
+          "default_value": false,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.http_transactions",
+          "env": "MP_STATS_TELEMETRY__SENTRY__HTTP_TRANSACTIONS",
+          "env_file": "MP_STATS_TELEMETRY__SENTRY__HTTP_TRANSACTIONS_FILE",
+          "secrets_file": "telemetry__sentry__http_transactions",
+          "docs": "Record request spans: one Sentry transaction per request, named by the *matched route*\nrather than the URI, so a `/data` path does not become its own transaction name.\n\nWhether a started transaction is *kept* is [`Self::traces_sample_rate`]'s decision, and\nthat rate is `0.0` by default — so this key on its own costs one span per request and\nsends nothing. It is the switch for a deployment that should stay out of traces entirely.",
+          "ty": "bool",
+          "values": [],
+          "constraint": {
+            "type": "boolean"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(true|false)\\s*$",
+            "type": "string"
+          },
+          "text_form": "boolean",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "true",
+          "default_value": true,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.span_attributes",
+          "env": "MP_STATS_TELEMETRY__SENTRY__SPAN_ATTRIBUTES",
+          "env_file": "MP_STATS_TELEMETRY__SENTRY__SPAN_ATTRIBUTES_FILE",
+          "secrets_file": "telemetry__sentry__span_attributes",
+          "docs": "Copy `tracing` span fields onto the Sentry span as attributes.\n\nOff: a transaction is stored under a longer retention than a log line, and the span\nfields this server records name paths on disk.",
+          "ty": "bool",
+          "values": [],
+          "constraint": {
+            "type": "boolean"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(true|false)\\s*$",
+            "type": "string"
+          },
+          "text_form": "boolean",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "false",
+          "default_value": false,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.shutdown_timeout_secs",
+          "env": "MP_STATS_TELEMETRY__SENTRY__SHUTDOWN_TIMEOUT_SECS",
+          "env_file": "MP_STATS_TELEMETRY__SENTRY__SHUTDOWN_TIMEOUT_SECS_FILE",
+          "secrets_file": "telemetry__sentry__shutdown_timeout_secs",
+          "docs": "How long process exit waits for queued events to drain.\n\nSpent only on a graceful shutdown, which this server performs on `SIGTERM`; a `SIGKILL`\ntakes the queue with it whatever this says.",
+          "ty": "u64",
+          "values": [],
+          "constraint": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*\\+?[0-9]+\\s*$",
+            "type": "string"
+          },
+          "text_form": "integer",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "2",
+          "default_value": 2,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.debug",
+          "env": "MP_STATS_TELEMETRY__SENTRY__DEBUG",
+          "env_file": "MP_STATS_TELEMETRY__SENTRY__DEBUG_FILE",
+          "secrets_file": "telemetry__sentry__debug",
+          "docs": "Print the SDK's own diagnostics to stderr. For proving a DSN works, not for running.",
+          "ty": "bool",
+          "values": [],
+          "constraint": {
+            "type": "boolean"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(true|false)\\s*$",
+            "type": "string"
+          },
+          "text_form": "boolean",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "false",
+          "default_value": false,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
         }
       ]
     },
@@ -275,13 +765,144 @@
             }
           },
           "type": "object"
+        },
+        "telemetry": {
+          "additionalProperties": false,
+          "properties": {
+            "json_logs": {
+              "default": false,
+              "description": "Emit one JSON object per record instead of human-readable lines.\n\nOff by default because the default deployment of this repository is `docker run` on a\nterminal. A cluster shipping logs to a collector wants it on.",
+              "type": "boolean"
+            },
+            "log_filter": {
+              "default": "info",
+              "description": "`RUST_LOG`-style filter deciding which records are emitted at all, for example\n`info,mp_stats_server=debug`.\n\n`RUST_LOG` itself outranks this key when it is set, which is the one place in this\nconfiguration where a bare environment variable wins over the layered loader: it is the\nvariable every Rust operator already reaches for while a container is misbehaving, and a\nfilter is not a value a deployment can be wrong about for long.\n\nIt governs the Sentry sink too — see [`SentryConfig`].",
+              "type": "string"
+            },
+            "sentry": {
+              "additionalProperties": false,
+              "properties": {
+                "attach_stacktraces": {
+                  "default": true,
+                  "description": "Attach a stack trace to events that carry none of their own.",
+                  "type": "boolean"
+                },
+                "breadcrumb_level": {
+                  "default": "info",
+                  "description": "Least severe `tracing` level kept as a **breadcrumb** — the trail attached to the next\nissue.\n\nRecords at or above [`Self::capture_level`] become issues instead, so this threshold only\never describes the band below it.",
+                  "enum": [
+                    "off",
+                    "error",
+                    "warn",
+                    "info",
+                    "debug",
+                    "trace"
+                  ],
+                  "type": "string"
+                },
+                "capture_level": {
+                  "default": "error",
+                  "description": "Least severe `tracing` level reported as a Sentry **issue**.",
+                  "enum": [
+                    "off",
+                    "error",
+                    "warn",
+                    "info",
+                    "debug",
+                    "trace"
+                  ],
+                  "type": "string"
+                },
+                "debug": {
+                  "default": false,
+                  "description": "Print the SDK's own diagnostics to stderr. For proving a DSN works, not for running.",
+                  "type": "boolean"
+                },
+                "dsn": {
+                  "description": "Ingest URL, `https://<key>@<host>/<project>`.\n\nA [`SecretString`]: the embedded key is a bearer credential for\nthe project's ingest endpoint, and this struct is nested in a block that is logged with\n`?`. Prefer supplying it through the secrets directory or `_FILE` indirection rather than\nthrough the environment.\n\nAbsent while [`Self::enabled`] is set is a boot failure, not a silent no-op.",
+                  "type": "string",
+                  "writeOnly": true
+                },
+                "enabled": {
+                  "default": false,
+                  "description": "Initialise the Sentry client. `false` installs no client, no panic hook, no `tracing`\nlayer and no HTTP middleware, so every other key here is inert and nothing leaves the\nprocess.",
+                  "type": "boolean"
+                },
+                "environment": {
+                  "description": "Environment tag on every event.\n\nLeft unset it is derived from the build rather than guessed: `production` for a release\nbinary — which every published image is — and `development` for a debug one. Set it\nexplicitly for anything in between, such as a staging cluster running a release build.",
+                  "type": "string"
+                },
+                "http_transactions": {
+                  "default": true,
+                  "description": "Record request spans: one Sentry transaction per request, named by the *matched route*\nrather than the URI, so a `/data` path does not become its own transaction name.\n\nWhether a started transaction is *kept* is [`Self::traces_sample_rate`]'s decision, and\nthat rate is `0.0` by default — so this key on its own costs one span per request and\nsends nothing. It is the switch for a deployment that should stay out of traces entirely.",
+                  "type": "boolean"
+                },
+                "max_breadcrumbs": {
+                  "default": 100,
+                  "description": "How many breadcrumbs one event carries.",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "release": {
+                  "description": "Release tag on every event.\n\nDefaults to `mp-stats-legacy-viewer@v<version>`, spelled as the image tag spells it, so a\nregression is attributable to a deploy without an operator having to remember to set it.",
+                  "type": "string"
+                },
+                "sample_rate": {
+                  "default": 1.0,
+                  "description": "Fraction of captured events actually sent, `0.0`–`1.0`.\n\nA blunt volume cap — it drops whole issues, not repetitions of one — so leave it at `1.0`\nunless a quota forces otherwise. A value outside the range fails the boot.",
+                  "type": "number"
+                },
+                "send_default_pii": {
+                  "default": false,
+                  "description": "Send personally identifying data with every event: the client IP, the full request header\nset (`Cookie` included) and the resolved user.\n\n**Off, and worth leaving off.** A reader's IP address is exactly what a crash report does\nnot need in order to be actionable, and Sentry is a third party for the purposes of\nwhatever data policy this deployment publishes. On, it also widens what the HTTP\nmiddleware records, because the Sentry tower layer reads this same flag to decide whether\nto redact sensitive headers.",
+                  "type": "boolean"
+                },
+                "server_name": {
+                  "description": "Host tag on every event.\n\nLeft unset, Sentry reports none: the hostname of a replica is infrastructure detail that\n[`Self::send_default_pii`] would otherwise gate, and a `scratch` container's hostname\nnames a pod that no longer exists by the time anyone reads the issue.",
+                  "type": "string"
+                },
+                "shutdown_timeout_secs": {
+                  "default": 2,
+                  "description": "How long process exit waits for queued events to drain.\n\nSpent only on a graceful shutdown, which this server performs on `SIGTERM`; a `SIGKILL`\ntakes the queue with it whatever this says.",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "span_attributes": {
+                  "default": false,
+                  "description": "Copy `tracing` span fields onto the Sentry span as attributes.\n\nOff: a transaction is stored under a longer retention than a log line, and the span\nfields this server records name paths on disk.",
+                  "type": "boolean"
+                },
+                "traces_sample_rate": {
+                  "default": 0.0,
+                  "description": "Fraction of traces this process **starts** that are recorded, `0.0`–`1.0`.\n\n`0.0` (the default) means it starts none of its own, which is the right figure for a\nstatic file server: a trace per asset request is volume without a question it answers.\nIt does **not** mean this process is absent from a trace — a request arriving with a\ntrace already sampled is continued regardless, which is what keeps one reader action\nreadable across whatever sits in front of this server.",
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
         }
       },
       "title": "mp-stats-legacy-viewer configuration",
       "type": "object"
     },
     "external": {
-      "env": [],
+      "env": [
+        {
+          "name": "RUST_LOG",
+          "owner": "tracing-subscriber",
+          "docs": "Overrides `telemetry.log_filter` for this process. Same grammar; set it to debug a running container without editing the configuration the deployment is otherwise described by.",
+          "ty": "String",
+          "values": [],
+          "constraint": {
+            "type": "string"
+          },
+          "text_form": "text",
+          "required": false,
+          "secret": false
+        }
+      ],
       "ignore": [
         "KUBERNETES_*",
         "HOSTNAME"

--- a/charts/mp-stats-legacy-viewer/templates/_helpers.tpl
+++ b/charts/mp-stats-legacy-viewer/templates/_helpers.tpl
@@ -7,6 +7,14 @@ and points `MP_STATS_CONFIG` at it; pointing that variable at this chart's mount
 that file rather than layering over it, so every key it carried has to be carried here or the
 server falls back to the workspace-relative defaults and refuses to start on a missing
 `index.html`.
+
+`telemetry.sentry` is written only while its switch is on: every key under it is inert
+otherwise, so writing the block unconditionally would put fifteen settings that do nothing into
+the document an operator reads to find out what the server is doing. Optional keys inside it are
+omitted rather than written empty — an empty `telemetry.sentry.environment` is a *supplied*
+value to the loader, and "reported with a blank environment tag" is not what an operator who
+left it unset meant. The DSN never appears here at all: it is a credential and goes to the
+Secret under `telemetry__sentry__dsn`.
 */}}
 {{- define "mp-stats-legacy-viewer.derivedConfig" -}}
 server:
@@ -19,6 +27,33 @@ server:
       script_nonce: {{ .Values.server.csp.cloudflare.scriptNonce }}
       turnstile: {{ .Values.server.csp.cloudflare.turnstile }}
       web_analytics: {{ .Values.server.csp.cloudflare.webAnalytics }}
+telemetry:
+  log_filter: {{ .Values.telemetry.logFilter | quote }}
+  json_logs: {{ .Values.telemetry.jsonLogs }}
+  {{- if .Values.telemetry.sentry.enabled }}
+  sentry:
+    enabled: true
+    {{- with .Values.telemetry.sentry.environment }}
+    environment: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.telemetry.sentry.release }}
+    release: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.telemetry.sentry.serverName }}
+    server_name: {{ . | quote }}
+    {{- end }}
+    sample_rate: {{ .Values.telemetry.sentry.sampleRate }}
+    traces_sample_rate: {{ .Values.telemetry.sentry.tracesSampleRate }}
+    capture_level: {{ .Values.telemetry.sentry.captureLevel | quote }}
+    breadcrumb_level: {{ .Values.telemetry.sentry.breadcrumbLevel | quote }}
+    max_breadcrumbs: {{ .Values.telemetry.sentry.maxBreadcrumbs }}
+    attach_stacktraces: {{ .Values.telemetry.sentry.attachStacktraces }}
+    send_default_pii: {{ .Values.telemetry.sentry.sendDefaultPii }}
+    http_transactions: {{ .Values.telemetry.sentry.httpTransactions }}
+    span_attributes: {{ .Values.telemetry.sentry.spanAttributes }}
+    shutdown_timeout_secs: {{ .Values.telemetry.sentry.shutdownTimeoutSecs }}
+    debug: {{ .Values.telemetry.sentry.debug }}
+  {{- end }}
 {{- end -}}
 
 {{/*
@@ -38,4 +73,59 @@ The complete `config.toml`: the effective tree, then the verbatim escape hatch.
 {{- define "mp-stats-legacy-viewer.configToml" -}}
 {{- $config := include "mp-stats-legacy-viewer.effectiveConfig" . | fromYaml -}}
 {{- include "common.configToml" (dict "ctx" . "maps" (list $config)) -}}
+{{- end -}}
+
+{{/*
+The credential this chart manages, keyed by the file name the loader reads it from: a
+configuration path with `__` for nesting and no dots, because a `.` in the name is refused
+rather than treated as a separator.
+
+The Sentry DSN is the only one, and it appears only while the switch is on. Listed
+unconditionally it would survive into `mp-stats-legacy-viewer.secretKeys` under an
+`existingSecret` — which cannot be read from here, so every key the chart knows about is
+projected — and a pod that reports to nothing would still carry a secrets volume and an
+`MP_STATS_SECRETS_DIR` pointing into it.
+*/}}
+{{- define "mp-stats-legacy-viewer.secretData" -}}
+{{- if .Values.telemetry.sentry.enabled }}
+telemetry__sentry__dsn: {{ .Values.telemetry.sentry.dsn | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
+The secret file names this pod projects, as a YAML list. Parse with `fromYamlArray`.
+*/}}
+{{- define "mp-stats-legacy-viewer.secretKeys" -}}
+{{- $data := include "mp-stats-legacy-viewer.secretData" . | fromYaml -}}
+{{- include "common.fileConfig.secretKeys" (dict "ctx" . "data" $data) -}}
+{{- end -}}
+
+{{/*
+Refuse the two Sentry combinations that are certainly not what was meant.
+
+Upstream refuses to boot with the switch on and no DSN, so that is a CrashLoopBackOff rather
+than a degraded feature, and a rejected `helm upgrade` beats one. An `existingSecret` is taken
+as the answer, because the chart cannot see inside one and a DSN it cannot see is not the same
+as a DSN that is missing.
+
+The converse is the ordinary dead-value check: a DSN set while the switch is off is neither
+projected into the pod nor written into the Secret, so it would sit in the release meaning
+nothing — and a DSN is a credential to leave lying around.
+
+Checked against the values rather than against the effective tree: unlike every other setting
+here the DSN cannot arrive through `config` or `configExtraToml`, because it does not travel the
+configuration document at all.
+*/}}
+{{- define "mp-stats-legacy-viewer.validateValues" -}}
+{{- $messages := list -}}
+{{- $sentry := .Values.telemetry.sentry -}}
+{{- if and $sentry.enabled (not $sentry.dsn) (not .Values.existingSecret) -}}
+{{- $messages = append $messages "  - telemetry.sentry.enabled is set but no DSN is available. The server refuses to boot rather than installing a client that reports nowhere, so this is a CrashLoopBackOff, not a degraded feature. Set `telemetry.sentry.dsn`, or put `telemetry__sentry__dsn` in the Secret named by `existingSecret`." -}}
+{{- end -}}
+{{- if and (not $sentry.enabled) $sentry.dsn -}}
+{{- $messages = append $messages "  - telemetry.sentry.dsn is set while telemetry.sentry.enabled is false. No client is installed, so the DSN is neither projected into the pod nor written into the Secret and would sit in the release meaning nothing. Set `telemetry.sentry.enabled=true`, or clear the DSN." -}}
+{{- end -}}
+{{- if $messages -}}
+{{- fail (printf "\n\nVALUES VALIDATION FAILED for chart %q:\n%s\n" .Chart.Name (join "\n" $messages)) -}}
+{{- end -}}
 {{- end -}}

--- a/charts/mp-stats-legacy-viewer/templates/configmap.yaml
+++ b/charts/mp-stats-legacy-viewer/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- include "mp-stats-legacy-viewer.validateValues" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/mp-stats-legacy-viewer/templates/deployment.yaml
+++ b/charts/mp-stats-legacy-viewer/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
           file layer *is*, so it is the one thing that cannot itself be file-sourced — and
           pointing it here replaces the `/config.toml` the image ships.
         */}}
-        {{- $secretKeys := list }}
+        {{- $secretKeys := include "mp-stats-legacy-viewer.secretKeys" . | fromYamlArray }}
         {{- include "common.container" (dict
               "ctx" $
               "ports" (list (dict "name" "http" "containerPort" (int .Values.server.port) "protocol" "TCP"))

--- a/charts/mp-stats-legacy-viewer/templates/secret.yaml
+++ b/charts/mp-stats-legacy-viewer/templates/secret.yaml
@@ -1,0 +1,24 @@
+{{- $data := include "mp-stats-legacy-viewer.secretData" . | fromYaml }}
+{{- if (include "common.fileConfig.createSecret" (dict "ctx" . "data" $data)) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.fullname" . }}
+  namespace: {{ include "common.namespace" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+  {{- with (include "common.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+type: Opaque
+stringData:
+  {{- /*
+    One key, and only while Sentry is switched on: the DSN is the single credential this server
+    reads. The key name is a configuration path with `__` for nesting and no dots, because that
+    is how a file in `MP_STATS_SECRETS_DIR` has to be named — the loader reads the key out of
+    the file *name*. Rendered as `stringData` so the value stays readable in a diff review;
+    Kubernetes stores it base64-encoded either way.
+  */}}
+  {{- include "common.fileConfig.secretData" (dict "data" $data) | nindent 2 }}
+{{- end }}

--- a/charts/mp-stats-legacy-viewer/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/mp-stats-legacy-viewer/tests/__snapshot__/snapshot_test.yaml.snap
@@ -15,6 +15,10 @@ matches the committed Deployment snapshot:
         script_nonce = false
         turnstile = false
         web_analytics = false
+
+        [telemetry]
+        json_logs = false
+        log_filter = "info"
     kind: ConfigMap
     metadata:
       labels:
@@ -47,7 +51,7 @@ matches the committed Deployment snapshot:
       template:
         metadata:
           annotations:
-            checksum/configmap: d5ad6f28f9ad5a9d8a06f3c339f6f01d1ee32f95af810dde63349cbe893409cf
+            checksum/configmap: 4c6f489007931ced9fe5eff2dde39c91d5b89bc47939854fc25b313ea6ea7af5
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
@@ -145,6 +149,10 @@ matches the committed Deployment snapshot with network policies and probes on:
         script_nonce = false
         turnstile = false
         web_analytics = false
+
+        [telemetry]
+        json_logs = false
+        log_filter = "info"
     kind: ConfigMap
     metadata:
       labels:
@@ -177,7 +185,7 @@ matches the committed Deployment snapshot with network policies and probes on:
       template:
         metadata:
           annotations:
-            checksum/configmap: d5ad6f28f9ad5a9d8a06f3c339f6f01d1ee32f95af810dde63349cbe893409cf
+            checksum/configmap: 4c6f489007931ced9fe5eff2dde39c91d5b89bc47939854fc25b313ea6ea7af5
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm

--- a/charts/mp-stats-legacy-viewer/tests/contract_roundtrip_viewer_test.yaml
+++ b/charts/mp-stats-legacy-viewer/tests/contract_roundtrip_viewer_test.yaml
@@ -8,7 +8,7 @@
 # Chart:       mp-stats-legacy-viewer
 # Declaration: charts/mp-stats-legacy-viewer/config-contract.yaml (document `viewer`)
 # Contract:    charts/mp-stats-legacy-viewer/contracts/viewer.json
-# Coverage:    6 of 7 contract keys carry a probe
+# Coverage:    21 of 25 contract keys carry a probe
 #
 # Regenerate with `just contract-tests`. `just check-contract-tests` fails a pull request whose
 # committed copy has drifted from the contract it was generated against.
@@ -96,8 +96,164 @@ tests:
           path: data["config.toml"]
           pattern: '(?m)^\[server\]$\n(?:[^\[\n][^\n]*\n|\n)*^dist_dir = "contract-probe-server-dist-dir"$'
 
+  - it: delivers telemetry.json_logs into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.telemetry.json_logs: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\]$\n(?:[^\[\n][^\n]*\n|\n)*^json_logs = true$'
+
+  - it: delivers telemetry.log_filter into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.telemetry.log_filter: contract-probe-telemetry-log-filter
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\]$\n(?:[^\[\n][^\n]*\n|\n)*^log_filter = "contract-probe-telemetry-log-filter"$'
+
+  - it: delivers telemetry.sentry.attach_stacktraces into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.telemetry.sentry.attach_stacktraces: false
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^attach_stacktraces = false$'
+
+  - it: delivers telemetry.sentry.breadcrumb_level into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.telemetry.sentry.breadcrumb_level: off
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^breadcrumb_level = "off"$'
+
+  - it: delivers telemetry.sentry.capture_level into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.telemetry.sentry.capture_level: off
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^capture_level = "off"$'
+
+  - it: delivers telemetry.sentry.debug into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.telemetry.sentry.debug: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^debug = true$'
+
+  - it: delivers telemetry.sentry.enabled into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.telemetry.sentry.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^enabled = true$'
+
+  - it: delivers telemetry.sentry.environment into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.telemetry.sentry.environment: contract-probe-telemetry-sentry-environment
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^environment = "contract-probe-telemetry-sentry-environment"$'
+
+  - it: delivers telemetry.sentry.http_transactions into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.telemetry.sentry.http_transactions: false
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^http_transactions = false$'
+
+  - it: delivers telemetry.sentry.max_breadcrumbs into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.telemetry.sentry.max_breadcrumbs: 4242
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^max_breadcrumbs = 4242$'
+
+  - it: delivers telemetry.sentry.release into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.telemetry.sentry.release: contract-probe-telemetry-sentry-release
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^release = "contract-probe-telemetry-sentry-release"$'
+
+  - it: delivers telemetry.sentry.send_default_pii into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.telemetry.sentry.send_default_pii: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^send_default_pii = true$'
+
+  - it: delivers telemetry.sentry.server_name into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.telemetry.sentry.server_name: contract-probe-telemetry-sentry-server-name
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^server_name = "contract-probe-telemetry-sentry-server-name"$'
+
+  - it: delivers telemetry.sentry.shutdown_timeout_secs into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.telemetry.sentry.shutdown_timeout_secs: 4242
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^shutdown_timeout_secs = 4242$'
+
+  - it: delivers telemetry.sentry.span_attributes into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.telemetry.sentry.span_attributes: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^span_attributes = true$'
+
   # Contract keys carrying no case, and why. An unexplained absence is indistinguishable from an
   # oversight, so every one of them is named here rather than simply left out.
   #
   # server.bind_addr: `unknown`: the producer publishes no constraint for this key, so no probe
   #                   can be known-valid
+  # telemetry.sentry.dsn: `secret: true`: the probe would be committed to this repository, and a
+  #                       credential-shaped value in a test file is a credential
+  # telemetry.sentry.sample_rate: `unknown`: the producer publishes no constraint for this key,
+  #                               so no probe can be known-valid
+  # telemetry.sentry.traces_sample_rate: `unknown`: the producer publishes no constraint for
+  #                                      this key, so no probe can be known-valid

--- a/charts/mp-stats-legacy-viewer/tests/deployment_test.yaml
+++ b/charts/mp-stats-legacy-viewer/tests/deployment_test.yaml
@@ -68,9 +68,10 @@ tests:
             mountPath: /etc/mp-stats/config
             readOnly: true
 
-  # Neither binary reads a secret, and a configured secrets directory that cannot be read is a
-  # boot failure naming the path, not an empty layer.
-  - it: names no secrets directory, because neither binary reads a secret
+  # The Sentry DSN is the only credential this server reads, so a release that does not report
+  # to Sentry has no secrets volume at all — and a configured secrets directory that cannot be
+  # read is a boot failure naming the path, not an empty layer.
+  - it: names no secrets directory while Sentry is off
     documentSelector:
       path: kind
       value: Deployment
@@ -86,6 +87,69 @@ tests:
             name: secrets
             mountPath: /etc/mp-stats/secrets
             readOnly: true
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: secrets
+          any: true
+
+  - it: mounts the DSN once Sentry is on
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      telemetry.sentry.enabled: true
+      telemetry.sentry.dsn: https://key@sentry.example.invalid/1
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MP_STATS_SECRETS_DIR
+            value: /etc/mp-stats/secrets
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: secrets
+            mountPath: /etc/mp-stats/secrets
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: secrets
+            projected:
+              defaultMode: 256
+              sources:
+                - secret:
+                    name: RELEASE-NAME-mp-stats-legacy-viewer
+                    optional: true
+                    items:
+                      - key: telemetry__sentry__dsn
+                        path: telemetry__sentry__dsn
+
+  # The chart cannot read an `existingSecret`, so it projects every key it knows how to consume.
+  # That list is still gated on the switch, or a release reporting nowhere would mount a file
+  # for a client it never installs.
+  - it: projects an existing Secret when one is given
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      telemetry.sentry.enabled: true
+      existingSecret: my-sentry-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: secrets
+            projected:
+              defaultMode: 256
+              sources:
+                - secret:
+                    name: my-sentry-secret
+                    optional: true
+                    items:
+                      - key: telemetry__sentry__dsn
+                        path: telemetry__sentry__dsn
 
   # The server does not reload, so a configuration change has to roll the pod to take effect.
   - it: rolls the pod when the mounted configuration changes

--- a/charts/mp-stats-legacy-viewer/tests/sentry_test.yaml
+++ b/charts/mp-stats-legacy-viewer/tests/sentry_test.yaml
@@ -1,0 +1,268 @@
+# Sentry error reporting and request tracing: an optional feature whose whole risk is asymmetric.
+#
+# Off, it must change nothing at all — not a key in the ConfigMap, not a Secret, not a volume,
+# not an environment variable — because it is off in every release that has not asked for it,
+# and because the DSN is the only credential this server reads. Switching it on is what gives
+# the pod a secrets volume and an `MP_STATS_SECRETS_DIR` in the first place, so "off changes
+# nothing" is a claim about pod shape here, not only about a document.
+#
+# On, fifteen settings have to arrive at fifteen distinct paths, and a value that lands at the
+# wrong one is a compiled default nobody chose rather than an error. The assertion that the DSN
+# never reaches the ConfigMap is the one whose failure would be a disclosure.
+#
+# The pod-shape assertions live in `deployment_test.yaml`. A suite that lists `deployment.yaml`
+# cannot also carry a `failedTemplate` assertion — helm-unittest reports "no failed document"
+# for the whole suite — and the validation this feature adds is the half worth testing.
+suite: sentry
+templates:
+  - configmap.yaml
+  - secret.yaml
+tests:
+  # Off has to mean *absent*, not "present and false": every key under the block is inert while
+  # the switch is down, so writing them would put fifteen settings that do nothing into the
+  # document an operator reads to find out what the server is doing.
+  - it: writes no Sentry block at all while the switch is off
+    template: configmap.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'sentry'
+
+  # The log settings are not gated on it and are always written: `MP_STATS_CONFIG` pointed at
+  # this mount *replaces* the `/config.toml` the image ships, so a key left out here falls back
+  # to the struct default rather than to the image's.
+  - it: always writes the log settings
+    template: configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[telemetry\]\njson_logs = false\nlog_filter = "info"'
+
+  - it: reflects changed log settings
+    template: configmap.yaml
+    set:
+      telemetry.logFilter: info,mp_stats_server=debug
+      telemetry.jsonLogs: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nlog_filter = "info,mp_stats_server=debug"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\njson_logs = true'
+
+  - it: renders no Secret while the switch is off
+    template: secret.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: writes the whole block when the switch is on
+    template: configmap.yaml
+    set:
+      telemetry.sentry:
+        enabled: true
+        dsn: https://key@sentry.example.invalid/1
+        environment: staging
+        release: mp-stats-legacy-viewer@v0.19.0
+        serverName: viewer-a
+        sampleRate: 0.5
+        tracesSampleRate: 0.25
+        captureLevel: warn
+        breadcrumbLevel: debug
+        maxBreadcrumbs: 50
+        attachStacktraces: false
+        sendDefaultPii: true
+        httpTransactions: false
+        spanAttributes: true
+        shutdownTimeoutSecs: 5
+        debug: true
+    asserts:
+      # One assertion per key, and every value set away from its default: the defect class this
+      # suite exists for is a value arriving at the wrong path, which a fixture that left the
+      # defaults in place would render identically whether the mapping were right or reversed.
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[telemetry\.sentry\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nenabled = true'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nenvironment = "staging"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nrelease = "mp-stats-legacy-viewer@v0\.19\.0"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nserver_name = "viewer-a"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nsample_rate = 0\.5'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\ntraces_sample_rate = 0\.25'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\ncapture_level = "warn"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nbreadcrumb_level = "debug"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nmax_breadcrumbs = 50'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nattach_stacktraces = false'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nsend_default_pii = true'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nhttp_transactions = false'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nspan_attributes = true'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nshutdown_timeout_secs = 5'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\ndebug = true'
+
+  # An empty optional value is a *supplied* value to the loader, and "reported with a blank
+  # environment tag" is not what leaving it unset meant. These three have no chart default
+  # because the server derives all of them.
+  - it: omits the three derived tags rather than writing them empty
+    template: configmap.yaml
+    set:
+      telemetry.sentry.enabled: true
+      telemetry.sentry.dsn: https://key@sentry.example.invalid/1
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'environment'
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'release'
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'server_name'
+      # The keys that do have a chart default are still written, so the document says what the
+      # server is actually doing rather than leaving it to the struct.
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nsample_rate = 1'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\ncapture_level = "error"'
+
+  # A reader's IP address is not what makes a crash report actionable, and the same flag is what
+  # stops the HTTP middleware redacting sensitive headers. Off is the chart default and has to
+  # stay it.
+  - it: leaves personally identifying data off by default
+    template: configmap.yaml
+    set:
+      telemetry.sentry.enabled: true
+      telemetry.sentry.dsn: https://key@sentry.example.invalid/1
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nsend_default_pii = false'
+
+  # The DSN embeds an ingest key. A ConfigMap is readable by anything that can read the
+  # namespace.
+  - it: keeps the DSN out of the ConfigMap
+    template: configmap.yaml
+    set:
+      telemetry.sentry.enabled: true
+      telemetry.sentry.dsn: https://key@sentry.example.invalid/1
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'dsn'
+
+  - it: writes the DSN into the Secret under the path the loader reads
+    template: secret.yaml
+    set:
+      telemetry.sentry.enabled: true
+      telemetry.sentry.dsn: https://key@sentry.example.invalid/1
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: type
+          value: Opaque
+      # stringData, not a hand-rolled b64enc into `data`: Kubernetes does the encoding and a
+      # wrongly-encoded value can no longer be committed.
+      - equal:
+          path: stringData.telemetry__sentry__dsn
+          value: https://key@sentry.example.invalid/1
+
+  - it: renders no Secret when an existing one is named
+    template: secret.yaml
+    set:
+      telemetry.sentry.enabled: true
+      existingSecret: my-sentry-secret
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # Upstream refuses to boot with the switch on and no DSN, so this is a CrashLoopBackOff rather
+  # than a degraded feature — worth catching at render time.
+  - it: refuses the switch with no DSN anywhere
+    template: configmap.yaml
+    set:
+      telemetry.sentry.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "telemetry.sentry.enabled is set but no DSN is available"
+
+  # The chart cannot see inside an `existingSecret`, and a DSN it cannot see is not the same as
+  # a DSN that is missing.
+  - it: accepts an existing Secret as the DSN it cannot see
+    template: configmap.yaml
+    set:
+      telemetry.sentry.enabled: true
+      existingSecret: my-sentry-secret
+    asserts:
+      - isKind:
+          of: ConfigMap
+
+  # The ordinary dead-value check: a credential sitting in the release meaning nothing.
+  - it: refuses a DSN set while the switch is off
+    template: configmap.yaml
+    set:
+      telemetry.sentry.dsn: https://key@sentry.example.invalid/1
+    asserts:
+      - failedTemplate:
+          errorPattern: "telemetry.sentry.dsn is set while telemetry.sentry.enabled is false"
+
+  # The DSN does not travel the configuration document, so unlike every other check in this
+  # chart the Sentry pair cannot be something `configExtraToml` is supplying.
+  - it: still refuses a bad Sentry pair behind configExtraToml
+    template: configmap.yaml
+    set:
+      configExtraToml: |
+        [converter]
+        enabled = false
+      telemetry.sentry.dsn: https://key@sentry.example.invalid/1
+    asserts:
+      - failedTemplate:
+          errorPattern: "telemetry.sentry.dsn is set while telemetry.sentry.enabled is false"
+
+  # `config` is the highest-precedence layer the chart renders, so it has to be able to reach
+  # inside a block the first-class values built.
+  - it: lets the raw config tree override a derived Sentry key
+    template: configmap.yaml
+    set:
+      telemetry.sentry.enabled: true
+      telemetry.sentry.dsn: https://key@sentry.example.invalid/1
+      config:
+        telemetry:
+          sentry:
+            traces_sample_rate: 0.75
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\ntraces_sample_rate = 0\.75'

--- a/charts/mp-stats-legacy-viewer/values.schema.json
+++ b/charts/mp-stats-legacy-viewer/values.schema.json
@@ -1607,7 +1607,7 @@
           "type": "string"
         },
         "tag": {
-          "default": "v0.18.0@sha256:22aec41fcd9170a7c4799e8170700436332413728ea9c476b7d4d539d284f9fb",
+          "default": "v0.19.0@sha256:115f48976c6091f381668f50c8f8410b26532926c618afbb567bfbd16009adec",
           "description": "The container image tag, pinned by digest (`vX.Y.Z\npull, while the tag stays on as the readable version marker. Defaults to the chart's\n`appVersion` when empty.",
           "required": [],
           "title": "tag",

--- a/charts/mp-stats-legacy-viewer/values.schema.json
+++ b/charts/mp-stats-legacy-viewer/values.schema.json
@@ -1303,7 +1303,7 @@
         },
         "secretsDir": {
           "default": "/etc/mp-stats/secrets",
-          "description": "Directory credential files would be mounted at, passed as `MP_STATS_SECRETS_DIR`. Neither\nbinary reads a secret today, so nothing is mounted and the variable is not set; the value is\nhere for an operator adding one through `extraVolumes`.",
+          "description": "Directory credential files are mounted at, passed as `MP_STATS_SECRETS_DIR`. The Sentry\nDSN is the only credential this chart handles, so the volume and the variable both appear\nonly while `telemetry.sentry.enabled` is set — a release that does not report to Sentry\ncarries neither.",
           "required": [],
           "title": "secretsDir",
           "type": "string"
@@ -1311,6 +1311,13 @@
       },
       "required": [],
       "title": "configMount"
+    },
+    "existingSecret": {
+      "default": "",
+      "description": "Name of an existing Secret holding the Sentry DSN, which keeps it out of `values.yaml` and\nout of the Helm release object. **Its key is the configuration path, not a free-form name**:\n`telemetry__sentry__dsn`, because the file name is what the loader parses. Set, the chart\nrenders no Secret of its own and `telemetry.sentry.dsn` is ignored. It is read only while\n`telemetry.sentry.enabled` is set — nothing else this server reads is a credential.",
+      "required": [],
+      "title": "existingSecret",
+      "type": "string"
     },
     "extraEnv": {
       "description": "Additional environment variables for the application container.",
@@ -2608,6 +2615,168 @@
     "strategy": {
       "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.apps.v1.DeploymentStrategy",
       "required": []
+    },
+    "telemetry": {
+      "additionalProperties": true,
+      "description": "Logging and error reporting. The log settings are rendered under `telemetry` in the mounted\n`config.toml`; the Sentry DSN is a credential and goes to the Secret instead. The whole block\nis read once as the process boots rather than re-read from the mount, so a change to it takes\neffect on the next rollout.",
+      "properties": {
+        "jsonLogs": {
+          "default": false,
+          "description": "Emit one JSON object per record instead of human-readable lines\n(`telemetry.json_logs`). The image's default suits `docker run` on a terminal; a cluster\nshipping logs to a collector wants this on.",
+          "required": [],
+          "title": "jsonLogs",
+          "type": "boolean"
+        },
+        "logFilter": {
+          "default": "info",
+          "description": "`RUST_LOG`-style filter deciding which records are emitted at all\n(`telemetry.log_filter`), for example `info,mp_stats_server=debug`. `RUST_LOG` set in the\ncontainer outranks this — the one place in this configuration where a bare environment\nvariable wins over the layered loader — so `extraEnv` is the override to reach for while a\npod is misbehaving. It governs what reaches Sentry too: a record this filter drops never\nbecomes an issue or a breadcrumb, whatever `sentry.captureLevel` says.",
+          "required": [],
+          "title": "logFilter",
+          "type": "string"
+        },
+        "sentry": {
+          "additionalProperties": true,
+          "description": "Sentry error reporting and request tracing. **Off**, and wholly inert while it is: no\nclient, no panic hook, no `tracing` layer and no HTTP middleware is installed, and nothing\nleaves the process.\n\nTwo things the chart deliberately does not do for you. It never reads the DSN, so it cannot\nname the ingest host in the NetworkPolicies. The defaults do happen to cover it —\n`networkPolicy.egress.https` permits TCP/443 to `0.0.0.0/0` minus private space — but a\ndeployment that narrowed `networkPolicy.egress.cidr`, turned `egress.https` off, or replaced\nthe CIDR rule with `networkPolicy.cilium.egress.toFQDNs` has to name the endpoint itself,\nand getting that wrong is silent: an SDK that cannot reach its endpoint queues events and\nthen discards them, so the project stays empty, which reads as \"no errors\". And it\nconfigures nothing inside Sentry — the project, its quota and its server-side data-scrubbing\nrules are yours.",
+          "properties": {
+            "attachStacktraces": {
+              "default": true,
+              "description": "Attach a stack trace to events that carry none of their own\n(`telemetry.sentry.attach_stacktraces`).",
+              "required": [],
+              "title": "attachStacktraces",
+              "type": "boolean"
+            },
+            "breadcrumbLevel": {
+              "default": "info",
+              "description": "Least severe `tracing` level kept as a breadcrumb, the trail attached to the next issue\n(`telemetry.sentry.breadcrumb_level`). Records at or above `captureLevel` become issues\ninstead, so this only ever describes the band below it. Quote `\"off\"`.",
+              "enum": [
+                "off",
+                "error",
+                "warn",
+                "info",
+                "debug",
+                "trace"
+              ],
+              "required": [],
+              "title": "breadcrumbLevel"
+            },
+            "captureLevel": {
+              "default": "error",
+              "description": "Least severe `tracing` level reported as a Sentry issue\n(`telemetry.sentry.capture_level`). Quote `\"off\"` — unquoted, YAML reads it as the boolean\n`false`. This and `breadcrumbLevel` both sit *under* `logFilter`, so a record that filter\ndrops never reaches Sentry either.",
+              "enum": [
+                "off",
+                "error",
+                "warn",
+                "info",
+                "debug",
+                "trace"
+              ],
+              "required": [],
+              "title": "captureLevel"
+            },
+            "debug": {
+              "default": false,
+              "description": "Print the SDK's own diagnostics to stderr (`telemetry.sentry.debug`). For proving a DSN\nworks, not for running.",
+              "required": [],
+              "title": "debug",
+              "type": "boolean"
+            },
+            "dsn": {
+              "default": "",
+              "description": "Ingest URL, `https://\u003ckey\u003e@\u003chost\u003e/\u003cproject\u003e`. A credential — the embedded key is a\nbearer token for the project's ingest endpoint — so it is delivered as a file in\n`MP_STATS_SECRETS_DIR` under `telemetry__sentry__dsn` and never written into the\nConfigMap. It is the only credential this chart handles, and switching Sentry on is what\ngives the pod a secrets volume at all. Leave it empty and put that key in the Secret named\nby `existingSecret` to keep it out of `helm get values` entirely.",
+              "required": [],
+              "title": "dsn",
+              "type": "string"
+            },
+            "enabled": {
+              "default": false,
+              "description": "Initialise the Sentry client (`telemetry.sentry.enabled`). Off, every other key here is\ninert. On, the server refuses to boot without a DSN rather than starting with a reporter\nthat reports nowhere, so this and `dsn` are set together.",
+              "required": [],
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "environment": {
+              "default": "",
+              "description": "Environment tag on every event (`telemetry.sentry.environment`). Empty lets the server\nderive it from the build: `production` for a release binary, which every published image\nis. Set it for anything in between, such as a staging cluster running that same binary.",
+              "required": [],
+              "title": "environment",
+              "type": "string"
+            },
+            "httpTransactions": {
+              "default": true,
+              "description": "Record one transaction per request, named by the matched route rather than by the URI\n(`telemetry.sentry.http_transactions`). Whether a started transaction is kept is\n`tracesSampleRate`'s decision; this is the switch for a deployment that wants error\nreporting and no performance data at all.",
+              "required": [],
+              "title": "httpTransactions",
+              "type": "boolean"
+            },
+            "maxBreadcrumbs": {
+              "default": 100,
+              "description": "How many breadcrumbs one event carries (`telemetry.sentry.max_breadcrumbs`).",
+              "minimum": 0,
+              "required": [],
+              "title": "maxBreadcrumbs",
+              "type": "integer"
+            },
+            "release": {
+              "default": "",
+              "description": "Release tag on every event (`telemetry.sentry.release`). Empty uses\n`mp-stats-legacy-viewer\nmakes a regression attributable to a deploy — set this only to match a release you create\nin Sentry under a name of your own.",
+              "required": [],
+              "title": "release",
+              "type": "string"
+            },
+            "sampleRate": {
+              "default": 1,
+              "description": "Fraction of captured events actually sent (`telemetry.sentry.sample_rate`). A blunt\nvolume cap — it drops whole issues, not repetitions of one — so leave it at `1` unless a\nquota forces otherwise. A value outside the range fails the boot.",
+              "maximum": 1,
+              "minimum": 0,
+              "required": [],
+              "title": "sampleRate",
+              "type": "number"
+            },
+            "sendDefaultPii": {
+              "default": false,
+              "description": "Send personally identifying data with every event: the client IP, the whole request\nheader set — `Cookie` included — and the resolved user\n(`telemetry.sentry.send_default_pii`). **Off, and worth leaving off** — a reader's IP\naddress is not what makes a crash report actionable, and Sentry is a third party for the\npurposes of whatever data policy this deployment publishes. It is two controls rather than\none, besides: off is also what keeps the HTTP middleware redacting sensitive headers.",
+              "required": [],
+              "title": "sendDefaultPii",
+              "type": "boolean"
+            },
+            "serverName": {
+              "default": "",
+              "description": "Host tag on every event (`telemetry.sentry.server_name`). Empty reports none, which is\nthe right answer here: the value would be one replica's pod name, gone by the time anyone\nreads the issue.",
+              "required": [],
+              "title": "serverName",
+              "type": "string"
+            },
+            "shutdownTimeoutSecs": {
+              "default": 2,
+              "description": "How long process exit waits for queued events to drain\n(`telemetry.sentry.shutdown_timeout_secs`). Paid on every pod shutdown, so it is time\nadded to every rollout; keep it well inside `terminationGracePeriodSeconds`.",
+              "minimum": 0,
+              "required": [],
+              "title": "shutdownTimeoutSecs",
+              "type": "integer"
+            },
+            "spanAttributes": {
+              "default": false,
+              "description": "Copy `tracing` span fields onto the Sentry span as attributes\n(`telemetry.sentry.span_attributes`). Off: the span fields here carry request paths, and a\ntransaction is retained for longer than a log line.",
+              "required": [],
+              "title": "spanAttributes",
+              "type": "boolean"
+            },
+            "tracesSampleRate": {
+              "default": 0,
+              "description": "Fraction of traces this server **starts** that are recorded\n(`telemetry.sentry.traces_sample_rate`). `0` starts none, which is the right figure for a\nstatic file server — a trace per asset request is volume without a question behind it —\nand it is what makes the feature free to switch on for error reporting alone. It does not\ntake the server out of a trace that reaches it already sampled: an inbound `sentry-trace`\nheader is continued whatever this says.",
+              "maximum": 1,
+              "minimum": 0,
+              "required": [],
+              "title": "tracesSampleRate",
+              "type": "number"
+            }
+          },
+          "required": [],
+          "title": "sentry"
+        }
+      },
+      "required": [],
+      "title": "telemetry"
     },
     "terminationGracePeriodSeconds": {
       "default": 30,

--- a/charts/mp-stats-legacy-viewer/values.yaml
+++ b/charts/mp-stats-legacy-viewer/values.yaml
@@ -126,6 +126,219 @@ server:
       webAnalytics: false
 
 # @schema
+# additionalProperties: true
+# @schema
+# -- Logging and error reporting. The log settings are rendered under `telemetry` in the mounted
+# `config.toml`; the Sentry DSN is a credential and goes to the Secret instead. The whole block
+# is read once as the process boots rather than re-read from the mount, so a change to it takes
+# effect on the next rollout.
+telemetry:
+  # @schema
+  # # @config projection telemetry.log_filter
+  # type: string
+  # @schema
+  # -- `RUST_LOG`-style filter deciding which records are emitted at all
+  # (`telemetry.log_filter`), for example `info,mp_stats_server=debug`. `RUST_LOG` set in the
+  # container outranks this — the one place in this configuration where a bare environment
+  # variable wins over the layered loader — so `extraEnv` is the override to reach for while a
+  # pod is misbehaving. It governs what reaches Sentry too: a record this filter drops never
+  # becomes an issue or a breadcrumb, whatever `sentry.captureLevel` says.
+  logFilter: info
+
+  # @schema
+  # # @config projection telemetry.json_logs
+  # type: boolean
+  # @schema
+  # -- Emit one JSON object per record instead of human-readable lines
+  # (`telemetry.json_logs`). The image's default suits `docker run` on a terminal; a cluster
+  # shipping logs to a collector wants this on.
+  jsonLogs: false
+
+  # @schema
+  # additionalProperties: true
+  # @schema
+  # -- Sentry error reporting and request tracing. **Off**, and wholly inert while it is: no
+  # client, no panic hook, no `tracing` layer and no HTTP middleware is installed, and nothing
+  # leaves the process.
+  #
+  # Two things the chart deliberately does not do for you. It never reads the DSN, so it cannot
+  # name the ingest host in the NetworkPolicies. The defaults do happen to cover it —
+  # `networkPolicy.egress.https` permits TCP/443 to `0.0.0.0/0` minus private space — but a
+  # deployment that narrowed `networkPolicy.egress.cidr`, turned `egress.https` off, or replaced
+  # the CIDR rule with `networkPolicy.cilium.egress.toFQDNs` has to name the endpoint itself,
+  # and getting that wrong is silent: an SDK that cannot reach its endpoint queues events and
+  # then discards them, so the project stays empty, which reads as "no errors". And it
+  # configures nothing inside Sentry — the project, its quota and its server-side data-scrubbing
+  # rules are yours.
+  sentry:
+    # @schema
+    # # @config projection telemetry.sentry.enabled optional
+    # type: boolean
+    # @schema
+    # -- Initialise the Sentry client (`telemetry.sentry.enabled`). Off, every other key here is
+    # inert. On, the server refuses to boot without a DSN rather than starting with a reporter
+    # that reports nowhere, so this and `dsn` are set together.
+    enabled: false
+
+    # @schema
+    # type: string
+    # @schema
+    # -- Ingest URL, `https://<key>@<host>/<project>`. A credential — the embedded key is a
+    # bearer token for the project's ingest endpoint — so it is delivered as a file in
+    # `MP_STATS_SECRETS_DIR` under `telemetry__sentry__dsn` and never written into the
+    # ConfigMap. It is the only credential this chart handles, and switching Sentry on is what
+    # gives the pod a secrets volume at all. Leave it empty and put that key in the Secret named
+    # by `existingSecret` to keep it out of `helm get values` entirely.
+    dsn: ""
+
+    # @schema
+    # # @config projection telemetry.sentry.environment optional when telemetry.sentry.enabled
+    # type: string
+    # @schema
+    # -- Environment tag on every event (`telemetry.sentry.environment`). Empty lets the server
+    # derive it from the build: `production` for a release binary, which every published image
+    # is. Set it for anything in between, such as a staging cluster running that same binary.
+    environment: ""
+
+    # @schema
+    # # @config projection telemetry.sentry.release optional when telemetry.sentry.enabled
+    # type: string
+    # @schema
+    # -- Release tag on every event (`telemetry.sentry.release`). Empty uses
+    # `mp-stats-legacy-viewer@v<version>`, spelled as the image tag spells it, which is what
+    # makes a regression attributable to a deploy — set this only to match a release you create
+    # in Sentry under a name of your own.
+    release: ""
+
+    # @schema
+    # # @config projection telemetry.sentry.server_name optional when telemetry.sentry.enabled
+    # type: string
+    # @schema
+    # -- Host tag on every event (`telemetry.sentry.server_name`). Empty reports none, which is
+    # the right answer here: the value would be one replica's pod name, gone by the time anyone
+    # reads the issue.
+    serverName: ""
+
+    # @schema
+    # # @config projection telemetry.sentry.sample_rate when telemetry.sentry.enabled
+    # type: number
+    # minimum: 0
+    # maximum: 1
+    # @schema
+    # -- Fraction of captured events actually sent (`telemetry.sentry.sample_rate`). A blunt
+    # volume cap — it drops whole issues, not repetitions of one — so leave it at `1` unless a
+    # quota forces otherwise. A value outside the range fails the boot.
+    sampleRate: 1.0
+
+    # @schema
+    # # @config projection telemetry.sentry.traces_sample_rate when telemetry.sentry.enabled
+    # type: number
+    # minimum: 0
+    # maximum: 1
+    # @schema
+    # -- Fraction of traces this server **starts** that are recorded
+    # (`telemetry.sentry.traces_sample_rate`). `0` starts none, which is the right figure for a
+    # static file server — a trace per asset request is volume without a question behind it —
+    # and it is what makes the feature free to switch on for error reporting alone. It does not
+    # take the server out of a trace that reaches it already sampled: an inbound `sentry-trace`
+    # header is continued whatever this says.
+    tracesSampleRate: 0.0
+
+    # @schema
+    # # @config projection telemetry.sentry.capture_level when telemetry.sentry.enabled
+    # enum: ["off", error, warn, info, debug, trace]
+    # @schema
+    # -- Least severe `tracing` level reported as a Sentry issue
+    # (`telemetry.sentry.capture_level`). Quote `"off"` — unquoted, YAML reads it as the boolean
+    # `false`. This and `breadcrumbLevel` both sit *under* `logFilter`, so a record that filter
+    # drops never reaches Sentry either.
+    captureLevel: error
+
+    # @schema
+    # # @config projection telemetry.sentry.breadcrumb_level when telemetry.sentry.enabled
+    # enum: ["off", error, warn, info, debug, trace]
+    # @schema
+    # -- Least severe `tracing` level kept as a breadcrumb, the trail attached to the next issue
+    # (`telemetry.sentry.breadcrumb_level`). Records at or above `captureLevel` become issues
+    # instead, so this only ever describes the band below it. Quote `"off"`.
+    breadcrumbLevel: info
+
+    # @schema
+    # # @config projection telemetry.sentry.max_breadcrumbs when telemetry.sentry.enabled
+    # type: integer
+    # minimum: 0
+    # @schema
+    # -- How many breadcrumbs one event carries (`telemetry.sentry.max_breadcrumbs`).
+    maxBreadcrumbs: 100
+
+    # @schema
+    # # @config projection telemetry.sentry.attach_stacktraces when telemetry.sentry.enabled
+    # type: boolean
+    # @schema
+    # -- Attach a stack trace to events that carry none of their own
+    # (`telemetry.sentry.attach_stacktraces`).
+    attachStacktraces: true
+
+    # @schema
+    # # @config projection telemetry.sentry.send_default_pii when telemetry.sentry.enabled
+    # type: boolean
+    # @schema
+    # -- Send personally identifying data with every event: the client IP, the whole request
+    # header set — `Cookie` included — and the resolved user
+    # (`telemetry.sentry.send_default_pii`). **Off, and worth leaving off** — a reader's IP
+    # address is not what makes a crash report actionable, and Sentry is a third party for the
+    # purposes of whatever data policy this deployment publishes. It is two controls rather than
+    # one, besides: off is also what keeps the HTTP middleware redacting sensitive headers.
+    sendDefaultPii: false
+
+    # @schema
+    # # @config projection telemetry.sentry.http_transactions when telemetry.sentry.enabled
+    # type: boolean
+    # @schema
+    # -- Record one transaction per request, named by the matched route rather than by the URI
+    # (`telemetry.sentry.http_transactions`). Whether a started transaction is kept is
+    # `tracesSampleRate`'s decision; this is the switch for a deployment that wants error
+    # reporting and no performance data at all.
+    httpTransactions: true
+
+    # @schema
+    # # @config projection telemetry.sentry.span_attributes when telemetry.sentry.enabled
+    # type: boolean
+    # @schema
+    # -- Copy `tracing` span fields onto the Sentry span as attributes
+    # (`telemetry.sentry.span_attributes`). Off: the span fields here carry request paths, and a
+    # transaction is retained for longer than a log line.
+    spanAttributes: false
+
+    # @schema
+    # # @config projection telemetry.sentry.shutdown_timeout_secs when telemetry.sentry.enabled
+    # type: integer
+    # minimum: 0
+    # @schema
+    # -- How long process exit waits for queued events to drain
+    # (`telemetry.sentry.shutdown_timeout_secs`). Paid on every pod shutdown, so it is time
+    # added to every rollout; keep it well inside `terminationGracePeriodSeconds`.
+    shutdownTimeoutSecs: 2
+
+    # @schema
+    # # @config projection telemetry.sentry.debug when telemetry.sentry.enabled
+    # type: boolean
+    # @schema
+    # -- Print the SDK's own diagnostics to stderr (`telemetry.sentry.debug`). For proving a DSN
+    # works, not for running.
+    debug: false
+
+# @schema
+# type: string
+# @schema
+# -- Name of an existing Secret holding the Sentry DSN, which keeps it out of `values.yaml` and
+# out of the Helm release object. **Its key is the configuration path, not a free-form name**:
+# `telemetry__sentry__dsn`, because the file name is what the loader parses. Set, the chart
+# renders no Secret of its own and `telemetry.sentry.dsn` is ignored. It is read only while
+# `telemetry.sentry.enabled` is set — nothing else this server reads is a credential.
+existingSecret: ""
+
+# @schema
 # type: object
 # additionalProperties: true
 # @schema
@@ -159,9 +372,10 @@ configMount:
   # @schema
   # type: string
   # @schema
-  # -- Directory credential files would be mounted at, passed as `MP_STATS_SECRETS_DIR`. Neither
-  # binary reads a secret today, so nothing is mounted and the variable is not set; the value is
-  # here for an operator adding one through `extraVolumes`.
+  # -- Directory credential files are mounted at, passed as `MP_STATS_SECRETS_DIR`. The Sentry
+  # DSN is the only credential this chart handles, so the volume and the variable both appear
+  # only while `telemetry.sentry.enabled` is set — a release that does not report to Sentry
+  # carries neither.
   secretsDir: /etc/mp-stats/secrets
 
 # @schema

--- a/charts/mp-stats-legacy-viewer/values.yaml
+++ b/charts/mp-stats-legacy-viewer/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- The container image tag, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the
   # pull, while the tag stays on as the readable version marker. Defaults to the chart's
   # `appVersion` when empty.
-  tag: v0.18.0@sha256:22aec41fcd9170a7c4799e8170700436332413728ea9c476b7d4d539d284f9fb
+  tag: v0.19.0@sha256:115f48976c6091f381668f50c8f8410b26532926c618afbb567bfbd16009adec
 
   # @schema
   # enum: ["", Always, IfNotPresent, Never]

--- a/charts/netcup-offer-bot/Chart.yaml
+++ b/charts/netcup-offer-bot/Chart.yaml
@@ -1,7 +1,7 @@
 name: netcup-offer-bot
 description: This chart deploys the Netcup Offer Bot, which monitors https://www.netcup-sonderangebote.de/ RSS feed and sends notifications to Discord webhooks when new offers are available.
-version: 5.1.3
-appVersion: v2.1.1
+version: 5.1.4
+appVersion: v3.0.0
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts
 sources:

--- a/charts/netcup-offer-bot/Chart.yaml
+++ b/charts/netcup-offer-bot/Chart.yaml
@@ -1,7 +1,7 @@
 name: netcup-offer-bot
 description: This chart deploys the Netcup Offer Bot, which monitors https://www.netcup-sonderangebote.de/ RSS feed and sends notifications to Discord webhooks when new offers are available.
-version: 5.1.3
-appVersion: v2.1.1
+version: 6.0.0
+appVersion: v3.0.0
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts
 sources:

--- a/charts/netcup-offer-bot/README.md
+++ b/charts/netcup-offer-bot/README.md
@@ -1,6 +1,6 @@
 # netcup-offer-bot
 
-![Version: 5.1.3](https://img.shields.io/badge/Version-5.1.3-informational?style=flat-square) ![AppVersion: v2.1.1](https://img.shields.io/badge/AppVersion-v2.1.1-informational?style=flat-square)
+![Version: 5.1.4](https://img.shields.io/badge/Version-5.1.4-informational?style=flat-square) ![AppVersion: v3.0.0](https://img.shields.io/badge/AppVersion-v3.0.0-informational?style=flat-square)
 
 This chart deploys the Netcup Offer Bot, which monitors https://www.netcup-sonderangebote.de/ RSS feed and sends notifications to Discord webhooks when new offers are available.
 
@@ -232,11 +232,11 @@ policy pointing at the wrong Gateway looks correct and blocks everything.
 | feed | object | `{"checkIntervalSecs":180}` | The RSS poll loop. Only the interval is configurable; which feed the bot watches is not a configuration key. |
 | feed.checkIntervalSecs | int | `180` | Seconds between two RSS feed checks (`feed.check_interval_secs`). |
 | fullnameOverride | string | `""` | Override the full generated resource name. |
-| image | object | `{"pullPolicy":"","registry":"","repository":"timmi6790/netcup-offer-bot","tag":"v2.1.1@sha256:550648f0c51c9664fb519b1e3f1e421a2cbf441ed0a96e025a34b2bcc39f12b9"}` | Container image the pod runs, composed as `registry/repository:tag`. |
+| image | object | `{"pullPolicy":"","registry":"","repository":"timmi6790/netcup-offer-bot","tag":"v3.0.0@sha256:973e861a1e546066d87520994643b0d7208c0dfafd583c2055b094caec9d1648"}` | Container image the pod runs, composed as `registry/repository:tag`. |
 | image.pullPolicy | string | `""` | The image pull policy. Empty resolves automatically from the tag/digest. |
 | image.registry | string | `""` | Registry host. Empty means Docker Hub. |
 | image.repository | string | `"timmi6790/netcup-offer-bot"` | The container image repository. |
-| image.tag | string | `"v2.1.1@sha256:550648f0c51c9664fb519b1e3f1e421a2cbf441ed0a96e025a34b2bcc39f12b9"` | The container image tag. Defaults to the chart's `appVersion` when empty. |
+| image.tag | string | `"v3.0.0@sha256:973e861a1e546066d87520994643b0d7208c0dfafd583c2055b094caec9d1648"` | The container image tag. Defaults to the chart's `appVersion` when empty. |
 | imagePullSecrets | list | `[]` | Optional image pull secrets for private registries |
 | kubeVersionOverride | string | `""` | Kubernetes version to target when branching on API availability. Lets `helm template` render for a specific cluster version without a live connection. |
 | metrics | object | `{"enabled":false,"ip":"0.0.0.0","podMonitor":{"enabled":true,"interval":"1m","labels":{},"scrapeTimeout":"30s"},"port":9184}` | The Prometheus exporter and the PodMonitor that scrapes it. The bot binds no metrics listener at all until `enabled` is set. |

--- a/charts/netcup-offer-bot/README.md
+++ b/charts/netcup-offer-bot/README.md
@@ -1,6 +1,6 @@
 # netcup-offer-bot
 
-![Version: 5.1.3](https://img.shields.io/badge/Version-5.1.3-informational?style=flat-square) ![AppVersion: v2.1.1](https://img.shields.io/badge/AppVersion-v2.1.1-informational?style=flat-square)
+![Version: 6.0.0](https://img.shields.io/badge/Version-6.0.0-informational?style=flat-square) ![AppVersion: v3.0.0](https://img.shields.io/badge/AppVersion-v3.0.0-informational?style=flat-square)
 
 This chart deploys the Netcup Offer Bot, which monitors https://www.netcup-sonderangebote.de/ RSS feed and sends notifications to Discord webhooks when new offers are available.
 
@@ -12,6 +12,7 @@ offers; everything else is defaults.
 - Kubernetes 1.19+
 - Helm 3.0+
 - A Discord webhook URL
+- A Sentry DSN, if `telemetry.sentry.enabled` is set
 - The Prometheus Operator CRDs, if `metrics.podMonitor` is enabled
 - Cilium 1.16+, if `networkPolicy.engine` is `cilium` or `both`
 
@@ -29,36 +30,40 @@ helm install [RELEASE_NAME] timschoenle/netcup-offer-bot \
 Upgrade with `helm upgrade [RELEASE_NAME] timschoenle/netcup-offer-bot -n [NAMESPACE]`,
 remove with `helm uninstall [RELEASE_NAME] -n [NAMESPACE]`.
 
-## Keeping the webhook out of the release
+## Keeping the credentials out of the release
 
-`discord.webhookUrl` is written into a Secret, but it still passes through `values.yaml` and
-stays readable in the Helm release object afterwards. Point `existingSecret` at a Secret you
-created yourself to avoid both:
+`discord.webhookUrl` and `telemetry.sentry.dsn` are written into a Secret, but they still pass
+through `values.yaml` and stay readable in the Helm release object afterwards. Point
+`existingSecret` at a Secret you created yourself to avoid both:
 
 ```shell
-kubectl create secret generic netcup-webhook   --namespace [NAMESPACE]   --from-literal=discord__webhook_url='https://discord.com/api/webhooks/...'
+kubectl create secret generic netcup-webhook   --namespace [NAMESPACE]   --from-literal=discord__webhook_url='https://discord.com/api/webhooks/...'   --from-literal=telemetry__sentry__dsn='https://<key>@<host>/<project>'
 ```
 
 ```yaml
 existingSecret: netcup-webhook
 ```
 
-**The key name is the configuration path the bot reads, not a free-form name.** The webhook
-arrives as a file in a projected volume and the bot takes the key out of the file *name*, so
-`discord__webhook_url` is required; a Secret spelled any other way mounts cleanly, supplies
-nothing, and the bot refuses to boot naming the missing credential.
+**The key names are the configuration paths the bot reads, not free-form names.** Each
+credential arrives as a file in a projected volume and the bot takes the key out of the file
+*name*, so `discord__webhook_url` and `telemetry__sentry__dsn` are the required spellings; a
+Secret spelled any other way mounts cleanly, supplies nothing, and the bot refuses to boot
+naming the missing credential.
 
-`discord.webhookUrl` is then ignored.
+`discord.webhookUrl` and `telemetry.sentry.dsn` are then ignored. Only the keys the release
+actually uses need to be present: the DSN is projected only while `telemetry.sentry.enabled` is
+set, so a Secret for a release that does not report to Sentry carries the webhook alone.
 
 ## Configuration
 
 Everything the bot reads is rendered into one `config.toml`, mounted as a ConfigMap and pointed
-at by `NETCUP_OFFER_BOT_CONFIG`; the webhook is mounted separately as a file under
-`NETCUP_OFFER_BOT_SECRETS_DIR`. Nothing is passed as an environment variable, and that is
-deliberate on two counts: the loader **fails the boot on a key supplied by both the environment
-and a file** rather than resolving it by precedence, and an environment variable is visible in
-`kubectl describe pod`, in `/proc/<pid>/environ` and in the environment of every child process
-— which for a webhook URL is exactly the exposure worth removing.
+at by `NETCUP_OFFER_BOT_CONFIG`; the credentials — the Discord webhook, and the Sentry DSN when
+that is switched on — are mounted separately as files under `NETCUP_OFFER_BOT_SECRETS_DIR`.
+Nothing is passed as an environment variable, and that is deliberate on two counts: the loader
+**fails the boot on a key supplied by both the environment and a file** rather than resolving it
+by precedence, and an environment variable is visible in `kubectl describe pod`, in
+`/proc/<pid>/environ` and in the environment of every child process — which for a webhook URL is
+exactly the exposure worth removing.
 
 The values above cover the whole documented surface. `config` takes the raw TOML tree for
 anything they do not, merged over the derived one, and `configExtraToml` is appended verbatim
@@ -102,10 +107,86 @@ Without a matching label the PodMonitor is created and never read.
 nothing from outside the container — a PodMonitor pointed at that would scrape a refused
 connection.
 
-`telemetry.sentryDsn` additionally routes application errors to Sentry; leave it empty to keep
-the bot's egress to Discord and the netcup feed only.
+## Error reporting and tracing
+
+`telemetry.sentry` reports errors and panics to Sentry, and can record traces of the poll loop.
+It is off, and inert while it is off: no client, no panic hook and no layer is installed, so
+nothing leaves the process and nothing about a rendered release changes.
+
+```yaml
+telemetry:
+  sentry:
+    enabled: true
+    dsn: https://<key>@<host>/<project>
+    tracesSampleRate: 0.1
+```
+
+The DSN embeds a write key for the project's event stream, so the chart treats it as the
+credential it is: it goes to the Secret under `telemetry__sentry__dsn`, never into the
+ConfigMap. Switching the feature on with no DSN — neither here nor in an `existingSecret` — is
+refused at render time, because the bot refuses to boot rather than installing a client that
+reports nowhere, and a rejected `helm upgrade` beats a CrashLoopBackOff.
+
+**Check the egress.** The chart never reads the DSN, so it cannot name the ingest host in the
+network policies. The defaults do cover it — `networkPolicy.egress.https` permits TCP/443 to
+`0.0.0.0/0` minus private space — so an out-of-the-box release reaches Sentry without further
+work. A release that narrowed `networkPolicy.egress.cidr`, turned `egress.https` off, or
+replaced the CIDR rule with `networkPolicy.cilium.egress.toFQDNs` has to name the endpoint
+itself. Getting that wrong is silent: an SDK that cannot reach its endpoint queues events and
+then discards them, so the project simply stays empty, which reads as "no errors".
+
+```yaml
+networkPolicy:
+  enabled: true
+  extraEgress:
+    - to:
+        - ipBlock:
+            cidr: 34.120.195.249/32 # your ingest endpoint
+      ports:
+        - port: 443
+          protocol: TCP
+```
+
+Under the Cilium engine the same destination is better expressed by name, via
+`networkPolicy.cilium.egress.toFQDNs`.
+
+`environment`, `release` and `serverName` are empty by default and the chart writes none of
+them: the bot sends `production` (or `development` from a debug build) and the version the
+binary was built from, and the second is what makes a regression attributable to a deploy. A
+blank value is a *supplied* value to the loader, not an absent one, so set them only to say
+something the bot cannot derive.
+
+`telemetry.sentry` is installed once as the process boots, so a change to it is a restart rather
+than a reload — which for this chart is the ordinary behaviour anyway, since it keeps the
+`checksum/*` pod annotations.
 
 ## Upgrading
+
+### 5.x to 6.0
+
+Chart 6.0 tracks the bot's 3.0 release, which replaced the single `telemetry.sentry_dsn` key
+with a full `telemetry.sentry` block — twelve settings and the DSN — and made Sentry an optional
+compile-time feature. `telemetry.sentryDsn` is gone; a `helm upgrade` with 5.x values fails
+schema validation naming the key rather than silently dropping error reporting.
+
+| Before | After |
+|---|---|
+| `telemetry.sentryDsn: https://...` | `telemetry.sentry.enabled: true` **and** `telemetry.sentry.dsn: https://...` |
+| (unset) | (unset — `telemetry.sentry.enabled` defaults to `false`) |
+
+Two behaviours changed along with the spelling:
+
+- **The DSN is a credential now.** 5.x rendered it into `config.toml`, where anything that can
+  read the namespace could print it. It goes to the Secret instead, under
+  `telemetry__sentry__dsn` — so an `existingSecret` that should carry it needs that key added,
+  and the pod projects it only while `telemetry.sentry.enabled` is set.
+- **The switch is separate from the DSN.** Setting one without the other is refused at render
+  time in both directions: on with no DSN is a boot failure upstream, and a DSN with the switch
+  off is a credential in the release that nothing reads.
+
+Everything else under the block is new and optional; the defaults reproduce 5.x behaviour apart
+from `tracesSampleRate`, which is `0.0` here against the `0.2` the old build hard-coded. Set it
+explicitly if you were relying on those traces.
 
 ### 4.x to 5.0
 
@@ -225,7 +306,7 @@ policy pointing at the wrong Gateway looks correct and blocks everything.
 | configMount.secretsDir | string | `"/etc/netcup-offer-bot/secrets"` | Directory the credential file is mounted at, passed as `NETCUP_OFFER_BOT_SECRETS_DIR`. |
 | discord | object | `{"webhookUrl":""}` | Where the offers are posted. The webhook is a bearer credential, so it is rendered into the Secret and the render fails when neither it nor `existingSecret` supplies one. |
 | discord.webhookUrl | string | `""` | Discord webhook the offers are posted to (`discord.webhook_url`). Rendered into the chart's Secret and mounted as a file rather than passed as an environment variable, so it never appears in `kubectl describe pod` or in the environment of a child process. Required unless `existingSecret` supplies it. |
-| existingSecret | string | `""` | Name of an existing Secret holding the Discord webhook, which keeps it out of `values.yaml` and out of the Helm release object. **Its key is the configuration path, not a free-form name**: `discord__webhook_url`, because the file name is what the loader parses. Set, the chart renders no Secret of its own and `discord.webhookUrl` is ignored. |
+| existingSecret | string | `""` | Name of an existing Secret holding the bot's credentials, which keeps them out of `values.yaml` and out of the Helm release object. **Its keys are configuration paths, not free-form names**: `discord__webhook_url` and, once `telemetry.sentry.enabled` is set, `telemetry__sentry__dsn` — because the file name is what the loader parses. Set, the chart renders no Secret of its own and `discord.webhookUrl` / `telemetry.sentry.dsn` are ignored. |
 | extraEnv | list | `[]` | Additional environment variables for the application container. |
 | extraVolumeMounts | list | `[]` | Additional volume mounts added to the application container. |
 | extraVolumes | list | `[]` | Additional volumes added to the pod. |
@@ -331,9 +412,22 @@ policy pointing at the wrong Gateway looks correct and blocks everything.
 | serviceAccount.create | bool | `true` | Whether to create a dedicated service account |
 | serviceAccount.name | string | `""` | Custom service account name (auto-generated if empty) |
 | strategy | object | `{}` | Deployment update strategy. Empty uses the Kubernetes default rolling update. |
-| telemetry | object | `{"logLevel":"INFO","sentryDsn":""}` | Logging and error reporting, rendered under `telemetry` in `config.toml`. |
+| telemetry | object | `{"logLevel":"INFO","sentry":{"attachStacktraces":true,"breadcrumbLevel":"info","captureLevel":"error","debug":false,"dsn":"","enabled":false,"environment":"","maxBreadcrumbs":100,"release":"","sampleRate":1,"serverName":"","shutdownTimeoutSecs":2,"tracesSampleRate":0}}` | Logging and error reporting. `log_level` is rendered under `telemetry` in `config.toml`; the Sentry DSN is a credential and goes to the Secret instead. Both are read once as the process boots rather than re-read from the mount, so a change here needs a restart — `configMount.rolloutOnChange` is what turns one into a rollout. |
 | telemetry.logLevel | string | `"INFO"` | Log level (`telemetry.log_level`). |
-| telemetry.sentryDsn | string | `""` | Sentry DSN (`telemetry.sentry_dsn`). Empty disables Sentry entirely. |
+| telemetry.sentry | object | `{"attachStacktraces":true,"breadcrumbLevel":"info","captureLevel":"error","debug":false,"dsn":"","enabled":false,"environment":"","maxBreadcrumbs":100,"release":"","sampleRate":1,"serverName":"","shutdownTimeoutSecs":2,"tracesSampleRate":0}` | Sentry error reporting and tracing. **Off**, and wholly inert while it is: no client, no panic hook and no layer is installed, and nothing leaves the process.  Two things the chart deliberately does not do for you. It never reads the DSN, so it cannot name the ingest host in the NetworkPolicies. The defaults do happen to cover it — `networkPolicy.egress.https` permits TCP/443 to `0.0.0.0/0` minus private space — but a deployment that narrowed `networkPolicy.egress.cidr`, turned `egress.https` off, or replaced the CIDR rule with `networkPolicy.cilium.egress.toFQDNs` has to name the endpoint itself, and getting that wrong is silent: an SDK that cannot reach its endpoint queues events and then discards them, so the project stays empty, which reads as "no errors". And it configures nothing inside Sentry — the project, its quota and its server-side data-scrubbing rules are yours. |
+| telemetry.sentry.attachStacktraces | bool | `true` | Attach a stack trace to events that carry none of their own (`telemetry.sentry.attach_stacktraces`). |
+| telemetry.sentry.breadcrumbLevel | string | `"info"` | Least severe `tracing` level kept as a breadcrumb, the trail attached to the next issue (`telemetry.sentry.breadcrumb_level`). Records at or above `captureLevel` become issues instead. Independent of `logLevel` on purpose: the trail keeps being collected however quiet stdout is. Quote `"off"`. |
+| telemetry.sentry.captureLevel | string | `"error"` | Least severe `tracing` level reported as a Sentry issue (`telemetry.sentry.capture_level`). Quote `"off"` — unquoted, YAML reads it as the boolean `false`. This one sits *under* the subscriber's own filter, so a record `logLevel` drops never reaches Sentry either. |
+| telemetry.sentry.debug | bool | `false` | Print the SDK's own diagnostics to stderr (`telemetry.sentry.debug`). For proving a DSN works, not for running. |
+| telemetry.sentry.dsn | string | `""` | Ingest URL, `https://<key>@<host>/<project>`. A credential — the embedded key is a bearer token for the project's ingest endpoint — so it is delivered as a file in `NETCUP_OFFER_BOT_SECRETS_DIR` under `telemetry__sentry__dsn` and never written into the ConfigMap. Leave it empty and put that key in the Secret named by `existingSecret` to keep it out of `helm get values` entirely. |
+| telemetry.sentry.enabled | bool | `false` | Initialise the Sentry client (`telemetry.sentry.enabled`). Off, every other key here is inert. On, the bot refuses to boot without a DSN rather than starting with a reporter that reports nowhere, so this and `dsn` are set together. |
+| telemetry.sentry.environment | string | `""` | Environment tag on every event (`telemetry.sentry.environment`). Empty lets the bot send `production`, or `development` from a debug build. |
+| telemetry.sentry.maxBreadcrumbs | int | `100` | How many breadcrumbs one event carries (`telemetry.sentry.max_breadcrumbs`). |
+| telemetry.sentry.release | string | `""` | Release tag on every event (`telemetry.sentry.release`). Empty uses the version the binary was built from, which is what makes a regression attributable to a deploy and what the image's debug files are indexed under — set this only to match a release you create in Sentry under a name of your own. |
+| telemetry.sentry.sampleRate | float | `1` | Fraction of captured events actually sent (`telemetry.sentry.sample_rate`). A blunt volume cap — it drops whole issues, not repetitions of one — so leave it at `1` unless a quota forces otherwise. |
+| telemetry.sentry.serverName | string | `""` | Host tag on every event (`telemetry.sentry.server_name`). Empty reports none, which is the right answer here: the value would be one pod's generated name, not anything an operator chose. |
+| telemetry.sentry.shutdownTimeoutSecs | int | `2` | How long process exit waits for queued events to drain (`telemetry.sentry.shutdown_timeout_secs`). It is the only flush this process performs, and it is spent on every pod shutdown, so keep it well inside `terminationGracePeriodSeconds`. |
+| telemetry.sentry.tracesSampleRate | float | `0` | Fraction of traces that are recorded (`telemetry.sentry.traces_sample_rate`). `0` records none, and nothing hands this process a trace to continue, so at `0` no spans are built at all — which is what makes the feature free to switch on for error reporting alone. `0.05`-`0.2` is an ordinary production figure. |
 | terminationGracePeriodSeconds | int | `30` | Grace period for pod shutdown. |
 | tolerations | list | `[]` | Tolerations for pod assignment. |
 | topologySpreadConstraints | list | `[]` | Pod topology spread constraints for availability |

--- a/charts/netcup-offer-bot/README.md
+++ b/charts/netcup-offer-bot/README.md
@@ -313,11 +313,11 @@ policy pointing at the wrong Gateway looks correct and blocks everything.
 | feed | object | `{"checkIntervalSecs":180}` | The RSS poll loop. Only the interval is configurable; which feed the bot watches is not a configuration key. |
 | feed.checkIntervalSecs | int | `180` | Seconds between two RSS feed checks (`feed.check_interval_secs`). |
 | fullnameOverride | string | `""` | Override the full generated resource name. |
-| image | object | `{"pullPolicy":"","registry":"","repository":"timmi6790/netcup-offer-bot","tag":"v2.1.1@sha256:550648f0c51c9664fb519b1e3f1e421a2cbf441ed0a96e025a34b2bcc39f12b9"}` | Container image the pod runs, composed as `registry/repository:tag`. |
+| image | object | `{"pullPolicy":"","registry":"","repository":"timmi6790/netcup-offer-bot","tag":"v3.0.0@sha256:973e861a1e546066d87520994643b0d7208c0dfafd583c2055b094caec9d1648"}` | Container image the pod runs, composed as `registry/repository:tag`. |
 | image.pullPolicy | string | `""` | The image pull policy. Empty resolves automatically from the tag/digest. |
 | image.registry | string | `""` | Registry host. Empty means Docker Hub. |
 | image.repository | string | `"timmi6790/netcup-offer-bot"` | The container image repository. |
-| image.tag | string | `"v2.1.1@sha256:550648f0c51c9664fb519b1e3f1e421a2cbf441ed0a96e025a34b2bcc39f12b9"` | The container image tag. Defaults to the chart's `appVersion` when empty. |
+| image.tag | string | `"v3.0.0@sha256:973e861a1e546066d87520994643b0d7208c0dfafd583c2055b094caec9d1648"` | The container image tag. Defaults to the chart's `appVersion` when empty. |
 | imagePullSecrets | list | `[]` | Optional image pull secrets for private registries |
 | kubeVersionOverride | string | `""` | Kubernetes version to target when branching on API availability. Lets `helm template` render for a specific cluster version without a live connection. |
 | metrics | object | `{"enabled":false,"ip":"0.0.0.0","podMonitor":{"enabled":true,"interval":"1m","labels":{},"scrapeTimeout":"30s"},"port":9184}` | The Prometheus exporter and the PodMonitor that scrapes it. The bot binds no metrics listener at all until `enabled` is set. |

--- a/charts/netcup-offer-bot/README.md.gotmpl
+++ b/charts/netcup-offer-bot/README.md.gotmpl
@@ -14,6 +14,7 @@ offers; everything else is defaults.
 - Kubernetes 1.19+
 - Helm 3.0+
 - A Discord webhook URL
+- A Sentry DSN, if `telemetry.sentry.enabled` is set
 - The Prometheus Operator CRDs, if `metrics.podMonitor` is enabled
 - Cilium 1.16+, if `networkPolicy.engine` is `cilium` or `both`
 
@@ -31,36 +32,40 @@ helm install [RELEASE_NAME] timschoenle/{{ template "chart.name" . }} \
 Upgrade with `helm upgrade [RELEASE_NAME] timschoenle/{{ template "chart.name" . }} -n [NAMESPACE]`,
 remove with `helm uninstall [RELEASE_NAME] -n [NAMESPACE]`.
 
-## Keeping the webhook out of the release
+## Keeping the credentials out of the release
 
-`discord.webhookUrl` is written into a Secret, but it still passes through `values.yaml` and
-stays readable in the Helm release object afterwards. Point `existingSecret` at a Secret you
-created yourself to avoid both:
+`discord.webhookUrl` and `telemetry.sentry.dsn` are written into a Secret, but they still pass
+through `values.yaml` and stay readable in the Helm release object afterwards. Point
+`existingSecret` at a Secret you created yourself to avoid both:
 
 ```shell
-kubectl create secret generic netcup-webhook   --namespace [NAMESPACE]   --from-literal=discord__webhook_url='https://discord.com/api/webhooks/...'
+kubectl create secret generic netcup-webhook   --namespace [NAMESPACE]   --from-literal=discord__webhook_url='https://discord.com/api/webhooks/...'   --from-literal=telemetry__sentry__dsn='https://<key>@<host>/<project>'
 ```
 
 ```yaml
 existingSecret: netcup-webhook
 ```
 
-**The key name is the configuration path the bot reads, not a free-form name.** The webhook
-arrives as a file in a projected volume and the bot takes the key out of the file *name*, so
-`discord__webhook_url` is required; a Secret spelled any other way mounts cleanly, supplies
-nothing, and the bot refuses to boot naming the missing credential.
+**The key names are the configuration paths the bot reads, not free-form names.** Each
+credential arrives as a file in a projected volume and the bot takes the key out of the file
+*name*, so `discord__webhook_url` and `telemetry__sentry__dsn` are the required spellings; a
+Secret spelled any other way mounts cleanly, supplies nothing, and the bot refuses to boot
+naming the missing credential.
 
-`discord.webhookUrl` is then ignored.
+`discord.webhookUrl` and `telemetry.sentry.dsn` are then ignored. Only the keys the release
+actually uses need to be present: the DSN is projected only while `telemetry.sentry.enabled` is
+set, so a Secret for a release that does not report to Sentry carries the webhook alone.
 
 ## Configuration
 
 Everything the bot reads is rendered into one `config.toml`, mounted as a ConfigMap and pointed
-at by `NETCUP_OFFER_BOT_CONFIG`; the webhook is mounted separately as a file under
-`NETCUP_OFFER_BOT_SECRETS_DIR`. Nothing is passed as an environment variable, and that is
-deliberate on two counts: the loader **fails the boot on a key supplied by both the environment
-and a file** rather than resolving it by precedence, and an environment variable is visible in
-`kubectl describe pod`, in `/proc/<pid>/environ` and in the environment of every child process
-— which for a webhook URL is exactly the exposure worth removing.
+at by `NETCUP_OFFER_BOT_CONFIG`; the credentials — the Discord webhook, and the Sentry DSN when
+that is switched on — are mounted separately as files under `NETCUP_OFFER_BOT_SECRETS_DIR`.
+Nothing is passed as an environment variable, and that is deliberate on two counts: the loader
+**fails the boot on a key supplied by both the environment and a file** rather than resolving it
+by precedence, and an environment variable is visible in `kubectl describe pod`, in
+`/proc/<pid>/environ` and in the environment of every child process — which for a webhook URL is
+exactly the exposure worth removing.
 
 The values above cover the whole documented surface. `config` takes the raw TOML tree for
 anything they do not, merged over the derived one, and `configExtraToml` is appended verbatim
@@ -104,10 +109,86 @@ Without a matching label the PodMonitor is created and never read.
 nothing from outside the container — a PodMonitor pointed at that would scrape a refused
 connection.
 
-`telemetry.sentryDsn` additionally routes application errors to Sentry; leave it empty to keep
-the bot's egress to Discord and the netcup feed only.
+## Error reporting and tracing
+
+`telemetry.sentry` reports errors and panics to Sentry, and can record traces of the poll loop.
+It is off, and inert while it is off: no client, no panic hook and no layer is installed, so
+nothing leaves the process and nothing about a rendered release changes.
+
+```yaml
+telemetry:
+  sentry:
+    enabled: true
+    dsn: https://<key>@<host>/<project>
+    tracesSampleRate: 0.1
+```
+
+The DSN embeds a write key for the project's event stream, so the chart treats it as the
+credential it is: it goes to the Secret under `telemetry__sentry__dsn`, never into the
+ConfigMap. Switching the feature on with no DSN — neither here nor in an `existingSecret` — is
+refused at render time, because the bot refuses to boot rather than installing a client that
+reports nowhere, and a rejected `helm upgrade` beats a CrashLoopBackOff.
+
+**Check the egress.** The chart never reads the DSN, so it cannot name the ingest host in the
+network policies. The defaults do cover it — `networkPolicy.egress.https` permits TCP/443 to
+`0.0.0.0/0` minus private space — so an out-of-the-box release reaches Sentry without further
+work. A release that narrowed `networkPolicy.egress.cidr`, turned `egress.https` off, or
+replaced the CIDR rule with `networkPolicy.cilium.egress.toFQDNs` has to name the endpoint
+itself. Getting that wrong is silent: an SDK that cannot reach its endpoint queues events and
+then discards them, so the project simply stays empty, which reads as "no errors".
+
+```yaml
+networkPolicy:
+  enabled: true
+  extraEgress:
+    - to:
+        - ipBlock:
+            cidr: 34.120.195.249/32 # your ingest endpoint
+      ports:
+        - port: 443
+          protocol: TCP
+```
+
+Under the Cilium engine the same destination is better expressed by name, via
+`networkPolicy.cilium.egress.toFQDNs`.
+
+`environment`, `release` and `serverName` are empty by default and the chart writes none of
+them: the bot sends `production` (or `development` from a debug build) and the version the
+binary was built from, and the second is what makes a regression attributable to a deploy. A
+blank value is a *supplied* value to the loader, not an absent one, so set them only to say
+something the bot cannot derive.
+
+`telemetry.sentry` is installed once as the process boots, so a change to it is a restart rather
+than a reload — which for this chart is the ordinary behaviour anyway, since it keeps the
+`checksum/*` pod annotations.
 
 ## Upgrading
+
+### 5.x to 6.0
+
+Chart 6.0 tracks the bot's 3.0 release, which replaced the single `telemetry.sentry_dsn` key
+with a full `telemetry.sentry` block — twelve settings and the DSN — and made Sentry an optional
+compile-time feature. `telemetry.sentryDsn` is gone; a `helm upgrade` with 5.x values fails
+schema validation naming the key rather than silently dropping error reporting.
+
+| Before | After |
+|---|---|
+| `telemetry.sentryDsn: https://...` | `telemetry.sentry.enabled: true` **and** `telemetry.sentry.dsn: https://...` |
+| (unset) | (unset — `telemetry.sentry.enabled` defaults to `false`) |
+
+Two behaviours changed along with the spelling:
+
+- **The DSN is a credential now.** 5.x rendered it into `config.toml`, where anything that can
+  read the namespace could print it. It goes to the Secret instead, under
+  `telemetry__sentry__dsn` — so an `existingSecret` that should carry it needs that key added,
+  and the pod projects it only while `telemetry.sentry.enabled` is set.
+- **The switch is separate from the DSN.** Setting one without the other is refused at render
+  time in both directions: on with no DSN is a boot failure upstream, and a DSN with the switch
+  off is a credential in the release that nothing reads.
+
+Everything else under the block is new and optional; the defaults reproduce 5.x behaviour apart
+from `tracesSampleRate`, which is `0.0` here against the `0.2` the old build hard-coded. Set it
+explicitly if you were relying on those traces.
 
 ### 4.x to 5.0
 

--- a/charts/netcup-offer-bot/ci/sentry.yaml
+++ b/charts/netcup-offer-bot/ci/sentry.yaml
@@ -1,0 +1,45 @@
+# Sentry switched on, with the egress rule that makes it reach anything.
+#
+# A render fixture, not an install fixture: the DSN points at a host that does not exist. `ct
+# install` takes every `ci/*-values.yaml`, while the render and policy jobs glob `ci/*.yaml`.
+#
+# Every key is set away from its default on purpose. The chart writes the whole block through to
+# one document, so a fixture that left the defaults in place would render the same `config.toml`
+# whether the mapping were right or reversed.
+#
+# `networkPolicy` is here for the half of this feature the chart cannot derive. The DSN is a
+# credential, so the chart never reads it and cannot name the ingest host. The defaults would
+# already reach it — `egress.https` permits TCP/443 to `0.0.0.0/0` minus private space — so the
+# fixture renders the *explicit* form instead, which is what a deployment that narrowed
+# `egress.cidr` or turned `egress.https` off has to write for itself. It names a CIDR because
+# the portable dialect cannot express a hostname; `ci/cilium.yaml` is where `toFQDNs` is
+# exercised.
+discord:
+  webhookUrl: https://discord.com/api/webhooks/000000000000000000/ci-render-fixture
+
+telemetry:
+  logLevel: DEBUG
+  sentry:
+    enabled: true
+    dsn: https://ci0123456789abcdef@sentry.example.com/42
+    environment: ci
+    release: netcup-offer-bot@3.0.0
+    serverName: ci-render-fixture
+    sampleRate: 0.5
+    tracesSampleRate: 0.2
+    captureLevel: warn
+    breadcrumbLevel: debug
+    maxBreadcrumbs: 50
+    attachStacktraces: false
+    shutdownTimeoutSecs: 5
+    debug: true
+
+networkPolicy:
+  enabled: true
+  extraEgress:
+    - to:
+        - ipBlock:
+            cidr: 34.120.195.249/32
+      ports:
+        - port: 443
+          protocol: TCP

--- a/charts/netcup-offer-bot/config-contract.yaml
+++ b/charts/netcup-offer-bot/config-contract.yaml
@@ -20,22 +20,25 @@ bindings: true
 # Chart-level: a key nothing surfaces is unsurfaced in every document that declares it, and this
 # chart declares one. `documents:` narrows an entry where that is untrue.
 #
-# Secret keys are not exempt by default, and this chart is why the rule was refused:
-# `telemetry.sentry_dsn` is `secret: true` in the same contract *and* is projected into
-# `config.toml` by `telemetry.sentryDsn`. A blanket "credentials need no marker" would have
-# written off a key this chart binds, and the gate would then stop noticing if that projection
-# were dropped. Each key is written out.
+# Secret keys are not exempt by default, and each one is written out. The blanket rule
+# "credentials need no marker" was refused because it cannot tell a key delivered as a file from
+# a key a chart merely forgot: both look identical from the contract's side, and the second is
+# exactly the regression this gate exists to catch. Naming them one by one costs a line and
+# keeps the gate honest — a chart that stopped projecting one would go red rather than quiet.
 unbound:
   - keys:
       - discord.webhook_url
+      - telemetry.sentry.dsn
     reason: >-
-      Delivered as a file in the secrets directory — from the Secret this chart renders, or
-      from `existingSecret` under the file name `discord__webhook_url` — and never written
-      into `config.toml`, because a bearer credential in a ConfigMap is readable by anything
-      that can read the namespace. `discord.webhookUrl` is the value that carries it, so the
-      binding does exist; it simply does not run through the configuration document the
-      markers describe. `just check-config-secrets` is what reconciles that channel, and it
-      does it from the rendered manifests rather than from a comment.
+      Delivered as files in the secrets directory — from the Secret this chart renders, or
+      from `existingSecret` under the file names `discord__webhook_url` and
+      `telemetry__sentry__dsn` — and never written into `config.toml`, because a bearer
+      credential in a ConfigMap is readable by anything that can read the namespace. The DSN
+      embeds an ingest key and is one. `discord.webhookUrl` and `telemetry.sentry.dsn` are the
+      values that carry them, so both bindings exist; they simply do not run through the
+      configuration document the markers describe. `just check-config-secrets` is what
+      reconciles that channel, and it does it from the rendered manifests rather than from a
+      comment.
 
 documents:
   - name: bot

--- a/charts/netcup-offer-bot/contracts/bot.json
+++ b/charts/netcup-offer-bot/contracts/bot.json
@@ -1,15 +1,15 @@
 {
   "source": {
     "image": "docker.io/timmi6790/netcup-offer-bot",
-    "digest": "sha256:550648f0c51c9664fb519b1e3f1e421a2cbf441ed0a96e025a34b2bcc39f12b9",
-    "sha256": "ffcbd241d5a60239bc128077d21ee4cfc1a8d8e3abd7a062f05dbf2b0f942f7b",
-    "fetched": "2026-08-19T12:22:26Z"
+    "digest": "sha256:973e861a1e546066d87520994643b0d7208c0dfafd583c2055b094caec9d1648",
+    "sha256": "ea61fe2e73bae5de2b3083a69b25f825c7103b52742083f137d3c81f98ceba9b",
+    "fetched": "2026-08-26T13:56:35Z"
   },
   "contract": {
     "terrace_contract": 1,
     "app": {
       "name": "netcup-offer-bot",
-      "version": "v2.1.1",
+      "version": "v3.0.0",
       "source": "https://github.com/TimSchoenle/netcup-offer-bot"
     },
     "schema": {
@@ -39,7 +39,7 @@
           "env": "NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL",
           "env_file": "NETCUP_OFFER_BOT_DISCORD__WEBHOOK_URL_FILE",
           "secrets_file": "discord__webhook_url",
-          "docs": "Discord webhook the offers are posted to.\n\nSecret: it is a bearer credential — anyone holding it can post to the channel — so it\nstays wrapped from the layer that read it to the request that uses it. `SecretString`\nrefuses to implement `Serialize` for that reason, which is why the field is skipped on\nthe way out; the key keeps its row and its `secret` flag either way, and a required key\nhas no default to print.",
+          "docs": "Discord webhook the offers are posted to.\n\nA bearer credential: anyone holding it can post to the channel. It stays wrapped from the\nlayer that read it to the request that uses it, so nothing between the two can print it.",
           "ty": "SecretString",
           "values": [],
           "constraint": {
@@ -158,11 +158,38 @@
           "reserved": false
         },
         {
-          "path": "telemetry.sentry_dsn",
-          "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY_DSN",
-          "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY_DSN_FILE",
-          "secrets_file": "telemetry__sentry_dsn",
-          "docs": "Sentry DSN. Unset disables Sentry entirely.\n\nSecret: a DSN is a write credential for the project's event stream, and skipped on the\nway out for the reason [`DiscordConfig::webhook_url`] is. The key still reports itself\nas unset by default, which is the whole of what a table can usefully say about an\noptional secret.",
+          "path": "telemetry.sentry.enabled",
+          "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__ENABLED",
+          "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__ENABLED_FILE",
+          "secrets_file": "telemetry__sentry__enabled",
+          "docs": "Initialise the Sentry client. `false` installs no client, no panic hook and no layer, so\nevery other key here is inert and nothing leaves the process.\n\nSet on a binary built with `--no-default-features` it fails the boot: that build carries\nno client to install, and starting anyway would be the silent no-op this key exists to\navoid.",
+          "ty": "bool",
+          "values": [],
+          "constraint": {
+            "type": "boolean"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(true|false)\\s*$",
+            "type": "string"
+          },
+          "text_form": "boolean",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "false",
+          "default_value": false,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.dsn",
+          "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__DSN",
+          "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__DSN_FILE",
+          "secrets_file": "telemetry__sentry__dsn",
+          "docs": "Ingest URL, `https://<key>@<host>/<project>`. Required once `enabled` is set.\n\nA write credential for the project's event stream, wrapped for the reason\n[`DiscordConfig::webhook_url`](super::DiscordConfig::webhook_url) is. Empty is treated as\nabsent rather than as a malformed URL, because an unfilled chart value and a compose\npass-through both produce an empty string and neither is a typo in a DSN.",
           "ty": "SecretString",
           "values": [],
           "constraint": {
@@ -179,6 +206,315 @@
           "required": false,
           "secret": true,
           "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.environment",
+          "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__ENVIRONMENT",
+          "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__ENVIRONMENT_FILE",
+          "secrets_file": "telemetry__sentry__environment",
+          "docs": "Environment tag on every event. Defaults to `production`, or `development` for a debug\nbuild.\n\nAlways sent, never left for the SDK to fill in. `sentry::init` otherwise reads\n`SENTRY_ENVIRONMENT` from the process environment — a second configuration channel that\nbypasses the layered loader, its shadow-key rejection and the contract, whose external\nsurface says this image reads nothing outside the loader's namespace.",
+          "ty": "String",
+          "values": [],
+          "constraint": {
+            "type": "string"
+          },
+          "text_form": "text",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": null,
+          "default_value": null,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.release",
+          "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__RELEASE",
+          "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__RELEASE_FILE",
+          "secrets_file": "telemetry__sentry__release",
+          "docs": "Release tag on every event. Defaults to the version the binary was built from.\n\nSet explicitly for the same reason [`Self::environment`] is, and this is the field that\nmakes a regression attributable to a deploy. The default is what\n`sentry::release_name!` reads out of the build, which is what the image's debug-file\nupload names the symbols under.",
+          "ty": "String",
+          "values": [],
+          "constraint": {
+            "type": "string"
+          },
+          "text_form": "text",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": null,
+          "default_value": null,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.server_name",
+          "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__SERVER_NAME",
+          "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__SERVER_NAME_FILE",
+          "secrets_file": "telemetry__sentry__server_name",
+          "docs": "Host tag on every event. Unset, Sentry reports none.\n\nThe hostname of a replica is infrastructure detail, and a pod's is a generated string\nthat changes on every restart, so it is worth a tag only where a deployment has a\nstable name to give it.",
+          "ty": "String",
+          "values": [],
+          "constraint": {
+            "type": "string"
+          },
+          "text_form": "text",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": null,
+          "default_value": null,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.sample_rate",
+          "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__SAMPLE_RATE",
+          "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__SAMPLE_RATE_FILE",
+          "secrets_file": "telemetry__sentry__sample_rate",
+          "docs": "Fraction of captured events actually sent, `0.0`–`1.0`.\n\nA blunt volume cap: it drops whole issues rather than repetitions of one, so leave it at\n`1.0` unless a quota forces otherwise.",
+          "ty": "f32",
+          "values": [],
+          "constraint": {
+            "type": "number"
+          },
+          "text_form": "unknown",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "1",
+          "default_value": 1.0,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.traces_sample_rate",
+          "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__TRACES_SAMPLE_RATE",
+          "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__TRACES_SAMPLE_RATE_FILE",
+          "secrets_file": "telemetry__sentry__traces_sample_rate",
+          "docs": "Fraction of traces that are recorded, `0.0`–`1.0`. `0.0` records none.\n\nThis process starts every trace it has — nothing hands it one — so at `0.0` no spans are\nbuilt at all rather than built and dropped by the sampler. `0.05`–`0.2` is an ordinary\nproduction figure; the previous hard-coded value was `0.2`.",
+          "ty": "f32",
+          "values": [],
+          "constraint": {
+            "type": "number"
+          },
+          "text_form": "unknown",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "0",
+          "default_value": 0.0,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.capture_level",
+          "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__CAPTURE_LEVEL",
+          "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__CAPTURE_LEVEL_FILE",
+          "secrets_file": "telemetry__sentry__capture_level",
+          "docs": "Least severe `tracing` level reported as a Sentry issue: `off`, `error`, `warn`, `info`,\n`debug` or `trace`.",
+          "ty": "SentryLevel",
+          "values": [
+            "off",
+            "error",
+            "warn",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "constraint": {
+            "enum": [
+              "off",
+              "error",
+              "warn",
+              "info",
+              "debug",
+              "trace"
+            ],
+            "type": "string"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(off|error|warn|info|debug|trace)\\s*$",
+            "type": "string"
+          },
+          "text_form": "choice",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "error",
+          "default_value": "error",
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.breadcrumb_level",
+          "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__BREADCRUMB_LEVEL",
+          "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__BREADCRUMB_LEVEL_FILE",
+          "secrets_file": "telemetry__sentry__breadcrumb_level",
+          "docs": "Least severe `tracing` level kept as a breadcrumb — the trail attached to the next issue.\n\nRecords at or above [`Self::capture_level`] become issues instead. Independent of\n[`log_level`](super::TelemetryConfig::log_level) on purpose: the layer keeps collecting\nthe trail however quiet stdout is, so an issue raised from an `ERROR` still arrives with\nthe round that led to it attached.",
+          "ty": "SentryLevel",
+          "values": [
+            "off",
+            "error",
+            "warn",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "constraint": {
+            "enum": [
+              "off",
+              "error",
+              "warn",
+              "info",
+              "debug",
+              "trace"
+            ],
+            "type": "string"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(off|error|warn|info|debug|trace)\\s*$",
+            "type": "string"
+          },
+          "text_form": "choice",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "info",
+          "default_value": "info",
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.max_breadcrumbs",
+          "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__MAX_BREADCRUMBS",
+          "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__MAX_BREADCRUMBS_FILE",
+          "secrets_file": "telemetry__sentry__max_breadcrumbs",
+          "docs": "How many breadcrumbs one event carries.",
+          "ty": "usize",
+          "values": [],
+          "constraint": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*\\+?[0-9]+\\s*$",
+            "type": "string"
+          },
+          "text_form": "integer",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "100",
+          "default_value": 100,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.attach_stacktraces",
+          "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__ATTACH_STACKTRACES",
+          "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__ATTACH_STACKTRACES_FILE",
+          "secrets_file": "telemetry__sentry__attach_stacktraces",
+          "docs": "Attach a stack trace to events that carry none of their own.",
+          "ty": "bool",
+          "values": [],
+          "constraint": {
+            "type": "boolean"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(true|false)\\s*$",
+            "type": "string"
+          },
+          "text_form": "boolean",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "true",
+          "default_value": true,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.shutdown_timeout_secs",
+          "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__SHUTDOWN_TIMEOUT_SECS",
+          "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__SHUTDOWN_TIMEOUT_SECS_FILE",
+          "secrets_file": "telemetry__sentry__shutdown_timeout_secs",
+          "docs": "How long process exit waits for queued events to drain.\n\nThe only flush this process performs, and it happens when the guard `main` holds is\ndropped. A container stopped with a short grace period loses whatever is still queued\npast this window.",
+          "ty": "u64",
+          "values": [],
+          "constraint": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*\\+?[0-9]+\\s*$",
+            "type": "string"
+          },
+          "text_form": "integer",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "2",
+          "default_value": 2,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.debug",
+          "env": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__DEBUG",
+          "env_file": "NETCUP_OFFER_BOT_TELEMETRY__SENTRY__DEBUG_FILE",
+          "secrets_file": "telemetry__sentry__debug",
+          "docs": "Print the SDK's own diagnostics to stderr. For proving a DSN works, not for running.",
+          "ty": "bool",
+          "values": [],
+          "constraint": {
+            "type": "boolean"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(true|false)\\s*$",
+            "type": "string"
+          },
+          "text_form": "boolean",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "false",
+          "default_value": false,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
         }
       ]
     },
@@ -190,7 +526,7 @@
           "additionalProperties": false,
           "properties": {
             "webhook_url": {
-              "description": "Discord webhook the offers are posted to.\n\nSecret: it is a bearer credential — anyone holding it can post to the channel — so it\nstays wrapped from the layer that read it to the request that uses it. `SecretString`\nrefuses to implement `Serialize` for that reason, which is why the field is skipped on\nthe way out; the key keeps its row and its `secret` flag either way, and a required key\nhas no default to print.",
+              "description": "Discord webhook the offers are posted to.\n\nA bearer credential: anyone holding it can post to the channel. It stays wrapped from the\nlayer that read it to the request that uses it, so nothing between the two can print it.",
               "type": "string",
               "writeOnly": true
             }
@@ -233,10 +569,91 @@
               "default": "INFO",
               "description": "The maximum verbosity that reaches stdout: `TRACE`, `DEBUG`, `INFO`, `WARN` or `ERROR`,\nin any case.\n\nParsed at boot so an unusable value fails the load rather than the first log line.\n`DEBUG` and `TRACE` additionally print which layer supplied each configuration key."
             },
-            "sentry_dsn": {
-              "description": "Sentry DSN. Unset disables Sentry entirely.\n\nSecret: a DSN is a write credential for the project's event stream, and skipped on the\nway out for the reason [`DiscordConfig::webhook_url`] is. The key still reports itself\nas unset by default, which is the whole of what a table can usefully say about an\noptional secret.",
-              "type": "string",
-              "writeOnly": true
+            "sentry": {
+              "additionalProperties": false,
+              "properties": {
+                "attach_stacktraces": {
+                  "default": true,
+                  "description": "Attach a stack trace to events that carry none of their own.",
+                  "type": "boolean"
+                },
+                "breadcrumb_level": {
+                  "default": "info",
+                  "description": "Least severe `tracing` level kept as a breadcrumb — the trail attached to the next issue.\n\nRecords at or above [`Self::capture_level`] become issues instead. Independent of\n[`log_level`](super::TelemetryConfig::log_level) on purpose: the layer keeps collecting\nthe trail however quiet stdout is, so an issue raised from an `ERROR` still arrives with\nthe round that led to it attached.",
+                  "enum": [
+                    "off",
+                    "error",
+                    "warn",
+                    "info",
+                    "debug",
+                    "trace"
+                  ],
+                  "type": "string"
+                },
+                "capture_level": {
+                  "default": "error",
+                  "description": "Least severe `tracing` level reported as a Sentry issue: `off`, `error`, `warn`, `info`,\n`debug` or `trace`.",
+                  "enum": [
+                    "off",
+                    "error",
+                    "warn",
+                    "info",
+                    "debug",
+                    "trace"
+                  ],
+                  "type": "string"
+                },
+                "debug": {
+                  "default": false,
+                  "description": "Print the SDK's own diagnostics to stderr. For proving a DSN works, not for running.",
+                  "type": "boolean"
+                },
+                "dsn": {
+                  "description": "Ingest URL, `https://<key>@<host>/<project>`. Required once `enabled` is set.\n\nA write credential for the project's event stream, wrapped for the reason\n[`DiscordConfig::webhook_url`](super::DiscordConfig::webhook_url) is. Empty is treated as\nabsent rather than as a malformed URL, because an unfilled chart value and a compose\npass-through both produce an empty string and neither is a typo in a DSN.",
+                  "type": "string",
+                  "writeOnly": true
+                },
+                "enabled": {
+                  "default": false,
+                  "description": "Initialise the Sentry client. `false` installs no client, no panic hook and no layer, so\nevery other key here is inert and nothing leaves the process.\n\nSet on a binary built with `--no-default-features` it fails the boot: that build carries\nno client to install, and starting anyway would be the silent no-op this key exists to\navoid.",
+                  "type": "boolean"
+                },
+                "environment": {
+                  "description": "Environment tag on every event. Defaults to `production`, or `development` for a debug\nbuild.\n\nAlways sent, never left for the SDK to fill in. `sentry::init` otherwise reads\n`SENTRY_ENVIRONMENT` from the process environment — a second configuration channel that\nbypasses the layered loader, its shadow-key rejection and the contract, whose external\nsurface says this image reads nothing outside the loader's namespace.",
+                  "type": "string"
+                },
+                "max_breadcrumbs": {
+                  "default": 100,
+                  "description": "How many breadcrumbs one event carries.",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "release": {
+                  "description": "Release tag on every event. Defaults to the version the binary was built from.\n\nSet explicitly for the same reason [`Self::environment`] is, and this is the field that\nmakes a regression attributable to a deploy. The default is what\n`sentry::release_name!` reads out of the build, which is what the image's debug-file\nupload names the symbols under.",
+                  "type": "string"
+                },
+                "sample_rate": {
+                  "default": 1.0,
+                  "description": "Fraction of captured events actually sent, `0.0`–`1.0`.\n\nA blunt volume cap: it drops whole issues rather than repetitions of one, so leave it at\n`1.0` unless a quota forces otherwise.",
+                  "type": "number"
+                },
+                "server_name": {
+                  "description": "Host tag on every event. Unset, Sentry reports none.\n\nThe hostname of a replica is infrastructure detail, and a pod's is a generated string\nthat changes on every restart, so it is worth a tag only where a deployment has a\nstable name to give it.",
+                  "type": "string"
+                },
+                "shutdown_timeout_secs": {
+                  "default": 2,
+                  "description": "How long process exit waits for queued events to drain.\n\nThe only flush this process performs, and it happens when the guard `main` holds is\ndropped. A container stopped with a short grace period loses whatever is still queued\npast this window.",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "traces_sample_rate": {
+                  "default": 0.0,
+                  "description": "Fraction of traces that are recorded, `0.0`–`1.0`. `0.0` records none.\n\nThis process starts every trace it has — nothing hands it one — so at `0.0` no spans are\nbuilt at all rather than built and dropped by the sampler. `0.05`–`0.2` is an ordinary\nproduction figure; the previous hard-coded value was `0.2`.",
+                  "type": "number"
+                }
+              },
+              "type": "object"
             }
           },
           "type": "object"

--- a/charts/netcup-offer-bot/templates/_helpers.tpl
+++ b/charts/netcup-offer-bot/templates/_helpers.tpl
@@ -19,17 +19,41 @@ The configuration the chart derives from its own first-class values, as the TOML
 reads.
 
 `metrics` is emitted only when the exporter is on: written unconditionally it would bind a
-listener no PodMonitor scrapes and no Service exposes. Optional keys are omitted rather than
-written empty — an empty `telemetry.sentry_dsn` is a *supplied* value to the loader, and
-"Sentry configured with a blank DSN" is not what an operator who left it unset meant.
+listener no PodMonitor scrapes and no Service exposes. `telemetry.sentry` follows the same rule
+for a stronger reason — every key under it is inert while the switch is off, so writing the
+block unconditionally would put twelve settings that do nothing into the document an operator
+reads to find out what the bot is doing.
+
+Optional keys inside the block are omitted rather than written empty: an empty
+`telemetry.sentry.environment` is a *supplied* value to the loader, and "reported with a blank
+environment tag" is not what an operator who left it unset meant. The DSN never appears here at
+all — it is a credential, and it goes to the Secret under `telemetry__sentry__dsn`.
 */}}
 {{- define "netcup-offer-bot.derivedConfig" -}}
 feed:
   check_interval_secs: {{ .Values.feed.checkIntervalSecs }}
 telemetry:
   log_level: {{ .Values.telemetry.logLevel | quote }}
-  {{- with .Values.telemetry.sentryDsn }}
-  sentry_dsn: {{ . | quote }}
+  {{- if .Values.telemetry.sentry.enabled }}
+  sentry:
+    enabled: true
+    {{- with .Values.telemetry.sentry.environment }}
+    environment: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.telemetry.sentry.release }}
+    release: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.telemetry.sentry.serverName }}
+    server_name: {{ . | quote }}
+    {{- end }}
+    sample_rate: {{ .Values.telemetry.sentry.sampleRate }}
+    traces_sample_rate: {{ .Values.telemetry.sentry.tracesSampleRate }}
+    capture_level: {{ .Values.telemetry.sentry.captureLevel | quote }}
+    breadcrumb_level: {{ .Values.telemetry.sentry.breadcrumbLevel | quote }}
+    max_breadcrumbs: {{ .Values.telemetry.sentry.maxBreadcrumbs }}
+    attach_stacktraces: {{ .Values.telemetry.sentry.attachStacktraces }}
+    shutdown_timeout_secs: {{ .Values.telemetry.sentry.shutdownTimeoutSecs }}
+    debug: {{ .Values.telemetry.sentry.debug }}
   {{- end }}
 {{- if .Values.metrics.enabled }}
 metrics:
@@ -58,12 +82,20 @@ The complete `config.toml`: the effective tree, then the verbatim escape hatch.
 {{- end -}}
 
 {{/*
-The credential this chart manages, keyed by the file name the loader reads it from: a
+The credentials this chart manages, keyed by the file name the loader reads them from: a
 configuration path with `__` for nesting and no dots, because a `.` in the name is refused
 rather than treated as a separator.
+
+The Sentry DSN appears only while the switch is on. Listed unconditionally it would survive into
+`netcup-offer-bot.secretKeys` under an `existingSecret` — which cannot be read from here, so
+every key the chart knows about is projected — and the pod would mount a file for a client it
+never installs.
 */}}
 {{- define "netcup-offer-bot.secretData" -}}
 discord__webhook_url: {{ .Values.discord.webhookUrl | quote }}
+{{- if .Values.telemetry.sentry.enabled }}
+telemetry__sentry__dsn: {{ .Values.telemetry.sentry.dsn | quote }}
+{{- end }}
 {{- end -}}
 
 {{/*
@@ -75,14 +107,33 @@ The secret file names this pod projects, as a YAML list. Parse with `fromYamlArr
 {{- end -}}
 
 {{/*
-Refuse a render that could only produce a bot with nowhere to post.
+Refuse a render that could only produce a bot with nowhere to post, and the two Sentry
+combinations that are certainly not what was meant.
 
-Checked against the projected key list rather than against `.Values.discord.webhookUrl`, so an
-`existingSecret` counts — the chart cannot see inside one, and a webhook it cannot see is not
-the same as a webhook that is missing.
+The webhook is checked against the projected key list rather than against
+`.Values.discord.webhookUrl`, so an `existingSecret` counts — the chart cannot see inside one,
+and a webhook it cannot see is not the same as a webhook that is missing. The DSN is checked the
+same way and for the same reason: upstream refuses to boot when the switch is on and no DSN
+resolves, so the case this chart can see offline is caught before the rollout rather than after
+it.
+
+The converse is the ordinary dead-value check: a DSN set while the switch is off is neither
+projected into the pod nor written into the Secret, so it would sit in the release meaning
+nothing — and a DSN is a credential to leave lying around.
 */}}
 {{- define "netcup-offer-bot.validateValues" -}}
-{{- if not (include "netcup-offer-bot.secretKeys" .) -}}
-{{- fail (printf "\n\nVALUES VALIDATION FAILED for chart %q:\n  - discord.webhookUrl is required unless existingSecret supplies `discord__webhook_url`\n" .Chart.Name) -}}
+{{- $messages := list -}}
+{{- if not (has "discord__webhook_url" (include "netcup-offer-bot.secretKeys" . | fromYamlArray)) -}}
+{{- $messages = append $messages "  - discord.webhookUrl is required unless existingSecret supplies `discord__webhook_url`" -}}
+{{- end -}}
+{{- $sentry := .Values.telemetry.sentry -}}
+{{- if and $sentry.enabled (not $sentry.dsn) (not .Values.existingSecret) -}}
+{{- $messages = append $messages "  - telemetry.sentry.enabled is set but no DSN is available. The bot refuses to boot rather than installing a client that reports nowhere, so this is a CrashLoopBackOff, not a degraded feature. Set `telemetry.sentry.dsn`, or put `telemetry__sentry__dsn` in the Secret named by `existingSecret`." -}}
+{{- end -}}
+{{- if and (not $sentry.enabled) $sentry.dsn -}}
+{{- $messages = append $messages "  - telemetry.sentry.dsn is set while telemetry.sentry.enabled is false. No client is installed, so the DSN is neither projected into the pod nor written into the Secret and would sit in the release meaning nothing. Set `telemetry.sentry.enabled=true`, or clear the DSN." -}}
+{{- end -}}
+{{- if $messages -}}
+{{- fail (printf "\n\nVALUES VALIDATION FAILED for chart %q:\n%s\n" .Chart.Name (join "\n" $messages)) -}}
 {{- end -}}
 {{- end -}}

--- a/charts/netcup-offer-bot/tests/configmap_test.yaml
+++ b/charts/netcup-offer-bot/tests/configmap_test.yaml
@@ -43,12 +43,13 @@ tests:
           path: data["config.toml"]
           pattern: '\[metrics\]\nip = "0\.0\.0\.0"\nport = 9184'
 
-  # An empty optional value is still a *supplied* value to the loader.
-  - it: omits an unset Sentry DSN rather than writing it empty
+  # Off has to mean *absent*, not "present and false": every key under the block is inert while
+  # the switch is down. `tests/sentry_test.yaml` is where the block itself is exercised.
+  - it: writes no Sentry block while the switch is off
     asserts:
       - notMatchRegex:
           path: data["config.toml"]
-          pattern: 'sentry_dsn'
+          pattern: 'sentry'
 
   - it: merges the raw config tree over the derived values
     set:

--- a/charts/netcup-offer-bot/tests/contract_roundtrip_bot_test.yaml
+++ b/charts/netcup-offer-bot/tests/contract_roundtrip_bot_test.yaml
@@ -8,7 +8,7 @@
 # Chart:       netcup-offer-bot
 # Declaration: charts/netcup-offer-bot/config-contract.yaml (document `bot`)
 # Contract:    charts/netcup-offer-bot/contracts/bot.json
-# Coverage:    2 of 6 contract keys carry a probe
+# Coverage:    12 of 18 contract keys carry a probe
 #
 # Regenerate with `just contract-tests`. `just check-contract-tests` fails a pull request whose
 # committed copy has drifted from the contract it was generated against.
@@ -81,6 +81,116 @@ tests:
           path: data["config.toml"]
           pattern: '(?m)^\[metrics\]$\n(?:[^\[\n][^\n]*\n|\n)*^port = 4242$'
 
+  - it: delivers telemetry.sentry.attach_stacktraces into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      discord.webhookUrl: 'https://render-prerequisite.invalid/api/webhooks/0/0'
+      config.telemetry.sentry.attach_stacktraces: false
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^attach_stacktraces = false$'
+
+  - it: delivers telemetry.sentry.breadcrumb_level into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      discord.webhookUrl: 'https://render-prerequisite.invalid/api/webhooks/0/0'
+      config.telemetry.sentry.breadcrumb_level: off
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^breadcrumb_level = "off"$'
+
+  - it: delivers telemetry.sentry.capture_level into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      discord.webhookUrl: 'https://render-prerequisite.invalid/api/webhooks/0/0'
+      config.telemetry.sentry.capture_level: off
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^capture_level = "off"$'
+
+  - it: delivers telemetry.sentry.debug into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      discord.webhookUrl: 'https://render-prerequisite.invalid/api/webhooks/0/0'
+      config.telemetry.sentry.debug: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^debug = true$'
+
+  - it: delivers telemetry.sentry.enabled into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      discord.webhookUrl: 'https://render-prerequisite.invalid/api/webhooks/0/0'
+      config.telemetry.sentry.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^enabled = true$'
+
+  - it: delivers telemetry.sentry.environment into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      discord.webhookUrl: 'https://render-prerequisite.invalid/api/webhooks/0/0'
+      config.telemetry.sentry.environment: contract-probe-telemetry-sentry-environment
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^environment = "contract-probe-telemetry-sentry-environment"$'
+
+  - it: delivers telemetry.sentry.max_breadcrumbs into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      discord.webhookUrl: 'https://render-prerequisite.invalid/api/webhooks/0/0'
+      config.telemetry.sentry.max_breadcrumbs: 4242
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^max_breadcrumbs = 4242$'
+
+  - it: delivers telemetry.sentry.release into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      discord.webhookUrl: 'https://render-prerequisite.invalid/api/webhooks/0/0'
+      config.telemetry.sentry.release: contract-probe-telemetry-sentry-release
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^release = "contract-probe-telemetry-sentry-release"$'
+
+  - it: delivers telemetry.sentry.server_name into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      discord.webhookUrl: 'https://render-prerequisite.invalid/api/webhooks/0/0'
+      config.telemetry.sentry.server_name: contract-probe-telemetry-sentry-server-name
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^server_name = "contract-probe-telemetry-sentry-server-name"$'
+
+  - it: delivers telemetry.sentry.shutdown_timeout_secs into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      discord.webhookUrl: 'https://render-prerequisite.invalid/api/webhooks/0/0'
+      config.telemetry.sentry.shutdown_timeout_secs: 4242
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^shutdown_timeout_secs = 4242$'
+
   # Contract keys carrying no case, and why. An unexplained absence is indistinguishable from an
   # oversight, so every one of them is named here rather than simply left out.
   #
@@ -90,5 +200,9 @@ tests:
   #             known-valid
   # telemetry.log_level: `unknown`: the producer publishes no constraint for this key, so no
   #                      probe can be known-valid
-  # telemetry.sentry_dsn: `secret: true`: the probe would be committed to this repository, and a
+  # telemetry.sentry.dsn: `secret: true`: the probe would be committed to this repository, and a
   #                       credential-shaped value in a test file is a credential
+  # telemetry.sentry.sample_rate: `unknown`: the producer publishes no constraint for this key,
+  #                               so no probe can be known-valid
+  # telemetry.sentry.traces_sample_rate: `unknown`: the producer publishes no constraint for
+  #                                      this key, so no probe can be known-valid

--- a/charts/netcup-offer-bot/tests/deployment_test.yaml
+++ b/charts/netcup-offer-bot/tests/deployment_test.yaml
@@ -101,6 +101,38 @@ tests:
                       - key: discord__webhook_url
                         path: discord__webhook_url
 
+  # `common.fileConfig.secretKeys` projects every key the chart knows about once an
+  # `existingSecret` is named, because it cannot read one. A DSN key listed unconditionally would
+  # therefore mount a file for a client that is never installed.
+  - it: projects no DSN key while Sentry is off
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      discord.webhookUrl: null
+      existingSecret: my-webhook-secret
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes[?(@.name == "secrets")].projected.sources[0].secret.items
+          content:
+            key: telemetry__sentry__dsn
+            path: telemetry__sentry__dsn
+
+  - it: projects the DSN key once Sentry is on
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      discord.webhookUrl: null
+      existingSecret: my-webhook-secret
+      telemetry.sentry.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes[?(@.name == "secrets")].projected.sources[0].secret.items
+          content:
+            key: telemetry__sentry__dsn
+            path: telemetry__sentry__dsn
+
   - it: mounts the state volume the bot needs to avoid re-announcing offers
     documentSelector:
       path: kind

--- a/charts/netcup-offer-bot/tests/sentry_test.yaml
+++ b/charts/netcup-offer-bot/tests/sentry_test.yaml
@@ -1,0 +1,193 @@
+# Sentry error reporting and tracing: an optional feature whose whole risk is asymmetric.
+#
+# Off, it must change nothing at all — not a key in the ConfigMap, not a key in the Secret —
+# because it is off in every release that has not asked for it. On, thirteen settings have to
+# arrive at thirteen distinct paths, and a value that lands at the wrong one is a compiled
+# default nobody chose rather than an error.
+#
+# So the suite is written around the edges: what is absent while it is off, what is present when
+# it is on, and where the DSN is allowed to appear. The assertion that the DSN never reaches the
+# ConfigMap is the one here whose failure would be a disclosure rather than a bug.
+#
+# The two pod-shape assertions live in `deployment_test.yaml` instead. A suite that lists
+# `deployment.yaml` cannot also carry a `failedTemplate` assertion — helm-unittest reports "no
+# failed document" for the whole suite — and the validation this feature adds is the half worth
+# testing.
+suite: sentry
+templates:
+  - configmap.yaml
+  - secret.yaml
+set:
+  discord.webhookUrl: https://example.invalid/hook
+tests:
+  # Off has to mean *absent*, not "present and false": every key under the block is inert while
+  # the switch is down, so writing them would put twelve settings that do nothing into the
+  # document an operator reads to find out what the bot is doing.
+  - it: writes no Sentry block at all while the switch is off
+    template: configmap.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'sentry'
+
+  - it: writes the whole block when the switch is on
+    template: configmap.yaml
+    set:
+      telemetry.sentry:
+        enabled: true
+        dsn: https://key@sentry.invalid/1
+        environment: staging
+        release: netcup-offer-bot@3.0.0
+        serverName: bot-a
+        sampleRate: 0.5
+        tracesSampleRate: 0.25
+        captureLevel: warn
+        breadcrumbLevel: debug
+        maxBreadcrumbs: 50
+        attachStacktraces: false
+        shutdownTimeoutSecs: 5
+        debug: true
+    asserts:
+      # One assertion per key, and every value set away from its default: the defect class this
+      # suite exists for is a value arriving at the wrong path, which a fixture that left the
+      # defaults in place would render identically whether the mapping were right or reversed.
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[telemetry\.sentry\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nenabled = true'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nenvironment = "staging"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nrelease = "netcup-offer-bot@3\.0\.0"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nserver_name = "bot-a"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nsample_rate = 0\.5'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\ntraces_sample_rate = 0\.25'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\ncapture_level = "warn"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nbreadcrumb_level = "debug"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nmax_breadcrumbs = 50'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nattach_stacktraces = false'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nshutdown_timeout_secs = 5'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\ndebug = true'
+
+  # An empty optional value is a *supplied* value to the loader, and "reported with a blank
+  # environment tag" is not what leaving it unset meant. These three have no chart default
+  # because the bot derives all of them.
+  - it: omits the three derived tags rather than writing them empty
+    template: configmap.yaml
+    set:
+      telemetry.sentry.enabled: true
+      telemetry.sentry.dsn: https://key@sentry.invalid/1
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'environment'
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'release'
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'server_name'
+      # The keys that do have a chart default are still written, so the document says what the
+      # bot is actually doing rather than leaving it to the struct.
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nsample_rate = 1'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\ncapture_level = "error"'
+
+  # The DSN embeds an ingest key. A ConfigMap is readable by anything that can read the
+  # namespace, so it travels the channel the Discord webhook does.
+  - it: keeps the DSN out of the ConfigMap
+    template: configmap.yaml
+    set:
+      telemetry.sentry.enabled: true
+      telemetry.sentry.dsn: https://key@sentry.invalid/1
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'dsn'
+
+  - it: writes the DSN into the Secret under the path the loader reads
+    template: secret.yaml
+    set:
+      telemetry.sentry.enabled: true
+      telemetry.sentry.dsn: https://key@sentry.invalid/1
+    asserts:
+      - equal:
+          path: stringData.telemetry__sentry__dsn
+          value: https://key@sentry.invalid/1
+
+  - it: writes no DSN key into the Secret while the switch is off
+    template: secret.yaml
+    asserts:
+      - isNull:
+          path: stringData.telemetry__sentry__dsn
+
+  # Upstream refuses to boot with the switch on and no DSN, so this is a CrashLoopBackOff rather
+  # than a degraded feature — worth catching at render time.
+  - it: refuses the switch with no DSN anywhere
+    template: configmap.yaml
+    set:
+      telemetry.sentry.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "telemetry.sentry.enabled is set but no DSN is available"
+
+  # The chart cannot see inside an `existingSecret`, and a DSN it cannot see is not the same as
+  # a DSN that is missing.
+  - it: accepts an existing Secret as the DSN it cannot see
+    template: configmap.yaml
+    set:
+      telemetry.sentry.enabled: true
+      existingSecret: my-secret
+    asserts:
+      - isKind:
+          of: ConfigMap
+
+  # The ordinary dead-value check: a credential sitting in the release meaning nothing.
+  - it: refuses a DSN set while the switch is off
+    template: configmap.yaml
+    set:
+      telemetry.sentry.dsn: https://key@sentry.invalid/1
+    asserts:
+      - failedTemplate:
+          errorPattern: "telemetry.sentry.dsn is set while telemetry.sentry.enabled is false"
+
+  # `config` is the highest-precedence layer the chart renders, so it has to be able to reach
+  # inside a block the first-class values built.
+  - it: lets the raw config tree override a derived Sentry key
+    template: configmap.yaml
+    set:
+      telemetry.sentry.enabled: true
+      telemetry.sentry.dsn: https://key@sentry.invalid/1
+      config:
+        telemetry:
+          sentry:
+            traces_sample_rate: 0.75
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\ntraces_sample_rate = 0\.75'

--- a/charts/netcup-offer-bot/values.schema.json
+++ b/charts/netcup-offer-bot/values.schema.json
@@ -1424,7 +1424,7 @@
           "type": "string"
         },
         "tag": {
-          "default": "v2.1.1@sha256:550648f0c51c9664fb519b1e3f1e421a2cbf441ed0a96e025a34b2bcc39f12b9",
+          "default": "v3.0.0@sha256:973e861a1e546066d87520994643b0d7208c0dfafd583c2055b094caec9d1648",
           "description": "The container image tag. Defaults to the chart's `appVersion` when empty.",
           "required": [],
           "title": "tag",

--- a/charts/netcup-offer-bot/values.schema.json
+++ b/charts/netcup-offer-bot/values.schema.json
@@ -1329,7 +1329,7 @@
     },
     "existingSecret": {
       "default": "",
-      "description": "Name of an existing Secret holding the Discord webhook, which keeps it out of `values.yaml`\nand out of the Helm release object. **Its key is the configuration path, not a free-form\nname**: `discord__webhook_url`, because the file name is what the loader parses. Set, the\nchart renders no Secret of its own and `discord.webhookUrl` is ignored.",
+      "description": "Name of an existing Secret holding the bot's credentials, which keeps them out of\n`values.yaml` and out of the Helm release object. **Its keys are configuration paths, not\nfree-form names**: `discord__webhook_url` and, once `telemetry.sentry.enabled` is set,\n`telemetry__sentry__dsn` — because the file name is what the loader parses. Set, the chart\nrenders no Secret of its own and `discord.webhookUrl` / `telemetry.sentry.dsn` are ignored.",
       "required": [],
       "title": "existingSecret",
       "type": "string"
@@ -2161,7 +2161,7 @@
     },
     "telemetry": {
       "additionalProperties": true,
-      "description": "Logging and error reporting, rendered under `telemetry` in `config.toml`.",
+      "description": "Logging and error reporting. `log_level` is rendered under `telemetry` in `config.toml`;\nthe Sentry DSN is a credential and goes to the Secret instead. Both are read once as the\nprocess boots rather than re-read from the mount, so a change here needs a restart —\n`configMount.rolloutOnChange` is what turns one into a rollout.",
       "properties": {
         "logLevel": {
           "default": "INFO",
@@ -2176,12 +2176,124 @@
           "required": [],
           "title": "logLevel"
         },
-        "sentryDsn": {
-          "default": "",
-          "description": "Sentry DSN (`telemetry.sentry_dsn`). Empty disables Sentry entirely.",
+        "sentry": {
+          "additionalProperties": true,
+          "description": "Sentry error reporting and tracing. **Off**, and wholly inert while it is: no client, no\npanic hook and no layer is installed, and nothing leaves the process.\n\nTwo things the chart deliberately does not do for you. It never reads the DSN, so it cannot\nname the ingest host in the NetworkPolicies. The defaults do happen to cover it —\n`networkPolicy.egress.https` permits TCP/443 to `0.0.0.0/0` minus private space — but a\ndeployment that narrowed `networkPolicy.egress.cidr`, turned `egress.https` off, or replaced\nthe CIDR rule with `networkPolicy.cilium.egress.toFQDNs` has to name the endpoint itself,\nand getting that wrong is silent: an SDK that cannot reach its endpoint queues events and\nthen discards them, so the project stays empty, which reads as \"no errors\". And it\nconfigures nothing inside Sentry — the project, its quota and its server-side data-scrubbing\nrules are yours.",
+          "properties": {
+            "attachStacktraces": {
+              "default": true,
+              "description": "Attach a stack trace to events that carry none of their own\n(`telemetry.sentry.attach_stacktraces`).",
+              "required": [],
+              "title": "attachStacktraces",
+              "type": "boolean"
+            },
+            "breadcrumbLevel": {
+              "default": "info",
+              "description": "Least severe `tracing` level kept as a breadcrumb, the trail attached to the next issue\n(`telemetry.sentry.breadcrumb_level`). Records at or above `captureLevel` become issues\ninstead. Independent of `logLevel` on purpose: the trail keeps being collected however\nquiet stdout is. Quote `\"off\"`.",
+              "enum": [
+                "off",
+                "error",
+                "warn",
+                "info",
+                "debug",
+                "trace"
+              ],
+              "required": [],
+              "title": "breadcrumbLevel"
+            },
+            "captureLevel": {
+              "default": "error",
+              "description": "Least severe `tracing` level reported as a Sentry issue\n(`telemetry.sentry.capture_level`). Quote `\"off\"` — unquoted, YAML reads it as the boolean\n`false`. This one sits *under* the subscriber's own filter, so a record `logLevel` drops\nnever reaches Sentry either.",
+              "enum": [
+                "off",
+                "error",
+                "warn",
+                "info",
+                "debug",
+                "trace"
+              ],
+              "required": [],
+              "title": "captureLevel"
+            },
+            "debug": {
+              "default": false,
+              "description": "Print the SDK's own diagnostics to stderr (`telemetry.sentry.debug`). For proving a DSN\nworks, not for running.",
+              "required": [],
+              "title": "debug",
+              "type": "boolean"
+            },
+            "dsn": {
+              "default": "",
+              "description": "Ingest URL, `https://\u003ckey\u003e@\u003chost\u003e/\u003cproject\u003e`. A credential — the embedded key is a\nbearer token for the project's ingest endpoint — so it is delivered as a file in\n`NETCUP_OFFER_BOT_SECRETS_DIR` under `telemetry__sentry__dsn` and never written into the\nConfigMap. Leave it empty and put that key in the Secret named by `existingSecret` to keep\nit out of `helm get values` entirely.",
+              "required": [],
+              "title": "dsn",
+              "type": "string"
+            },
+            "enabled": {
+              "default": false,
+              "description": "Initialise the Sentry client (`telemetry.sentry.enabled`). Off, every other key here is\ninert. On, the bot refuses to boot without a DSN rather than starting with a reporter that\nreports nowhere, so this and `dsn` are set together.",
+              "required": [],
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "environment": {
+              "default": "",
+              "description": "Environment tag on every event (`telemetry.sentry.environment`). Empty lets the bot\nsend `production`, or `development` from a debug build.",
+              "required": [],
+              "title": "environment",
+              "type": "string"
+            },
+            "maxBreadcrumbs": {
+              "default": 100,
+              "description": "How many breadcrumbs one event carries (`telemetry.sentry.max_breadcrumbs`).",
+              "minimum": 0,
+              "required": [],
+              "title": "maxBreadcrumbs",
+              "type": "integer"
+            },
+            "release": {
+              "default": "",
+              "description": "Release tag on every event (`telemetry.sentry.release`). Empty uses the version the\nbinary was built from, which is what makes a regression attributable to a deploy and what\nthe image's debug files are indexed under — set this only to match a release you create in\nSentry under a name of your own.",
+              "required": [],
+              "title": "release",
+              "type": "string"
+            },
+            "sampleRate": {
+              "default": 1,
+              "description": "Fraction of captured events actually sent (`telemetry.sentry.sample_rate`). A blunt\nvolume cap — it drops whole issues, not repetitions of one — so leave it at `1` unless a\nquota forces otherwise.",
+              "maximum": 1,
+              "minimum": 0,
+              "required": [],
+              "title": "sampleRate",
+              "type": "number"
+            },
+            "serverName": {
+              "default": "",
+              "description": "Host tag on every event (`telemetry.sentry.server_name`). Empty reports none, which is\nthe right answer here: the value would be one pod's generated name, not anything an\noperator chose.",
+              "required": [],
+              "title": "serverName",
+              "type": "string"
+            },
+            "shutdownTimeoutSecs": {
+              "default": 2,
+              "description": "How long process exit waits for queued events to drain\n(`telemetry.sentry.shutdown_timeout_secs`). It is the only flush this process performs, and\nit is spent on every pod shutdown, so keep it well inside\n`terminationGracePeriodSeconds`.",
+              "minimum": 0,
+              "required": [],
+              "title": "shutdownTimeoutSecs",
+              "type": "integer"
+            },
+            "tracesSampleRate": {
+              "default": 0,
+              "description": "Fraction of traces that are recorded (`telemetry.sentry.traces_sample_rate`). `0`\nrecords none, and nothing hands this process a trace to continue, so at `0` no spans are\nbuilt at all — which is what makes the feature free to switch on for error reporting\nalone. `0.05`-`0.2` is an ordinary production figure.",
+              "maximum": 1,
+              "minimum": 0,
+              "required": [],
+              "title": "tracesSampleRate",
+              "type": "number"
+            }
+          },
           "required": [],
-          "title": "sentryDsn",
-          "type": "string"
+          "title": "sentry"
         }
       },
       "required": [],

--- a/charts/netcup-offer-bot/values.yaml
+++ b/charts/netcup-offer-bot/values.yaml
@@ -22,7 +22,7 @@ image:
   # type: string
   # @schema
   # -- The container image tag. Defaults to the chart's `appVersion` when empty.
-  tag: v2.1.1@sha256:550648f0c51c9664fb519b1e3f1e421a2cbf441ed0a96e025a34b2bcc39f12b9
+  tag: v3.0.0@sha256:973e861a1e546066d87520994643b0d7208c0dfafd583c2055b094caec9d1648
 
   # @schema
   # enum: ["", Always, IfNotPresent, Never]

--- a/charts/netcup-offer-bot/values.yaml
+++ b/charts/netcup-offer-bot/values.yaml
@@ -68,7 +68,10 @@ feed:
 # @schema
 # additionalProperties: true
 # @schema
-# -- Logging and error reporting, rendered under `telemetry` in `config.toml`.
+# -- Logging and error reporting. `log_level` is rendered under `telemetry` in `config.toml`;
+# the Sentry DSN is a credential and goes to the Secret instead. Both are read once as the
+# process boots rather than re-read from the mount, so a change here needs a restart —
+# `configMount.rolloutOnChange` is what turns one into a rollout.
 telemetry:
   # @schema
   # # @config projection telemetry.log_level
@@ -78,19 +81,153 @@ telemetry:
   logLevel: INFO
 
   # @schema
-  # # @config projection telemetry.sentry_dsn optional
-  # type: string
+  # additionalProperties: true
   # @schema
-  # -- Sentry DSN (`telemetry.sentry_dsn`). Empty disables Sentry entirely.
-  sentryDsn: ""
+  # -- Sentry error reporting and tracing. **Off**, and wholly inert while it is: no client, no
+  # panic hook and no layer is installed, and nothing leaves the process.
+  #
+  # Two things the chart deliberately does not do for you. It never reads the DSN, so it cannot
+  # name the ingest host in the NetworkPolicies. The defaults do happen to cover it —
+  # `networkPolicy.egress.https` permits TCP/443 to `0.0.0.0/0` minus private space — but a
+  # deployment that narrowed `networkPolicy.egress.cidr`, turned `egress.https` off, or replaced
+  # the CIDR rule with `networkPolicy.cilium.egress.toFQDNs` has to name the endpoint itself,
+  # and getting that wrong is silent: an SDK that cannot reach its endpoint queues events and
+  # then discards them, so the project stays empty, which reads as "no errors". And it
+  # configures nothing inside Sentry — the project, its quota and its server-side data-scrubbing
+  # rules are yours.
+  sentry:
+    # @schema
+    # # @config projection telemetry.sentry.enabled optional
+    # type: boolean
+    # @schema
+    # -- Initialise the Sentry client (`telemetry.sentry.enabled`). Off, every other key here is
+    # inert. On, the bot refuses to boot without a DSN rather than starting with a reporter that
+    # reports nowhere, so this and `dsn` are set together.
+    enabled: false
+
+    # @schema
+    # type: string
+    # @schema
+    # -- Ingest URL, `https://<key>@<host>/<project>`. A credential — the embedded key is a
+    # bearer token for the project's ingest endpoint — so it is delivered as a file in
+    # `NETCUP_OFFER_BOT_SECRETS_DIR` under `telemetry__sentry__dsn` and never written into the
+    # ConfigMap. Leave it empty and put that key in the Secret named by `existingSecret` to keep
+    # it out of `helm get values` entirely.
+    dsn: ""
+
+    # @schema
+    # # @config projection telemetry.sentry.environment optional when telemetry.sentry.enabled
+    # type: string
+    # @schema
+    # -- Environment tag on every event (`telemetry.sentry.environment`). Empty lets the bot
+    # send `production`, or `development` from a debug build.
+    environment: ""
+
+    # @schema
+    # # @config projection telemetry.sentry.release optional when telemetry.sentry.enabled
+    # type: string
+    # @schema
+    # -- Release tag on every event (`telemetry.sentry.release`). Empty uses the version the
+    # binary was built from, which is what makes a regression attributable to a deploy and what
+    # the image's debug files are indexed under — set this only to match a release you create in
+    # Sentry under a name of your own.
+    release: ""
+
+    # @schema
+    # # @config projection telemetry.sentry.server_name optional when telemetry.sentry.enabled
+    # type: string
+    # @schema
+    # -- Host tag on every event (`telemetry.sentry.server_name`). Empty reports none, which is
+    # the right answer here: the value would be one pod's generated name, not anything an
+    # operator chose.
+    serverName: ""
+
+    # @schema
+    # # @config projection telemetry.sentry.sample_rate when telemetry.sentry.enabled
+    # type: number
+    # minimum: 0
+    # maximum: 1
+    # @schema
+    # -- Fraction of captured events actually sent (`telemetry.sentry.sample_rate`). A blunt
+    # volume cap — it drops whole issues, not repetitions of one — so leave it at `1` unless a
+    # quota forces otherwise.
+    sampleRate: 1.0
+
+    # @schema
+    # # @config projection telemetry.sentry.traces_sample_rate when telemetry.sentry.enabled
+    # type: number
+    # minimum: 0
+    # maximum: 1
+    # @schema
+    # -- Fraction of traces that are recorded (`telemetry.sentry.traces_sample_rate`). `0`
+    # records none, and nothing hands this process a trace to continue, so at `0` no spans are
+    # built at all — which is what makes the feature free to switch on for error reporting
+    # alone. `0.05`-`0.2` is an ordinary production figure.
+    tracesSampleRate: 0.0
+
+    # @schema
+    # # @config projection telemetry.sentry.capture_level when telemetry.sentry.enabled
+    # enum: ["off", error, warn, info, debug, trace]
+    # @schema
+    # -- Least severe `tracing` level reported as a Sentry issue
+    # (`telemetry.sentry.capture_level`). Quote `"off"` — unquoted, YAML reads it as the boolean
+    # `false`. This one sits *under* the subscriber's own filter, so a record `logLevel` drops
+    # never reaches Sentry either.
+    captureLevel: error
+
+    # @schema
+    # # @config projection telemetry.sentry.breadcrumb_level when telemetry.sentry.enabled
+    # enum: ["off", error, warn, info, debug, trace]
+    # @schema
+    # -- Least severe `tracing` level kept as a breadcrumb, the trail attached to the next issue
+    # (`telemetry.sentry.breadcrumb_level`). Records at or above `captureLevel` become issues
+    # instead. Independent of `logLevel` on purpose: the trail keeps being collected however
+    # quiet stdout is. Quote `"off"`.
+    breadcrumbLevel: info
+
+    # @schema
+    # # @config projection telemetry.sentry.max_breadcrumbs when telemetry.sentry.enabled
+    # type: integer
+    # minimum: 0
+    # @schema
+    # -- How many breadcrumbs one event carries (`telemetry.sentry.max_breadcrumbs`).
+    maxBreadcrumbs: 100
+
+    # @schema
+    # # @config projection telemetry.sentry.attach_stacktraces when telemetry.sentry.enabled
+    # type: boolean
+    # @schema
+    # -- Attach a stack trace to events that carry none of their own
+    # (`telemetry.sentry.attach_stacktraces`).
+    attachStacktraces: true
+
+    # @schema
+    # # @config projection telemetry.sentry.shutdown_timeout_secs when telemetry.sentry.enabled
+    # type: integer
+    # minimum: 0
+    # @schema
+    # -- How long process exit waits for queued events to drain
+    # (`telemetry.sentry.shutdown_timeout_secs`). It is the only flush this process performs, and
+    # it is spent on every pod shutdown, so keep it well inside
+    # `terminationGracePeriodSeconds`.
+    shutdownTimeoutSecs: 2
+
+    # @schema
+    # # @config projection telemetry.sentry.debug when telemetry.sentry.enabled
+    # type: boolean
+    # @schema
+    # -- Print the SDK's own diagnostics to stderr (`telemetry.sentry.debug`). For proving a DSN
+    # works, not for running.
+    debug: false
 
 # @schema
 # type: string
 # @schema
-# -- Name of an existing Secret holding the Discord webhook, which keeps it out of `values.yaml`
-# and out of the Helm release object. **Its key is the configuration path, not a free-form
-# name**: `discord__webhook_url`, because the file name is what the loader parses. Set, the
-# chart renders no Secret of its own and `discord.webhookUrl` is ignored.
+# -- Name of an existing Secret holding the bot's credentials, which keeps them out of
+# `values.yaml` and out of the Helm release object. **Its keys are configuration paths, not
+# free-form names**: `discord__webhook_url` and, once `telemetry.sentry.enabled` is set,
+# `telemetry__sentry__dsn` — because the file name is what the loader parses. Set, the chart
+# renders no Secret of its own and `discord.webhookUrl` / `telemetry.sentry.dsn` are ignored.
 existingSecret: ""
 
 # @schema

--- a/charts/portfolio/Chart.yaml
+++ b/charts/portfolio/Chart.yaml
@@ -1,7 +1,7 @@
 name: portfolio
 description: Personal portfolio built with Rust (Yew frontend, Axum server).
-version: 5.1.7
-appVersion: v2.9.0
+version: 5.2.0
+appVersion: v2.10.0
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts
 sources:

--- a/charts/portfolio/Chart.yaml
+++ b/charts/portfolio/Chart.yaml
@@ -1,7 +1,7 @@
 name: portfolio
 description: Personal portfolio built with Rust (Yew frontend, Axum server).
-version: 5.1.7
-appVersion: v2.9.0
+version: 5.1.8
+appVersion: v2.10.0
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts
 sources:

--- a/charts/portfolio/README.md
+++ b/charts/portfolio/README.md
@@ -1,6 +1,6 @@
 # portfolio
 
-![Version: 5.1.7](https://img.shields.io/badge/Version-5.1.7-informational?style=flat-square) ![AppVersion: v2.9.0](https://img.shields.io/badge/AppVersion-v2.9.0-informational?style=flat-square)
+![Version: 5.2.0](https://img.shields.io/badge/Version-5.2.0-informational?style=flat-square) ![AppVersion: v2.10.0](https://img.shields.io/badge/AppVersion-v2.10.0-informational?style=flat-square)
 
 Personal portfolio built with Rust (Yew frontend, Axum server).
 
@@ -12,6 +12,7 @@ most installs add is an Ingress.
 ## Prerequisites
 
 - Kubernetes 1.19+
+- A Sentry DSN, if `sentry.enabled` is set
 - Helm 3.0+
 - An ingress controller, if `ingress.enabled=true`
 - The Gateway API CRDs and a `Gateway` to attach to, if `gateway.enabled=true`
@@ -107,6 +108,73 @@ The server does not reload its configuration — only the loader half of the lib
 the chart keeps the conventional `checksum/config` pod annotation: a configuration change rolls
 the Deployment, which is the only way it takes effect.
 
+## Error reporting and tracing
+
+`sentry` reports errors and panics to Sentry, and can record a transaction per request. It is
+off, and inert while it is off: no client, no panic hook, no `tracing` layer and no HTTP
+middleware is installed, so nothing leaves the process and nothing about a rendered release
+changes.
+
+```yaml
+sentry:
+  enabled: true
+  dsn: https://<key>@<host>/<project>
+```
+
+Switching it on moves one thing that has nothing to do with Sentry: the server installs the log
+subscriber itself instead of leaving it to the Dioxus toolchain, because a Sentry layer has to
+be a layer *of* the subscriber and the framework's is not extensible after the fact. `logLevel`
+still decides what is printed and the format is unchanged.
+
+The DSN embeds a write key for the project's event stream, so the chart treats it as the
+credential it is: it goes to a Secret under `sentry__dsn`, never into the ConfigMap — which
+matters twice here, because the server prints the configuration it holds on the refusal path. It
+is the **only** credential this server reads, so switching Sentry on is what gives the pod a
+secrets volume and a `PORTFOLIO_SECRETS_DIR` at all; expect the pod spec to change shape, not
+just the ConfigMap. Point `existingSecret` at a Secret you created yourself to keep the DSN out
+of `values.yaml` and out of the Helm release object:
+
+```shell
+kubectl create secret generic portfolio-sentry   --namespace [NAMESPACE]   --from-literal=sentry__dsn='https://<key>@<host>/<project>'
+```
+
+```yaml
+existingSecret: portfolio-sentry
+```
+
+**The key name is the configuration path the server reads, not a free-form name.** The DSN
+arrives as a file in a projected volume and the server takes the key out of the file *name*, so
+`sentry__dsn` is required; a Secret spelled any other way mounts cleanly and supplies nothing.
+Switching the feature on with no DSN — neither inline nor in an `existingSecret` — is refused at
+render time, because the server refuses to boot rather than installing a client that reports
+nowhere, and a rejected `helm upgrade` beats a CrashLoopBackOff.
+
+**Check the egress.** The chart never reads the DSN, so it cannot name the ingest host in the
+network policies. The defaults do cover it — `networkPolicy.egress.https` permits TCP/443 to
+`0.0.0.0/0` minus private space — so an out-of-the-box release reaches Sentry without further
+work. A release that narrowed `networkPolicy.egress.cidr`, turned `egress.https` off, or
+replaced the CIDR rule with `networkPolicy.cilium.egress.toFQDNs` has to name the endpoint
+itself. Getting that wrong is silent: an SDK that cannot reach its endpoint queues events and
+then discards them, so the project simply stays empty, which reads as "no errors".
+
+**`sendDefaultPii` is the one setting to decide deliberately.** On, every event carries the
+client IP, the whole request header set including `Cookie`, and the resolved user, to a third
+party — and the same flag is what stops the HTTP middleware redacting sensitive headers. This
+site publishes a privacy page stating that no third-party service receives visitor data; that
+page is what the setting has to agree with. It is off by default.
+
+`tracesSampleRate` is `0`, which is what keeps switching Sentry on for crash reporting from also
+switching performance data on. This server is the edge and starts every trace it has — nothing
+upstream hands it one — so this rate alone decides whether a trace exists. `0.05`-`0.2` is an
+ordinary production figure.
+
+`environment`, `release` and `serverName` are empty by default and the chart writes none of
+them: the server derives the first two — `production` for the release binary every published
+image is built as, and `portfolio@<version>` from the workspace the binary was cut from, which
+is what makes a regression attributable to a deploy — and reports no host tag. A blank value is
+a *supplied* value to the loader, not an absent one, so set them only to say something the
+server cannot derive.
+
 ### What checks that the configuration is one the image accepts
 
 Nothing about the paragraphs above is enforced by Helm. `values.schema.json` describes this
@@ -177,6 +245,24 @@ positive TTL only when a *persistent* cache volume is shared across deploys — 
 `extraVolumes` mount, since the default cache lives in an `emptyDir`.
 
 ## Upgrading
+
+### 5.1 to 5.2
+
+Chart 5.2 tracks Portfolio 2.10.0, which adds optional Sentry error reporting and request
+tracing. Everything is additive and off, so an existing release needs no change.
+
+Three things are worth knowing before switching it on:
+
+- **The pod gains a secrets volume.** The DSN is the only credential this server reads, so
+  today's pods carry no secrets volume and no `PORTFOLIO_SECRETS_DIR`. Setting `sentry.enabled`
+  gives them both, and an `existingSecret` that should carry the DSN needs the key `sentry__dsn`.
+- **The log subscriber changes hands.** On, the server installs it rather than the Dioxus
+  toolchain, because a Sentry layer has to be a layer of the subscriber. `logLevel` still decides
+  what is printed and the format is unchanged.
+- **`sendDefaultPii` contradicts the privacy page if you turn it on.** The page this site
+  publishes says no third-party service receives visitor data; the key sends the client IP,
+  cookies and the resolved user to Sentry. It is off by default and this is not a default to
+  change casually.
 
 ### 4.x to 5.0
 
@@ -412,13 +498,14 @@ policy pointing at the wrong Gateway looks correct and blocks everything.
 | configExtraToml | string | `""` | Verbatim TOML appended after the rendered configuration. The escape hatch for anything the chart's TOML renderer cannot express, notably arrays of tables. |
 | configMount | object | `{"configDir":"/etc/portfolio/config","secretsDir":"/etc/portfolio/secrets"}` | Where the rendered configuration and the credential files land in the container. |
 | configMount.configDir | string | `"/etc/portfolio/config"` | Directory the rendered `config.toml` is mounted at, passed as `PORTFOLIO_CONFIG`. |
-| configMount.secretsDir | string | `"/etc/portfolio/secrets"` | Directory credential files would be mounted at, passed as `PORTFOLIO_SECRETS_DIR`. The server reads no secret today — `github.token` belongs to the build-time repository builder — so nothing is mounted and the variable is not set; the value is here for an operator adding one through `extraVolumes`. |
+| configMount.secretsDir | string | `"/etc/portfolio/secrets"` | Directory credential files are mounted at, passed as `PORTFOLIO_SECRETS_DIR`. The Sentry DSN is the only credential this server reads — `github.token` belongs to the build-time repository builder — so the volume and the variable both appear only while `sentry.enabled` is set, and a release that does not report to Sentry carries neither. |
 | csp | object | `{"cloudflare":{"scriptNonce":true,"turnstile":false,"webAnalytics":false},"hashInlineScripts":true}` | The `Content-Security-Policy` the server sends on every document. The policy itself is not configurable — it is built from the response body, hashing each inline `<script>` the document actually carries, so it cannot drift from what is sent. These keys decide only what it has to make room for. |
 | csp.cloudflare | object | `{"scriptNonce":true,"turnstile":false,"webAnalytics":false}` | Concessions to the Cloudflare products running in front of this origin. Each one widens the policy, so each is switched on only for a product that is actually in use. |
 | csp.cloudflare.scriptNonce | bool | `true` | Reserve a per-response nonce in `script-src` (`csp.cloudflare.script_nonce`) for the inline `<script>` Cloudflare's bot products — Bot Fight Mode, JavaScript Detections, the challenge platform — inject at the edge, after the server has hashed what it rendered. No hash can cover it, and without the nonce the detection is refused and silently never runs. On by default, and it carries one obligation the chart cannot enforce: **no Cloudflare Cache Rule may cache the shell**, or a single nonce is pinned across every reader for the lifetime of the cache entry. |
 | csp.cloudflare.turnstile | bool | `false` | Admit `https://challenges.cloudflare.com` in `script-src` *and* `frame-src` (`csp.cloudflare.turnstile`), for a Turnstile widget rendered in a page this server serves. Admitting only the first renders an empty box. |
 | csp.cloudflare.webAnalytics | bool | `false` | Admit the Cloudflare Web Analytics beacon and the endpoint it reports to (`csp.cloudflare.web_analytics`). For the manually embedded snippet only — the automatic edge injection is an inline script, which is what `scriptNonce` covers instead. |
 | csp.hashInlineScripts | bool | `true` | Hash the document's inline scripts (`csp.hash_inline_scripts`) instead of admitting all inline script with `'unsafe-inline'`. An escape hatch, not a preference: turning it off also requires `csp.cloudflare.scriptNonce: false`, because a browser ignores `'unsafe-inline'` as soon as the policy carries a nonce. The chart refuses the mismatched pair rather than letting the server fail its own boot. |
+| existingSecret | string | `""` | Name of an existing Secret holding the Sentry DSN, which keeps it out of `values.yaml` and out of the Helm release object. **Its key is the configuration path, not a free-form name**: `sentry__dsn`, because the file name is what the loader parses. Set, the chart renders no Secret of its own and `sentry.dsn` is ignored. It is read only while `sentry.enabled` is set — nothing else this server reads is a credential. |
 | extraEnv | list | `[]` | Additional environment variables for the application container. |
 | extraVolumeMounts | list | `[]` | Additional volume mounts added to the application container. |
 | extraVolumes | list | `[]` | Additional volumes added to the pod. |
@@ -562,6 +649,22 @@ policy pointing at the wrong Gateway looks correct and blocks everything.
 | revisionHistoryLimit | int | `3` | Number of old ReplicaSets retained for rollback. |
 | securityContext | object | `{}` | Container security context, merged over the preset. The application is a statically linked binary serving pre-built assets and needs no writable root filesystem; a writable /tmp is provided automatically via an emptyDir. |
 | securityContextPreset | string | `"restricted"` | Container security context baseline. `restricted` drops all Linux capabilities and forbids privilege escalation and a writable root filesystem. |
+| sentry | object | `{"attachStacktraces":true,"breadcrumbLevel":"info","captureLevel":"error","debug":false,"dsn":"","enabled":false,"environment":"","httpTransactions":true,"maxBreadcrumbs":100,"release":"","sampleRate":1,"sendDefaultPii":false,"serverName":"","spanAttributes":false,"tracesSampleRate":0}` | Sentry error reporting and request tracing, rendered under `sentry` in the mounted `config.toml`. **Off**, and wholly inert while it is: no client, no panic hook, no `tracing` layer and no HTTP middleware is installed, and nothing leaves the process.  Switching it on moves one thing that has nothing to do with Sentry: the server installs the log subscriber itself instead of leaving it to the Dioxus toolchain, because a Sentry layer has to be a layer *of* the subscriber and the framework's is not extensible after the fact. `logLevel` still decides what is printed and the format is unchanged.  Two things the chart deliberately does not do for you. It never reads the DSN, so it cannot name the ingest host in the NetworkPolicies. The defaults do happen to cover it — `networkPolicy.egress.https` permits TCP/443 to `0.0.0.0/0` minus private space — but a deployment that narrowed `networkPolicy.egress.cidr`, turned `egress.https` off, or replaced the CIDR rule with `networkPolicy.cilium.egress.toFQDNs` has to name the endpoint itself, and getting that wrong is silent: an SDK that cannot reach its endpoint queues events and then discards them, so the project stays empty, which reads as "no errors". And it configures nothing inside Sentry — the project, its quota and its server-side data-scrubbing rules are yours. |
+| sentry.attachStacktraces | bool | `true` | Attach a stack trace to events that carry none of their own (`sentry.attach_stacktraces`). |
+| sentry.breadcrumbLevel | string | `"info"` | Least severe `tracing` level kept as a breadcrumb, the trail attached to the next issue (`sentry.breadcrumb_level`). Records at or above `captureLevel` become issues instead, so the two thresholds partition the stream rather than overlapping on it. Quote `"off"`. |
+| sentry.captureLevel | string | `"error"` | Least severe `tracing` level reported as a Sentry issue (`sentry.capture_level`). Quote `"off"` — unquoted, YAML reads it as the boolean `false`. |
+| sentry.debug | bool | `false` | Print the SDK's own diagnostics to stderr (`sentry.debug`). For proving a DSN works, not for running. |
+| sentry.dsn | string | `""` | Ingest URL, `https://<key>@<host>/<project>`. A credential — the embedded key is a bearer token for the project's ingest endpoint, and the server prints the configuration it holds on the refusal path — so it is delivered as a file in `PORTFOLIO_SECRETS_DIR` under `sentry__dsn` and never written into the ConfigMap. It is the only credential this chart handles, and switching Sentry on is what gives the pod a secrets volume at all. Leave it empty and put that key in the Secret named by `existingSecret` to keep it out of `helm get values` entirely. |
+| sentry.enabled | bool | `false` | Initialise the Sentry client (`sentry.enabled`). Off, every other key here is inert. On, the server refuses to boot without a DSN rather than starting with a reporter that reports nowhere, so this and `dsn` are set together. |
+| sentry.environment | string | `""` | Environment tag on every event (`sentry.environment`). Empty lets the server derive it from the build profile: `production` for the release binary every published image is. Set it for anything in between, such as a staging deployment of that same image. |
+| sentry.httpTransactions | bool | `true` | Record one transaction per request, named by the matched route rather than by the URI (`sentry.http_transactions`), so `/api/repos/{name}` does not become one transaction name per repository. Whether a started transaction is kept is `tracesSampleRate`'s decision; this is the switch for taking the middleware out entirely. |
+| sentry.maxBreadcrumbs | int | `100` | How many breadcrumbs one event carries (`sentry.max_breadcrumbs`). |
+| sentry.release | string | `""` | Release tag on every event (`sentry.release`). Empty uses `portfolio@<version>`, the workspace version the binary was built from — which is what makes a regression attributable to a deploy, since every deploy of this site is a new image cut from a new version. |
+| sentry.sampleRate | float | `1` | Fraction of captured events actually sent (`sentry.sample_rate`). A blunt volume cap — it drops whole issues, not repetitions of one, so a rare bug is exactly as likely to be dropped as a noisy one — so leave it at `1` unless a quota forces otherwise. |
+| sentry.sendDefaultPii | bool | `false` | Send personally identifying data with every event: the client IP, the whole request header set — `Cookie` included — and the resolved user (`sentry.send_default_pii`). **Off, and worth leaving off.** A reader's address and cookies are not what makes a crash report actionable, and Sentry is a third party for the purposes of the privacy page this site publishes — a page that says no third-party service receives visitor data, which is a statement this one key is the way to falsify. It is two controls rather than one, besides: off is also what keeps the HTTP middleware redacting sensitive headers. |
+| sentry.serverName | string | `""` | Host tag on every event (`sentry.server_name`). Empty reports none, which is the right answer here: the value would be one replica's pod name, and this site runs one image behind a tunnel, so it identifies nothing an event does not already say. |
+| sentry.spanAttributes | bool | `false` | Copy `tracing` span fields onto the Sentry span as attributes (`sentry.span_attributes`). Off: the span fields here routinely carry request paths and the negotiated locale, and a transaction is retained for longer than a log line. |
+| sentry.tracesSampleRate | float | `0` | Fraction of request traces recorded (`sentry.traces_sample_rate`). `0` records none, which is what keeps switching Sentry on for crash reporting from also switching performance data on. This server is the edge and starts every trace it has — nothing upstream hands it one — so this rate alone decides whether a trace exists. `0.05`-`0.2` is an ordinary production figure. |
 | server | object | `{"host":"0.0.0.0","port":8080}` | The listener, which is the one part of the configuration the `PORTFOLIO_` namespace does not own: `PORT`, `IP` and `RUST_LOG` belong to the Dioxus toolchain, which reads them from the environment itself. They are therefore still passed as environment variables, and cannot be supplied through `config`. |
 | server.host | string | `"0.0.0.0"` | Bind address, passed as `IP`. |
 | server.port | int | `8080` | Bind port, passed as `PORT`. Also the container port, the Service target and what every probe and NetworkPolicy rule is written against. |

--- a/charts/portfolio/README.md
+++ b/charts/portfolio/README.md
@@ -538,11 +538,11 @@ policy pointing at the wrong Gateway looks correct and blocks everything.
 | gateway.tls.enabled | bool | `false` | Add an HTTPS listener. |
 | gateway.tls.mode | string | `"Terminate"` | TLS mode. |
 | gateway.tls.options | object | `{}` | Implementation-specific TLS options. |
-| image | object | `{"pullPolicy":"","registry":"","repository":"timschoenle/portfolio","tag":"v2.9.0@sha256:a3380c804d62ea7dcadab149079414a94aeebad99d973eed3c384f912566466d"}` | Container image the pod runs, composed as `registry/repository:tag`. |
+| image | object | `{"pullPolicy":"","registry":"","repository":"timschoenle/portfolio","tag":"v2.10.0@sha256:a6ada5d26c75bad113006bb6889edc4a5d102edf373b0f57747c3722733fd32b"}` | Container image the pod runs, composed as `registry/repository:tag`. |
 | image.pullPolicy | string | `""` | Kubernetes image pull policy. Empty resolves automatically from the tag/digest. |
 | image.registry | string | `""` | Registry host. Empty means Docker Hub. |
 | image.repository | string | `"timschoenle/portfolio"` | Container image repository where the Portfolio application image is stored. |
-| image.tag | string | `"v2.9.0@sha256:a3380c804d62ea7dcadab149079414a94aeebad99d973eed3c384f912566466d"` | Container image tag to deploy, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the pull, while the tag stays on as the readable version marker. Defaults to the chart's `appVersion` when empty. |
+| image.tag | string | `"v2.10.0@sha256:a6ada5d26c75bad113006bb6889edc4a5d102edf373b0f57747c3722733fd32b"` | Container image tag to deploy, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the pull, while the tag stays on as the readable version marker. Defaults to the chart's `appVersion` when empty. |
 | imagePullSecrets | list | `[]` | Optional image pull secrets for private registries. |
 | ingress | object | `{"annotations":{},"enabled":false,"hosts":[],"ingressClassName":"nginx","tls":[]}` | The Ingress in front of the Service. Off by default; `gateway` is the Gateway API alternative and the two are independent switches. |
 | ingress.annotations | object | `{}` | Custom annotations for the Ingress resource. Example: ```yaml annotations:   cert-manager.io/cluster-issuer: "letsencrypt-prod"   nginx.ingress.kubernetes.io/ssl-redirect: "true" ``` |

--- a/charts/portfolio/README.md.gotmpl
+++ b/charts/portfolio/README.md.gotmpl
@@ -14,6 +14,7 @@ most installs add is an Ingress.
 ## Prerequisites
 
 - Kubernetes 1.19+
+- A Sentry DSN, if `sentry.enabled` is set
 - Helm 3.0+
 - An ingress controller, if `ingress.enabled=true`
 - The Gateway API CRDs and a `Gateway` to attach to, if `gateway.enabled=true`
@@ -109,6 +110,73 @@ The server does not reload its configuration — only the loader half of the lib
 the chart keeps the conventional `checksum/config` pod annotation: a configuration change rolls
 the Deployment, which is the only way it takes effect.
 
+## Error reporting and tracing
+
+`sentry` reports errors and panics to Sentry, and can record a transaction per request. It is
+off, and inert while it is off: no client, no panic hook, no `tracing` layer and no HTTP
+middleware is installed, so nothing leaves the process and nothing about a rendered release
+changes.
+
+```yaml
+sentry:
+  enabled: true
+  dsn: https://<key>@<host>/<project>
+```
+
+Switching it on moves one thing that has nothing to do with Sentry: the server installs the log
+subscriber itself instead of leaving it to the Dioxus toolchain, because a Sentry layer has to
+be a layer *of* the subscriber and the framework's is not extensible after the fact. `logLevel`
+still decides what is printed and the format is unchanged.
+
+The DSN embeds a write key for the project's event stream, so the chart treats it as the
+credential it is: it goes to a Secret under `sentry__dsn`, never into the ConfigMap — which
+matters twice here, because the server prints the configuration it holds on the refusal path. It
+is the **only** credential this server reads, so switching Sentry on is what gives the pod a
+secrets volume and a `PORTFOLIO_SECRETS_DIR` at all; expect the pod spec to change shape, not
+just the ConfigMap. Point `existingSecret` at a Secret you created yourself to keep the DSN out
+of `values.yaml` and out of the Helm release object:
+
+```shell
+kubectl create secret generic portfolio-sentry   --namespace [NAMESPACE]   --from-literal=sentry__dsn='https://<key>@<host>/<project>'
+```
+
+```yaml
+existingSecret: portfolio-sentry
+```
+
+**The key name is the configuration path the server reads, not a free-form name.** The DSN
+arrives as a file in a projected volume and the server takes the key out of the file *name*, so
+`sentry__dsn` is required; a Secret spelled any other way mounts cleanly and supplies nothing.
+Switching the feature on with no DSN — neither inline nor in an `existingSecret` — is refused at
+render time, because the server refuses to boot rather than installing a client that reports
+nowhere, and a rejected `helm upgrade` beats a CrashLoopBackOff.
+
+**Check the egress.** The chart never reads the DSN, so it cannot name the ingest host in the
+network policies. The defaults do cover it — `networkPolicy.egress.https` permits TCP/443 to
+`0.0.0.0/0` minus private space — so an out-of-the-box release reaches Sentry without further
+work. A release that narrowed `networkPolicy.egress.cidr`, turned `egress.https` off, or
+replaced the CIDR rule with `networkPolicy.cilium.egress.toFQDNs` has to name the endpoint
+itself. Getting that wrong is silent: an SDK that cannot reach its endpoint queues events and
+then discards them, so the project simply stays empty, which reads as "no errors".
+
+**`sendDefaultPii` is the one setting to decide deliberately.** On, every event carries the
+client IP, the whole request header set including `Cookie`, and the resolved user, to a third
+party — and the same flag is what stops the HTTP middleware redacting sensitive headers. This
+site publishes a privacy page stating that no third-party service receives visitor data; that
+page is what the setting has to agree with. It is off by default.
+
+`tracesSampleRate` is `0`, which is what keeps switching Sentry on for crash reporting from also
+switching performance data on. This server is the edge and starts every trace it has — nothing
+upstream hands it one — so this rate alone decides whether a trace exists. `0.05`-`0.2` is an
+ordinary production figure.
+
+`environment`, `release` and `serverName` are empty by default and the chart writes none of
+them: the server derives the first two — `production` for the release binary every published
+image is built as, and `portfolio@<version>` from the workspace the binary was cut from, which
+is what makes a regression attributable to a deploy — and reports no host tag. A blank value is
+a *supplied* value to the loader, not an absent one, so set them only to say something the
+server cannot derive.
+
 ### What checks that the configuration is one the image accepts
 
 Nothing about the paragraphs above is enforced by Helm. `values.schema.json` describes this
@@ -179,6 +247,24 @@ positive TTL only when a *persistent* cache volume is shared across deploys — 
 `extraVolumes` mount, since the default cache lives in an `emptyDir`.
 
 ## Upgrading
+
+### 5.1 to 5.2
+
+Chart 5.2 tracks Portfolio 2.10.0, which adds optional Sentry error reporting and request
+tracing. Everything is additive and off, so an existing release needs no change.
+
+Three things are worth knowing before switching it on:
+
+- **The pod gains a secrets volume.** The DSN is the only credential this server reads, so
+  today's pods carry no secrets volume and no `PORTFOLIO_SECRETS_DIR`. Setting `sentry.enabled`
+  gives them both, and an `existingSecret` that should carry the DSN needs the key `sentry__dsn`.
+- **The log subscriber changes hands.** On, the server installs it rather than the Dioxus
+  toolchain, because a Sentry layer has to be a layer of the subscriber. `logLevel` still decides
+  what is printed and the format is unchanged.
+- **`sendDefaultPii` contradicts the privacy page if you turn it on.** The page this site
+  publishes says no third-party service receives visitor data; the key sends the client IP,
+  cookies and the resolved user to Sentry. It is off by default and this is not a default to
+  change casually.
 
 ### 4.x to 5.0
 

--- a/charts/portfolio/ci/sentry.yaml
+++ b/charts/portfolio/ci/sentry.yaml
@@ -1,0 +1,44 @@
+# Sentry switched on, with the egress rule an already-narrowed deployment would need.
+#
+# A render fixture, not an install fixture: the DSN points at a host that does not exist. `ct
+# install` takes every `ci/*-values.yaml`, while the render and policy jobs glob `ci/*.yaml`.
+#
+# Every key is set away from its default on purpose. The chart writes the whole block through to
+# one document, so a fixture that left the defaults in place would render the same `config.toml`
+# whether the mapping were right or reversed. It is also the only fixture in which this chart
+# renders a Secret and a secrets volume at all — the DSN is the single credential the server
+# reads, so every other render leaves the pod without either.
+#
+# `networkPolicy` is here for the half of this feature the chart cannot derive. The DSN is a
+# credential, so the chart never reads it and cannot name the ingest host. The defaults would
+# already reach it — `egress.https` permits TCP/443 to `0.0.0.0/0` minus private space — so the
+# fixture renders the *explicit* form instead, which is what a deployment that narrowed
+# `egress.cidr` or turned `egress.https` off has to write for itself. It names a CIDR because
+# the portable dialect cannot express a hostname; `ci/cilium.yaml` is where `toFQDNs` is
+# exercised.
+sentry:
+  enabled: true
+  dsn: https://ci0123456789abcdef@sentry.example.com/42
+  environment: ci
+  release: portfolio@2.10.0
+  serverName: ci-render-fixture
+  sampleRate: 0.5
+  tracesSampleRate: 0.2
+  captureLevel: warn
+  breadcrumbLevel: debug
+  maxBreadcrumbs: 50
+  attachStacktraces: false
+  sendDefaultPii: false
+  httpTransactions: false
+  spanAttributes: true
+  debug: true
+
+networkPolicy:
+  enabled: true
+  extraEgress:
+    - to:
+        - ipBlock:
+            cidr: 34.120.195.249/32
+      ports:
+        - port: 443
+          protocol: TCP

--- a/charts/portfolio/config-contract.yaml
+++ b/charts/portfolio/config-contract.yaml
@@ -19,12 +19,27 @@ bindings: true
 
 # Contract keys no chart value binds, each group with the reason it does not.
 #
-# None: all seven keys are bound, which is what makes this chart the simplest enrolment in the
-# tree. `server.host`, `server.port` and `logLevel` carry markers too, and are not the reason this
-# list is empty — they bind `IP`, `PORT` and `RUST_LOG`, which are `external.env` variables owned
-# by the Dioxus toolchain and by `tracing`. The coverage rule is over `schema.keys` alone, so that
-# namespace neither needs an entry here nor could be satisfied by one.
-unbound: []
+# One, and only because of where it travels. `server.host`, `server.port` and `logLevel` carry
+# markers too, and are not entries here — they bind `IP`, `PORT` and `RUST_LOG`, which are
+# `external.env` variables owned by the Dioxus toolchain and by `tracing`. The coverage rule is
+# over `schema.keys` alone, so that namespace neither needs an entry here nor could be satisfied
+# by one.
+#
+# Secret keys are not exempt by default and the one below is written out. The blanket rule
+# "credentials need no marker" cannot tell a key delivered as a file from a key a chart merely
+# forgot, and the second is exactly the regression this gate exists to catch.
+unbound:
+  - keys:
+      - sentry.dsn
+    reason: >-
+      Delivered as a file in PORTFOLIO_SECRETS_DIR — from the Secret this chart renders, or from
+      `existingSecret` under the file name `sentry__dsn` — and never written into `config.toml`,
+      because the DSN embeds a bearer key for the project's ingest endpoint and a credential in
+      a ConfigMap is readable by anything that can read the namespace. `sentry.dsn` is the value
+      that carries it, so the binding does exist; it simply does not run through the
+      configuration document the markers describe. `just check-config-secrets` is what
+      reconciles that channel, and it does it from the rendered manifests rather than from a
+      comment.
 
 documents:
   - name: server

--- a/charts/portfolio/contracts/server.json
+++ b/charts/portfolio/contracts/server.json
@@ -1,15 +1,15 @@
 {
   "source": {
     "image": "docker.io/timschoenle/portfolio",
-    "digest": "sha256:a3380c804d62ea7dcadab149079414a94aeebad99d973eed3c384f912566466d",
-    "sha256": "eb67e70ea9ec4ce1cb948a8316d018c885ff97c632008634cf3a343d84a99df6",
-    "fetched": "2026-08-25T15:03:04Z"
+    "digest": "sha256:a6ada5d26c75bad113006bb6889edc4a5d102edf373b0f57747c3722733fd32b",
+    "sha256": "e5ff18c4fa39eda7fac61e77c4113ed28e3bdd4755c08695cb67e26e337b1a5e",
+    "fetched": "2026-08-26T15:19:27Z"
   },
   "contract": {
     "terrace_contract": 1,
     "app": {
       "name": "portfolio",
-      "version": "v2.9.0",
+      "version": "v2.10.0",
       "source": "https://github.com/TimSchoenle/Portfolio"
     },
     "schema": {
@@ -215,6 +215,418 @@
           "required": false,
           "secret": false,
           "reserved": false
+        },
+        {
+          "path": "sentry.enabled",
+          "env": "PORTFOLIO_SENTRY__ENABLED",
+          "env_file": "PORTFOLIO_SENTRY__ENABLED_FILE",
+          "secrets_file": "sentry__enabled",
+          "docs": "Initialise the Sentry client. `false` installs no client, no panic hook, no `tracing`\nlayer and no HTTP middleware, so every other key here is inert and nothing leaves the\nprocess.\n\nIt also decides who owns the log subscriber. Off — the default — the Dioxus toolchain\ninstalls its own, which is the behaviour this server has always had. On, the server\ninstalls one first (still reading `RUST_LOG`, still formatting the same way) because a\nSentry layer has to be a layer *of* the subscriber, and the framework's is not\nextensible after the fact.",
+          "ty": "bool",
+          "values": [],
+          "constraint": {
+            "type": "boolean"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(true|false)\\s*$",
+            "type": "string"
+          },
+          "text_form": "boolean",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "false",
+          "default_value": false,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "sentry.dsn",
+          "env": "PORTFOLIO_SENTRY__DSN",
+          "env_file": "PORTFOLIO_SENTRY__DSN_FILE",
+          "secrets_file": "sentry__dsn",
+          "docs": "Ingest URL, `https://<key>@<host>/<project>`.\n\nThe embedded key is a bearer credential for the project's ingest endpoint, so it is held\nas a `SecretString` — this block is nested in a `ServerConfig` that is printed with `?` on\nthe refusal path. Supply it as `PORTFOLIO_SENTRY__DSN_FILE=/run/secrets/sentry_dsn`, or as\n`sentry__dsn` inside `$PORTFOLIO_SECRETS_DIR`, so it never enters the process\nenvironment — where `/proc/<pid>/environ`, a crash dump and `docker inspect` all carry\nit, and every child process inherits it.\n\nAbsent while `sentry.enabled` is set is a boot failure, not a silent no-op.",
+          "ty": "SecretString",
+          "values": [],
+          "constraint": {
+            "type": "string"
+          },
+          "text_form": "text",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": null,
+          "default_value": null,
+          "note": null,
+          "required": false,
+          "secret": true,
+          "reserved": false
+        },
+        {
+          "path": "sentry.environment",
+          "env": "PORTFOLIO_SENTRY__ENVIRONMENT",
+          "env_file": "PORTFOLIO_SENTRY__ENVIRONMENT_FILE",
+          "secrets_file": "sentry__environment",
+          "docs": "Environment tag on every event.\n\nUnset resolves to `production` for a release build and `development` otherwise, which is\nthe only distinction this workspace has: it ships one image, and the thing that separates\na developer's `dx serve` from the deployed container is the profile it was built with.",
+          "ty": "String",
+          "values": [],
+          "constraint": {
+            "type": "string"
+          },
+          "text_form": "text",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": null,
+          "default_value": null,
+          "note": "`production` in a release build, `development` otherwise",
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "sentry.release",
+          "env": "PORTFOLIO_SENTRY__RELEASE",
+          "env_file": "PORTFOLIO_SENTRY__RELEASE_FILE",
+          "secrets_file": "sentry__release",
+          "docs": "Release tag on every event.\n\nUnset resolves to `portfolio@<version>`, the workspace version the binary was built from\n— which is what makes a regression attributable to a deploy, since every deploy of this\nsite is a new image cut from a new version.",
+          "ty": "String",
+          "values": [],
+          "constraint": {
+            "type": "string"
+          },
+          "text_form": "text",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": null,
+          "default_value": null,
+          "note": "`portfolio@` and the built version",
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "sentry.server_name",
+          "env": "PORTFOLIO_SENTRY__SERVER_NAME",
+          "env_file": "PORTFOLIO_SENTRY__SERVER_NAME_FILE",
+          "secrets_file": "sentry__server_name",
+          "docs": "Host tag on every event.\n\nLeft unset, Sentry reports none. The hostname of a replica is infrastructure detail that\n`sentry.send_default_pii` would otherwise be the gate for, and this site runs one image\nbehind a tunnel, so it identifies nothing an event does not already say.",
+          "ty": "String",
+          "values": [],
+          "constraint": {
+            "type": "string"
+          },
+          "text_form": "text",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": null,
+          "default_value": null,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "sentry.sample_rate",
+          "env": "PORTFOLIO_SENTRY__SAMPLE_RATE",
+          "env_file": "PORTFOLIO_SENTRY__SAMPLE_RATE_FILE",
+          "secrets_file": "sentry__sample_rate",
+          "docs": "Fraction of captured events actually sent, `0.0`–`1.0`.\n\nA blunt volume cap: it drops whole issues rather than repetitions of one, so a rare bug\nis exactly as likely to be dropped as a noisy one. Leave it at `1.0` unless a quota\nforces otherwise.",
+          "ty": "f32",
+          "values": [],
+          "constraint": {
+            "type": "number"
+          },
+          "text_form": "unknown",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "1",
+          "default_value": 1.0,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "sentry.traces_sample_rate",
+          "env": "PORTFOLIO_SENTRY__TRACES_SAMPLE_RATE",
+          "env_file": "PORTFOLIO_SENTRY__TRACES_SAMPLE_RATE_FILE",
+          "secrets_file": "sentry__traces_sample_rate",
+          "docs": "Fraction of request traces recorded, `0.0`–`1.0`.\n\n`0.0` — the default — records none, which is what keeps switching Sentry on for crash\nreporting from also switching performance data on. `0.05`–`0.2` is an ordinary\nproduction figure.\n\nThis server starts every trace it has: it is the edge, and nothing upstream of it hands\nit a sampled trace to continue. That is the difference from a service tier, where the\nrate of whoever *starts* the trace decides whether it exists at all.",
+          "ty": "f32",
+          "values": [],
+          "constraint": {
+            "type": "number"
+          },
+          "text_form": "unknown",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "0",
+          "default_value": 0.0,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "sentry.capture_level",
+          "env": "PORTFOLIO_SENTRY__CAPTURE_LEVEL",
+          "env_file": "PORTFOLIO_SENTRY__CAPTURE_LEVEL_FILE",
+          "secrets_file": "sentry__capture_level",
+          "docs": "Least severe `tracing` level reported as a Sentry **issue**.",
+          "ty": "SentryLevel",
+          "values": [
+            "off",
+            "error",
+            "warn",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "constraint": {
+            "enum": [
+              "off",
+              "error",
+              "warn",
+              "info",
+              "debug",
+              "trace"
+            ],
+            "type": "string"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(off|error|warn|info|debug|trace)\\s*$",
+            "type": "string"
+          },
+          "text_form": "choice",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "error",
+          "default_value": "error",
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "sentry.breadcrumb_level",
+          "env": "PORTFOLIO_SENTRY__BREADCRUMB_LEVEL",
+          "env_file": "PORTFOLIO_SENTRY__BREADCRUMB_LEVEL_FILE",
+          "secrets_file": "sentry__breadcrumb_level",
+          "docs": "Least severe `tracing` level kept as a **breadcrumb**, the trail attached to the next\nissue.\n\nRecords at or above `sentry.capture_level` become issues instead, so the two thresholds\npartition the stream rather than overlapping on it.",
+          "ty": "SentryLevel",
+          "values": [
+            "off",
+            "error",
+            "warn",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "constraint": {
+            "enum": [
+              "off",
+              "error",
+              "warn",
+              "info",
+              "debug",
+              "trace"
+            ],
+            "type": "string"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(off|error|warn|info|debug|trace)\\s*$",
+            "type": "string"
+          },
+          "text_form": "choice",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "info",
+          "default_value": "info",
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "sentry.max_breadcrumbs",
+          "env": "PORTFOLIO_SENTRY__MAX_BREADCRUMBS",
+          "env_file": "PORTFOLIO_SENTRY__MAX_BREADCRUMBS_FILE",
+          "secrets_file": "sentry__max_breadcrumbs",
+          "docs": "How many breadcrumbs one event carries.",
+          "ty": "usize",
+          "values": [],
+          "constraint": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*\\+?[0-9]+\\s*$",
+            "type": "string"
+          },
+          "text_form": "integer",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "100",
+          "default_value": 100,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "sentry.attach_stacktraces",
+          "env": "PORTFOLIO_SENTRY__ATTACH_STACKTRACES",
+          "env_file": "PORTFOLIO_SENTRY__ATTACH_STACKTRACES_FILE",
+          "secrets_file": "sentry__attach_stacktraces",
+          "docs": "Attach a stack trace to events that carry none of their own.",
+          "ty": "bool",
+          "values": [],
+          "constraint": {
+            "type": "boolean"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(true|false)\\s*$",
+            "type": "string"
+          },
+          "text_form": "boolean",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "true",
+          "default_value": true,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "sentry.send_default_pii",
+          "env": "PORTFOLIO_SENTRY__SEND_DEFAULT_PII",
+          "env_file": "PORTFOLIO_SENTRY__SEND_DEFAULT_PII_FILE",
+          "secrets_file": "sentry__send_default_pii",
+          "docs": "Send personally identifying data with every event: the client IP, the full request header\nset (`Cookie` included) and the resolved user.\n\n**Off, and worth leaving off.** A reader's IP address and cookies are exactly what a\ncrash report does not need in order to be actionable, and Sentry is a third party for the\npurposes of the privacy page this site publishes — a page that currently says no\nthird-party service receives visitor data, which is a statement this key is the one way\nto falsify. On, it also widens what the HTTP middleware records, because `sentry-tower`\nreads this same flag to decide whether to redact sensitive request headers.",
+          "ty": "bool",
+          "values": [],
+          "constraint": {
+            "type": "boolean"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(true|false)\\s*$",
+            "type": "string"
+          },
+          "text_form": "boolean",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "false",
+          "default_value": false,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "sentry.http_transactions",
+          "env": "PORTFOLIO_SENTRY__HTTP_TRANSACTIONS",
+          "env_file": "PORTFOLIO_SENTRY__HTTP_TRANSACTIONS_FILE",
+          "secrets_file": "sentry__http_transactions",
+          "docs": "Record one Sentry transaction per request, named by the *matched route* rather than by\nthe URI — so `/api/repos/{name}` does not become one transaction name per repository.\n\nWhether a started transaction is *kept* is `sentry.traces_sample_rate`'s decision; this is\nthe switch for taking the middleware out entirely.",
+          "ty": "bool",
+          "values": [],
+          "constraint": {
+            "type": "boolean"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(true|false)\\s*$",
+            "type": "string"
+          },
+          "text_form": "boolean",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "true",
+          "default_value": true,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "sentry.span_attributes",
+          "env": "PORTFOLIO_SENTRY__SPAN_ATTRIBUTES",
+          "env_file": "PORTFOLIO_SENTRY__SPAN_ATTRIBUTES_FILE",
+          "secrets_file": "sentry__span_attributes",
+          "docs": "Copy `tracing` span fields onto the Sentry span as attributes.\n\nOff. Span fields here routinely carry request paths and the negotiated locale, and a\ntransaction is stored under a longer retention than a log line.",
+          "ty": "bool",
+          "values": [],
+          "constraint": {
+            "type": "boolean"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(true|false)\\s*$",
+            "type": "string"
+          },
+          "text_form": "boolean",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "false",
+          "default_value": false,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "sentry.debug",
+          "env": "PORTFOLIO_SENTRY__DEBUG",
+          "env_file": "PORTFOLIO_SENTRY__DEBUG_FILE",
+          "secrets_file": "sentry__debug",
+          "docs": "Print the SDK's own diagnostics to stderr. For proving a DSN works, not for running.",
+          "ty": "bool",
+          "values": [],
+          "constraint": {
+            "type": "boolean"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(true|false)\\s*$",
+            "type": "string"
+          },
+          "text_form": "boolean",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "false",
+          "default_value": false,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
         }
       ]
     },
@@ -277,6 +689,101 @@
               "description": "Revalidation interval in seconds. Zero means a permanent cache.\n\nEvery page renders from compile-time data, so the only thing that changes the output is a\nnew build, which starts from an empty cache anyway. A positive value opts into a finite,\ntime-based TTL, which is useful only when a *persistent* cache volume is shared across\ndeploys.\n\nDefault: permanent.",
               "minimum": 0,
               "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "sentry": {
+          "additionalProperties": false,
+          "properties": {
+            "attach_stacktraces": {
+              "default": true,
+              "description": "Attach a stack trace to events that carry none of their own.",
+              "type": "boolean"
+            },
+            "breadcrumb_level": {
+              "default": "info",
+              "description": "Least severe `tracing` level kept as a **breadcrumb**, the trail attached to the next\nissue.\n\nRecords at or above `sentry.capture_level` become issues instead, so the two thresholds\npartition the stream rather than overlapping on it.",
+              "enum": [
+                "off",
+                "error",
+                "warn",
+                "info",
+                "debug",
+                "trace"
+              ],
+              "type": "string"
+            },
+            "capture_level": {
+              "default": "error",
+              "description": "Least severe `tracing` level reported as a Sentry **issue**.",
+              "enum": [
+                "off",
+                "error",
+                "warn",
+                "info",
+                "debug",
+                "trace"
+              ],
+              "type": "string"
+            },
+            "debug": {
+              "default": false,
+              "description": "Print the SDK's own diagnostics to stderr. For proving a DSN works, not for running.",
+              "type": "boolean"
+            },
+            "dsn": {
+              "description": "Ingest URL, `https://<key>@<host>/<project>`.\n\nThe embedded key is a bearer credential for the project's ingest endpoint, so it is held\nas a `SecretString` — this block is nested in a `ServerConfig` that is printed with `?` on\nthe refusal path. Supply it as `PORTFOLIO_SENTRY__DSN_FILE=/run/secrets/sentry_dsn`, or as\n`sentry__dsn` inside `$PORTFOLIO_SECRETS_DIR`, so it never enters the process\nenvironment — where `/proc/<pid>/environ`, a crash dump and `docker inspect` all carry\nit, and every child process inherits it.\n\nAbsent while `sentry.enabled` is set is a boot failure, not a silent no-op.",
+              "type": "string",
+              "writeOnly": true
+            },
+            "enabled": {
+              "default": false,
+              "description": "Initialise the Sentry client. `false` installs no client, no panic hook, no `tracing`\nlayer and no HTTP middleware, so every other key here is inert and nothing leaves the\nprocess.\n\nIt also decides who owns the log subscriber. Off — the default — the Dioxus toolchain\ninstalls its own, which is the behaviour this server has always had. On, the server\ninstalls one first (still reading `RUST_LOG`, still formatting the same way) because a\nSentry layer has to be a layer *of* the subscriber, and the framework's is not\nextensible after the fact.",
+              "type": "boolean"
+            },
+            "environment": {
+              "description": "Environment tag on every event.\n\nUnset resolves to `production` for a release build and `development` otherwise, which is\nthe only distinction this workspace has: it ships one image, and the thing that separates\na developer's `dx serve` from the deployed container is the profile it was built with.\n\nDefault: `production` in a release build, `development` otherwise.",
+              "type": "string"
+            },
+            "http_transactions": {
+              "default": true,
+              "description": "Record one Sentry transaction per request, named by the *matched route* rather than by\nthe URI — so `/api/repos/{name}` does not become one transaction name per repository.\n\nWhether a started transaction is *kept* is `sentry.traces_sample_rate`'s decision; this is\nthe switch for taking the middleware out entirely.",
+              "type": "boolean"
+            },
+            "max_breadcrumbs": {
+              "default": 100,
+              "description": "How many breadcrumbs one event carries.",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "release": {
+              "description": "Release tag on every event.\n\nUnset resolves to `portfolio@<version>`, the workspace version the binary was built from\n— which is what makes a regression attributable to a deploy, since every deploy of this\nsite is a new image cut from a new version.\n\nDefault: `portfolio@` and the built version.",
+              "type": "string"
+            },
+            "sample_rate": {
+              "default": 1.0,
+              "description": "Fraction of captured events actually sent, `0.0`–`1.0`.\n\nA blunt volume cap: it drops whole issues rather than repetitions of one, so a rare bug\nis exactly as likely to be dropped as a noisy one. Leave it at `1.0` unless a quota\nforces otherwise.",
+              "type": "number"
+            },
+            "send_default_pii": {
+              "default": false,
+              "description": "Send personally identifying data with every event: the client IP, the full request header\nset (`Cookie` included) and the resolved user.\n\n**Off, and worth leaving off.** A reader's IP address and cookies are exactly what a\ncrash report does not need in order to be actionable, and Sentry is a third party for the\npurposes of the privacy page this site publishes — a page that currently says no\nthird-party service receives visitor data, which is a statement this key is the one way\nto falsify. On, it also widens what the HTTP middleware records, because `sentry-tower`\nreads this same flag to decide whether to redact sensitive request headers.",
+              "type": "boolean"
+            },
+            "server_name": {
+              "description": "Host tag on every event.\n\nLeft unset, Sentry reports none. The hostname of a replica is infrastructure detail that\n`sentry.send_default_pii` would otherwise be the gate for, and this site runs one image\nbehind a tunnel, so it identifies nothing an event does not already say.",
+              "type": "string"
+            },
+            "span_attributes": {
+              "default": false,
+              "description": "Copy `tracing` span fields onto the Sentry span as attributes.\n\nOff. Span fields here routinely carry request paths and the negotiated locale, and a\ntransaction is stored under a longer retention than a log line.",
+              "type": "boolean"
+            },
+            "traces_sample_rate": {
+              "default": 0.0,
+              "description": "Fraction of request traces recorded, `0.0`–`1.0`.\n\n`0.0` — the default — records none, which is what keeps switching Sentry on for crash\nreporting from also switching performance data on. `0.05`–`0.2` is an ordinary\nproduction figure.\n\nThis server starts every trace it has: it is the edge, and nothing upstream of it hands\nit a sampled trace to continue. That is the difference from a service tier, where the\nrate of whoever *starts* the trace decides whether it exists at all.",
+              "type": "number"
             }
           },
           "type": "object"

--- a/charts/portfolio/templates/_helpers.tpl
+++ b/charts/portfolio/templates/_helpers.tpl
@@ -4,6 +4,13 @@ server reads.
 
 `PORT`, `IP` and `RUST_LOG` are deliberately absent: they belong to the Dioxus toolchain, which
 reads them from the environment itself, not to the `PORTFOLIO_` namespace this file describes.
+
+`sentry` is written only while its switch is on: every key under it is inert otherwise, so
+writing the block unconditionally would put fourteen settings that do nothing into the document
+an operator reads to find out what the server is doing. Optional keys inside it are omitted
+rather than written empty — an empty `sentry.environment` is a *supplied* value to the loader,
+and "reported with a blank environment tag" is not what an operator who left it unset meant. The
+DSN never appears here at all: it is a credential and goes to the Secret under `sentry__dsn`.
 */}}
 {{- define "portfolio.derivedConfig" -}}
 assets:
@@ -17,6 +24,29 @@ csp:
 isr:
   cache_dir: {{ .Values.isr.cacheDir | quote }}
   ttl_secs: {{ .Values.isr.ttlSecs }}
+{{- if .Values.sentry.enabled }}
+sentry:
+  enabled: true
+  {{- with .Values.sentry.environment }}
+  environment: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.sentry.release }}
+  release: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.sentry.serverName }}
+  server_name: {{ . | quote }}
+  {{- end }}
+  sample_rate: {{ .Values.sentry.sampleRate }}
+  traces_sample_rate: {{ .Values.sentry.tracesSampleRate }}
+  capture_level: {{ .Values.sentry.captureLevel | quote }}
+  breadcrumb_level: {{ .Values.sentry.breadcrumbLevel | quote }}
+  max_breadcrumbs: {{ .Values.sentry.maxBreadcrumbs }}
+  attach_stacktraces: {{ .Values.sentry.attachStacktraces }}
+  send_default_pii: {{ .Values.sentry.sendDefaultPii }}
+  http_transactions: {{ .Values.sentry.httpTransactions }}
+  span_attributes: {{ .Values.sentry.spanAttributes }}
+  debug: {{ .Values.sentry.debug }}
+{{- end }}
 {{- end -}}
 
 {{/*
@@ -56,15 +86,64 @@ first-class values or through `config`. `configExtraToml` is appended verbatim a
 so a chart that has one steps out of the way rather than rejecting what it cannot see.
 */}}
 {{- define "portfolio.validateValues" -}}
+{{- $messages := list -}}
 {{- if not .Values.configExtraToml -}}
 {{- $config := include "portfolio.effectiveConfig" . | fromYaml -}}
 {{- $hashInlineScripts := $config | dig "csp" "hash_inline_scripts" true -}}
 {{- $scriptNonce := $config | dig "csp" "cloudflare" "script_nonce" true -}}
 {{- if and (not $hashInlineScripts) $scriptNonce -}}
-{{- $messages := list "  - csp.hashInlineScripts is false while csp.cloudflare.scriptNonce is true: dropping the hashes restores 'unsafe-inline', which a browser ignores as soon as the policy carries a nonce, so every document would render blank. Turn scriptNonce off as well, or leave hashInlineScripts on." -}}
+{{- $messages = append $messages "  - csp.hashInlineScripts is false while csp.cloudflare.scriptNonce is true: dropping the hashes restores 'unsafe-inline', which a browser ignores as soon as the policy carries a nonce, so every document would render blank. Turn scriptNonce off as well, or leave hashInlineScripts on." -}}
+{{- end -}}
+{{- end -}}
+{{- /*
+Sentry, checked outside the `configExtraToml` guard above.
+
+Both halves of "a reporter that reports nowhere is worse than none". Upstream refuses to boot
+with the switch on and no DSN, so that is a CrashLoopBackOff rather than a degraded feature, and
+a rejected `helm upgrade` beats one. Unlike the CSP pair, the DSN cannot arrive through
+`configExtraToml` — it is a credential and travels the Secret, not the configuration document —
+so there is nothing here the escape hatch could be supplying, and stepping out of the way would
+only hide the fault. An `existingSecret` is taken as the answer, because the chart cannot see
+inside one.
+
+The converse is the ordinary dead-value check: a DSN set while the switch is off is neither
+projected into the pod nor written into the Secret, so it would sit in the release meaning
+nothing — and a DSN is a credential to leave lying around.
+*/ -}}
+{{- if and .Values.sentry.enabled (not .Values.sentry.dsn) (not .Values.existingSecret) -}}
+{{- $messages = append $messages "  - sentry.enabled is set but no DSN is available. The server refuses to boot rather than installing a client that reports nowhere, so this is a CrashLoopBackOff, not a degraded feature. Set `sentry.dsn`, or put `sentry__dsn` in the Secret named by `existingSecret`." -}}
+{{- end -}}
+{{- if and (not .Values.sentry.enabled) .Values.sentry.dsn -}}
+{{- $messages = append $messages "  - sentry.dsn is set while sentry.enabled is false. No client is installed, so the DSN is neither projected into the pod nor written into the Secret and would sit in the release meaning nothing. Set `sentry.enabled=true`, or clear the DSN." -}}
+{{- end -}}
+{{- if $messages -}}
 {{- fail (printf "\n\nVALUES VALIDATION FAILED for chart %q:\n%s\n" .Chart.Name (join "\n" $messages)) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+The credential this chart manages, keyed by the file name the loader reads it from: a
+configuration path with `__` for nesting and no dots, because a `.` in the name is refused
+rather than treated as a separator.
+
+The Sentry DSN is the only one, and it appears only while the switch is on. Listed
+unconditionally it would survive into `portfolio.secretKeys` under an `existingSecret` — which
+cannot be read from here, so every key the chart knows about is projected — and a pod that
+reports to nothing would still carry a secrets volume and a `PORTFOLIO_SECRETS_DIR` pointing
+into it.
+*/}}
+{{- define "portfolio.secretData" -}}
+{{- if .Values.sentry.enabled }}
+sentry__dsn: {{ .Values.sentry.dsn | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
+The secret file names this pod projects, as a YAML list. Parse with `fromYamlArray`.
+*/}}
+{{- define "portfolio.secretKeys" -}}
+{{- $data := include "portfolio.secretData" . | fromYaml -}}
+{{- include "common.fileConfig.secretKeys" (dict "ctx" . "data" $data) -}}
 {{- end -}}
 
 {{/*
@@ -90,6 +169,15 @@ is legal; only the environment, the secrets directory and `_FILE` collide with o
   value: {{ .Values.logLevel | quote }}
 - name: PORTFOLIO_CONFIG
   value: {{ .Values.configMount.configDir | quote }}
+{{- /*
+Emitted only for a pod that actually mounts the secrets volume — which today means only one
+that reports to Sentry. The directory it names is not optional to the server: a configured
+secrets directory that cannot be read is a boot failure naming the path, not an empty layer.
+*/}}
+{{- if (include "portfolio.secretKeys" .) }}
+- name: PORTFOLIO_SECRETS_DIR
+  value: {{ .Values.configMount.secretsDir | quote }}
+{{- end }}
 - name: PORTFOLIO_ISR__CACHE_DIR
   value: {{ $config | dig "isr" "cache_dir" "" | quote }}
 {{- end -}}

--- a/charts/portfolio/templates/deployment.yaml
+++ b/charts/portfolio/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
           remain are the loader's own pointer, the ISR cache directory the image bakes in — see
           `portfolio.env` — and the three the Dioxus toolchain reads for itself.
         */}}
-        {{- $secretKeys := list }}
+        {{- $secretKeys := include "portfolio.secretKeys" . | fromYamlArray }}
         {{- include "common.container" (dict
               "ctx" $
               "ports" (list (dict "name" "http" "containerPort" (int .Values.server.port) "protocol" "TCP"))

--- a/charts/portfolio/templates/secret.yaml
+++ b/charts/portfolio/templates/secret.yaml
@@ -1,0 +1,24 @@
+{{- $data := include "portfolio.secretData" . | fromYaml }}
+{{- if (include "common.fileConfig.createSecret" (dict "ctx" . "data" $data)) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.fullname" . }}
+  namespace: {{ include "common.namespace" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+  {{- with (include "common.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+type: Opaque
+stringData:
+  {{- /*
+    One key, and only while Sentry is switched on: the DSN is the single credential this server
+    reads. The key name is a configuration path with `__` for nesting and no dots, because that
+    is how a file in `PORTFOLIO_SECRETS_DIR` has to be named — the loader reads the key out of
+    the file *name*. Rendered as `stringData` so the value stays readable in a diff review;
+    Kubernetes stores it base64-encoded either way.
+  */}}
+  {{- include "common.fileConfig.secretData" (dict "data" $data) | nindent 2 }}
+{{- end }}

--- a/charts/portfolio/tests/contract_roundtrip_server_test.yaml
+++ b/charts/portfolio/tests/contract_roundtrip_server_test.yaml
@@ -8,7 +8,7 @@
 # Chart:       portfolio
 # Declaration: charts/portfolio/config-contract.yaml (document `server`)
 # Contract:    charts/portfolio/contracts/server.json
-# Coverage:    7 of 7 contract keys carry a probe
+# Coverage:    19 of 22 contract keys carry a probe
 #
 # Regenerate with `just contract-tests`. `just check-contract-tests` fails a pull request whose
 # committed copy has drifted from the contract it was generated against.
@@ -127,3 +127,145 @@ tests:
       - matchRegex:
           path: data["config.toml"]
           pattern: '(?m)^\[isr\]$\n(?:[^\[\n][^\n]*\n|\n)*^ttl_secs = 4242$'
+
+  - it: delivers sentry.attach_stacktraces into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.csp.cloudflare.script_nonce: false
+      config.sentry.attach_stacktraces: false
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^attach_stacktraces = false$'
+
+  - it: delivers sentry.breadcrumb_level into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.csp.cloudflare.script_nonce: false
+      config.sentry.breadcrumb_level: off
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^breadcrumb_level = "off"$'
+
+  - it: delivers sentry.capture_level into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.csp.cloudflare.script_nonce: false
+      config.sentry.capture_level: off
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^capture_level = "off"$'
+
+  - it: delivers sentry.debug into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.csp.cloudflare.script_nonce: false
+      config.sentry.debug: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^debug = true$'
+
+  - it: delivers sentry.enabled into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.csp.cloudflare.script_nonce: false
+      config.sentry.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^enabled = true$'
+
+  - it: delivers sentry.environment into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.csp.cloudflare.script_nonce: false
+      config.sentry.environment: contract-probe-sentry-environment
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^environment = "contract-probe-sentry-environment"$'
+
+  - it: delivers sentry.http_transactions into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.csp.cloudflare.script_nonce: false
+      config.sentry.http_transactions: false
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^http_transactions = false$'
+
+  - it: delivers sentry.max_breadcrumbs into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.csp.cloudflare.script_nonce: false
+      config.sentry.max_breadcrumbs: 4242
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^max_breadcrumbs = 4242$'
+
+  - it: delivers sentry.release into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.csp.cloudflare.script_nonce: false
+      config.sentry.release: contract-probe-sentry-release
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^release = "contract-probe-sentry-release"$'
+
+  - it: delivers sentry.send_default_pii into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.csp.cloudflare.script_nonce: false
+      config.sentry.send_default_pii: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^send_default_pii = true$'
+
+  - it: delivers sentry.server_name into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.csp.cloudflare.script_nonce: false
+      config.sentry.server_name: contract-probe-sentry-server-name
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^server_name = "contract-probe-sentry-server-name"$'
+
+  - it: delivers sentry.span_attributes into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      config.csp.cloudflare.script_nonce: false
+      config.sentry.span_attributes: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^span_attributes = true$'
+
+  # Contract keys carrying no case, and why. An unexplained absence is indistinguishable from an
+  # oversight, so every one of them is named here rather than simply left out.
+  #
+  # sentry.dsn: `secret: true`: the probe would be committed to this repository, and a
+  #             credential-shaped value in a test file is a credential
+  # sentry.sample_rate: `unknown`: the producer publishes no constraint for this key, so no
+  #                     probe can be known-valid
+  # sentry.traces_sample_rate: `unknown`: the producer publishes no constraint for this key, so
+  #                            no probe can be known-valid

--- a/charts/portfolio/tests/deployment_test.yaml
+++ b/charts/portfolio/tests/deployment_test.yaml
@@ -105,9 +105,10 @@ tests:
             mountPath: /etc/portfolio/config
             readOnly: true
 
-  # The server reads no secret, so pointing it at a directory no volume provides would be a
-  # boot failure naming the path.
-  - it: names no secrets directory, because the server reads no secret
+  # The Sentry DSN is the only credential this server reads, so a release that does not report
+  # to Sentry has no secrets volume at all — and pointing the server at a directory no volume
+  # provides would be a boot failure naming the path.
+  - it: names no secrets directory while Sentry is off
     documentSelector:
       path: kind
       value: Deployment
@@ -123,6 +124,69 @@ tests:
             name: secrets
             mountPath: /etc/portfolio/secrets
             readOnly: true
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: secrets
+          any: true
+
+  - it: mounts the DSN once Sentry is on
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      sentry.enabled: true
+      sentry.dsn: https://key@sentry.example.invalid/1
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PORTFOLIO_SECRETS_DIR
+            value: /etc/portfolio/secrets
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: secrets
+            mountPath: /etc/portfolio/secrets
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: secrets
+            projected:
+              defaultMode: 256
+              sources:
+                - secret:
+                    name: RELEASE-NAME-portfolio
+                    optional: true
+                    items:
+                      - key: sentry__dsn
+                        path: sentry__dsn
+
+  # The chart cannot read an `existingSecret`, so it projects every key it knows how to consume.
+  # That list is still gated on the switch, or a release reporting nowhere would mount a file
+  # for a client it never installs.
+  - it: projects an existing Secret when one is given
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      sentry.enabled: true
+      existingSecret: my-sentry-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: secrets
+            projected:
+              defaultMode: 256
+              sources:
+                - secret:
+                    name: my-sentry-secret
+                    optional: true
+                    items:
+                      - key: sentry__dsn
+                        path: sentry__dsn
 
   - it: probes the health endpoint on all three probes
     documentSelector:

--- a/charts/portfolio/tests/sentry_test.yaml
+++ b/charts/portfolio/tests/sentry_test.yaml
@@ -1,0 +1,242 @@
+# Sentry error reporting and request tracing: an optional feature whose whole risk is asymmetric.
+#
+# Off, it must change nothing at all — not a key in the ConfigMap, not a Secret, not a volume,
+# not an environment variable — because it is off in every release that has not asked for it,
+# and because the DSN is the only credential this server reads. Switching it on is what gives
+# the pod a secrets volume and a `PORTFOLIO_SECRETS_DIR` in the first place, so "off changes
+# nothing" is a claim about pod shape here, not only about a document.
+#
+# On, fourteen settings have to arrive at fourteen distinct paths, and a value that lands at the
+# wrong one is a compiled default nobody chose rather than an error. `sendDefaultPii` is the one
+# whose wrong answer contradicts the privacy page this site publishes, and the assertion that
+# the DSN never reaches the ConfigMap is the one whose failure would be a disclosure.
+#
+# The pod-shape assertions live in `deployment_test.yaml`. A suite that lists `deployment.yaml`
+# cannot also carry a `failedTemplate` assertion — helm-unittest reports "no failed document"
+# for the whole suite — and the validation this feature adds is the half worth testing.
+suite: sentry
+templates:
+  - configmap.yaml
+  - secret.yaml
+tests:
+  # Off has to mean *absent*, not "present and false": every key under the block is inert while
+  # the switch is down, so writing them would put fourteen settings that do nothing into the
+  # document an operator reads to find out what the server is doing.
+  - it: writes no Sentry block at all while the switch is off
+    template: configmap.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'sentry'
+
+  - it: renders no Secret while the switch is off
+    template: secret.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: writes the whole block when the switch is on
+    template: configmap.yaml
+    set:
+      sentry:
+        enabled: true
+        dsn: https://key@sentry.example.invalid/1
+        environment: staging
+        release: portfolio@2.10.0
+        serverName: portfolio-a
+        sampleRate: 0.5
+        tracesSampleRate: 0.25
+        captureLevel: warn
+        breadcrumbLevel: debug
+        maxBreadcrumbs: 50
+        attachStacktraces: false
+        sendDefaultPii: true
+        httpTransactions: false
+        spanAttributes: true
+        debug: true
+    asserts:
+      # One assertion per key, and every value set away from its default: the defect class this
+      # suite exists for is a value arriving at the wrong path, which a fixture that left the
+      # defaults in place would render identically whether the mapping were right or reversed.
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[sentry\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nenabled = true'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nenvironment = "staging"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nrelease = "portfolio@2\.10\.0"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nserver_name = "portfolio-a"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nsample_rate = 0\.5'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\ntraces_sample_rate = 0\.25'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\ncapture_level = "warn"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nbreadcrumb_level = "debug"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nmax_breadcrumbs = 50'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nattach_stacktraces = false'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nsend_default_pii = true'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nhttp_transactions = false'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nspan_attributes = true'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\ndebug = true'
+
+  # An empty optional value is a *supplied* value to the loader, and "reported with a blank
+  # environment tag" is not what leaving it unset meant. These three have no chart default
+  # because the server derives all of them.
+  - it: omits the three derived tags rather than writing them empty
+    template: configmap.yaml
+    set:
+      sentry.enabled: true
+      sentry.dsn: https://key@sentry.example.invalid/1
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'environment'
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'release'
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'server_name'
+      # The keys that do have a chart default are still written, so the document says what the
+      # server is actually doing rather than leaving it to the struct.
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nsample_rate = 1'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\ncapture_level = "error"'
+
+  # This site publishes a privacy page saying no third-party service receives visitor data. On,
+  # this key is the one way to falsify that — and it is also what stops the HTTP middleware
+  # redacting sensitive headers. Off is the chart default and has to stay it.
+  - it: leaves personally identifying data off by default
+    template: configmap.yaml
+    set:
+      sentry.enabled: true
+      sentry.dsn: https://key@sentry.example.invalid/1
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nsend_default_pii = false'
+
+  # The DSN embeds an ingest key, and the server prints the configuration it holds on the
+  # refusal path. A ConfigMap is readable by anything that can read the namespace.
+  - it: keeps the DSN out of the ConfigMap
+    template: configmap.yaml
+    set:
+      sentry.enabled: true
+      sentry.dsn: https://key@sentry.example.invalid/1
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'dsn'
+
+  - it: writes the DSN into the Secret under the path the loader reads
+    template: secret.yaml
+    set:
+      sentry.enabled: true
+      sentry.dsn: https://key@sentry.example.invalid/1
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: type
+          value: Opaque
+      # stringData, not a hand-rolled b64enc into `data`: Kubernetes does the encoding and a
+      # wrongly-encoded value can no longer be committed.
+      - equal:
+          path: stringData.sentry__dsn
+          value: https://key@sentry.example.invalid/1
+
+  - it: renders no Secret when an existing one is named
+    template: secret.yaml
+    set:
+      sentry.enabled: true
+      existingSecret: my-sentry-secret
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # Upstream refuses to boot with the switch on and no DSN, so this is a CrashLoopBackOff rather
+  # than a degraded feature — worth catching at render time.
+  - it: refuses the switch with no DSN anywhere
+    template: configmap.yaml
+    set:
+      sentry.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "sentry.enabled is set but no DSN is available"
+
+  # The chart cannot see inside an `existingSecret`, and a DSN it cannot see is not the same as
+  # a DSN that is missing.
+  - it: accepts an existing Secret as the DSN it cannot see
+    template: configmap.yaml
+    set:
+      sentry.enabled: true
+      existingSecret: my-sentry-secret
+    asserts:
+      - isKind:
+          of: ConfigMap
+
+  # The ordinary dead-value check: a credential sitting in the release meaning nothing.
+  - it: refuses a DSN set while the switch is off
+    template: configmap.yaml
+    set:
+      sentry.dsn: https://key@sentry.example.invalid/1
+    asserts:
+      - failedTemplate:
+          errorPattern: "sentry.dsn is set while sentry.enabled is false"
+
+  # `configExtraToml` makes the CSP check step out of the way, because it is appended verbatim
+  # and could be supplying the pair. It cannot be supplying the DSN — that travels the Secret —
+  # so the Sentry checks stay on.
+  - it: still refuses a bad Sentry pair behind configExtraToml
+    template: configmap.yaml
+    set:
+      configExtraToml: |
+        [csp]
+        hash_inline_scripts = true
+      sentry.dsn: https://key@sentry.example.invalid/1
+    asserts:
+      - failedTemplate:
+          errorPattern: "sentry.dsn is set while sentry.enabled is false"
+
+  # `config` is the highest-precedence layer the chart renders, so it has to be able to reach
+  # inside a block the first-class values built.
+  - it: lets the raw config tree override a derived Sentry key
+    template: configmap.yaml
+    set:
+      sentry.enabled: true
+      sentry.dsn: https://key@sentry.example.invalid/1
+      config:
+        sentry:
+          traces_sample_rate: 0.75
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\ntraces_sample_rate = 0\.75'

--- a/charts/portfolio/values.schema.json
+++ b/charts/portfolio/values.schema.json
@@ -1673,7 +1673,7 @@
           "type": "string"
         },
         "tag": {
-          "default": "v2.9.0@sha256:a3380c804d62ea7dcadab149079414a94aeebad99d973eed3c384f912566466d",
+          "default": "v2.10.0@sha256:a6ada5d26c75bad113006bb6889edc4a5d102edf373b0f57747c3722733fd32b",
           "description": "Container image tag to deploy, pinned by digest (`vX.Y.Z\nthe pull, while the tag stays on as the readable version marker. Defaults to the chart's\n`appVersion` when empty.",
           "required": [],
           "title": "tag",

--- a/charts/portfolio/values.schema.json
+++ b/charts/portfolio/values.schema.json
@@ -1318,7 +1318,7 @@
         },
         "secretsDir": {
           "default": "/etc/portfolio/secrets",
-          "description": "Directory credential files would be mounted at, passed as `PORTFOLIO_SECRETS_DIR`. The\nserver reads no secret today — `github.token` belongs to the build-time repository\nbuilder — so nothing is mounted and the variable is not set; the value is here for an\noperator adding one through `extraVolumes`.",
+          "description": "Directory credential files are mounted at, passed as `PORTFOLIO_SECRETS_DIR`. The Sentry\nDSN is the only credential this server reads — `github.token` belongs to the build-time\nrepository builder — so the volume and the variable both appear only while `sentry.enabled`\nis set, and a release that does not report to Sentry carries neither.",
           "required": [],
           "title": "secretsDir",
           "type": "string"
@@ -1370,6 +1370,13 @@
       },
       "required": [],
       "title": "csp"
+    },
+    "existingSecret": {
+      "default": "",
+      "description": "Name of an existing Secret holding the Sentry DSN, which keeps it out of `values.yaml` and\nout of the Helm release object. **Its key is the configuration path, not a free-form name**:\n`sentry__dsn`, because the file name is what the loader parses. Set, the chart renders no\nSecret of its own and `sentry.dsn` is ignored. It is read only while `sentry.enabled` is set —\nnothing else this server reads is a credential.",
+      "required": [],
+      "title": "existingSecret",
+      "type": "string"
     },
     "extraEnv": {
       "description": "Additional environment variables for the application container.",
@@ -2484,6 +2491,138 @@
       ],
       "required": [],
       "title": "securityContextPreset"
+    },
+    "sentry": {
+      "additionalProperties": true,
+      "description": "Sentry error reporting and request tracing, rendered under `sentry` in the mounted\n`config.toml`. **Off**, and wholly inert while it is: no client, no panic hook, no `tracing`\nlayer and no HTTP middleware is installed, and nothing leaves the process.\n\nSwitching it on moves one thing that has nothing to do with Sentry: the server installs the\nlog subscriber itself instead of leaving it to the Dioxus toolchain, because a Sentry layer\nhas to be a layer *of* the subscriber and the framework's is not extensible after the fact.\n`logLevel` still decides what is printed and the format is unchanged.\n\nTwo things the chart deliberately does not do for you. It never reads the DSN, so it cannot\nname the ingest host in the NetworkPolicies. The defaults do happen to cover it —\n`networkPolicy.egress.https` permits TCP/443 to `0.0.0.0/0` minus private space — but a\ndeployment that narrowed `networkPolicy.egress.cidr`, turned `egress.https` off, or replaced\nthe CIDR rule with `networkPolicy.cilium.egress.toFQDNs` has to name the endpoint itself, and\ngetting that wrong is silent: an SDK that cannot reach its endpoint queues events and then\ndiscards them, so the project stays empty, which reads as \"no errors\". And it configures\nnothing inside Sentry — the project, its quota and its server-side data-scrubbing rules are\nyours.",
+      "properties": {
+        "attachStacktraces": {
+          "default": true,
+          "description": "Attach a stack trace to events that carry none of their own (`sentry.attach_stacktraces`).",
+          "required": [],
+          "title": "attachStacktraces",
+          "type": "boolean"
+        },
+        "breadcrumbLevel": {
+          "default": "info",
+          "description": "Least severe `tracing` level kept as a breadcrumb, the trail attached to the next issue\n(`sentry.breadcrumb_level`). Records at or above `captureLevel` become issues instead, so the\ntwo thresholds partition the stream rather than overlapping on it. Quote `\"off\"`.",
+          "enum": [
+            "off",
+            "error",
+            "warn",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "required": [],
+          "title": "breadcrumbLevel"
+        },
+        "captureLevel": {
+          "default": "error",
+          "description": "Least severe `tracing` level reported as a Sentry issue (`sentry.capture_level`). Quote\n`\"off\"` — unquoted, YAML reads it as the boolean `false`.",
+          "enum": [
+            "off",
+            "error",
+            "warn",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "required": [],
+          "title": "captureLevel"
+        },
+        "debug": {
+          "default": false,
+          "description": "Print the SDK's own diagnostics to stderr (`sentry.debug`). For proving a DSN works, not\nfor running.",
+          "required": [],
+          "title": "debug",
+          "type": "boolean"
+        },
+        "dsn": {
+          "default": "",
+          "description": "Ingest URL, `https://\u003ckey\u003e@\u003chost\u003e/\u003cproject\u003e`. A credential — the embedded key is a bearer\ntoken for the project's ingest endpoint, and the server prints the configuration it holds on\nthe refusal path — so it is delivered as a file in `PORTFOLIO_SECRETS_DIR` under\n`sentry__dsn` and never written into the ConfigMap. It is the only credential this chart\nhandles, and switching Sentry on is what gives the pod a secrets volume at all. Leave it\nempty and put that key in the Secret named by `existingSecret` to keep it out of `helm get\nvalues` entirely.",
+          "required": [],
+          "title": "dsn",
+          "type": "string"
+        },
+        "enabled": {
+          "default": false,
+          "description": "Initialise the Sentry client (`sentry.enabled`). Off, every other key here is inert. On,\nthe server refuses to boot without a DSN rather than starting with a reporter that reports\nnowhere, so this and `dsn` are set together.",
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "environment": {
+          "default": "",
+          "description": "Environment tag on every event (`sentry.environment`). Empty lets the server derive it\nfrom the build profile: `production` for the release binary every published image is. Set it\nfor anything in between, such as a staging deployment of that same image.",
+          "required": [],
+          "title": "environment",
+          "type": "string"
+        },
+        "httpTransactions": {
+          "default": true,
+          "description": "Record one transaction per request, named by the matched route rather than by the URI\n(`sentry.http_transactions`), so `/api/repos/{name}` does not become one transaction name per\nrepository. Whether a started transaction is kept is `tracesSampleRate`'s decision; this is\nthe switch for taking the middleware out entirely.",
+          "required": [],
+          "title": "httpTransactions",
+          "type": "boolean"
+        },
+        "maxBreadcrumbs": {
+          "default": 100,
+          "description": "How many breadcrumbs one event carries (`sentry.max_breadcrumbs`).",
+          "minimum": 0,
+          "required": [],
+          "title": "maxBreadcrumbs",
+          "type": "integer"
+        },
+        "release": {
+          "default": "",
+          "description": "Release tag on every event (`sentry.release`). Empty uses `portfolio@\u003cversion\u003e`, the\nworkspace version the binary was built from — which is what makes a regression attributable\nto a deploy, since every deploy of this site is a new image cut from a new version.",
+          "required": [],
+          "title": "release",
+          "type": "string"
+        },
+        "sampleRate": {
+          "default": 1,
+          "description": "Fraction of captured events actually sent (`sentry.sample_rate`). A blunt volume cap — it\ndrops whole issues, not repetitions of one, so a rare bug is exactly as likely to be dropped\nas a noisy one — so leave it at `1` unless a quota forces otherwise.",
+          "maximum": 1,
+          "minimum": 0,
+          "required": [],
+          "title": "sampleRate",
+          "type": "number"
+        },
+        "sendDefaultPii": {
+          "default": false,
+          "description": "Send personally identifying data with every event: the client IP, the whole request header\nset — `Cookie` included — and the resolved user (`sentry.send_default_pii`). **Off, and worth\nleaving off.** A reader's address and cookies are not what makes a crash report actionable,\nand Sentry is a third party for the purposes of the privacy page this site publishes — a page\nthat says no third-party service receives visitor data, which is a statement this one key is\nthe way to falsify. It is two controls rather than one, besides: off is also what keeps the\nHTTP middleware redacting sensitive headers.",
+          "required": [],
+          "title": "sendDefaultPii",
+          "type": "boolean"
+        },
+        "serverName": {
+          "default": "",
+          "description": "Host tag on every event (`sentry.server_name`). Empty reports none, which is the right\nanswer here: the value would be one replica's pod name, and this site runs one image behind\na tunnel, so it identifies nothing an event does not already say.",
+          "required": [],
+          "title": "serverName",
+          "type": "string"
+        },
+        "spanAttributes": {
+          "default": false,
+          "description": "Copy `tracing` span fields onto the Sentry span as attributes (`sentry.span_attributes`).\nOff: the span fields here routinely carry request paths and the negotiated locale, and a\ntransaction is retained for longer than a log line.",
+          "required": [],
+          "title": "spanAttributes",
+          "type": "boolean"
+        },
+        "tracesSampleRate": {
+          "default": 0,
+          "description": "Fraction of request traces recorded (`sentry.traces_sample_rate`). `0` records none, which\nis what keeps switching Sentry on for crash reporting from also switching performance data\non. This server is the edge and starts every trace it has — nothing upstream hands it one —\nso this rate alone decides whether a trace exists. `0.05`-`0.2` is an ordinary production\nfigure.",
+          "maximum": 1,
+          "minimum": 0,
+          "required": [],
+          "title": "tracesSampleRate",
+          "type": "number"
+        }
+      },
+      "required": [],
+      "title": "sentry"
     },
     "server": {
       "additionalProperties": true,

--- a/charts/portfolio/values.yaml
+++ b/charts/portfolio/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image tag to deploy, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins
   # the pull, while the tag stays on as the readable version marker. Defaults to the chart's
   # `appVersion` when empty.
-  tag: v2.9.0@sha256:a3380c804d62ea7dcadab149079414a94aeebad99d973eed3c384f912566466d
+  tag: v2.10.0@sha256:a6ada5d26c75bad113006bb6889edc4a5d102edf373b0f57747c3722733fd32b
 
   # @schema
   # enum: ["", Always, IfNotPresent, Never]

--- a/charts/portfolio/values.yaml
+++ b/charts/portfolio/values.yaml
@@ -195,6 +195,182 @@ isr:
   ttlSecs: 0
 
 # @schema
+# additionalProperties: true
+# @schema
+# -- Sentry error reporting and request tracing, rendered under `sentry` in the mounted
+# `config.toml`. **Off**, and wholly inert while it is: no client, no panic hook, no `tracing`
+# layer and no HTTP middleware is installed, and nothing leaves the process.
+#
+# Switching it on moves one thing that has nothing to do with Sentry: the server installs the
+# log subscriber itself instead of leaving it to the Dioxus toolchain, because a Sentry layer
+# has to be a layer *of* the subscriber and the framework's is not extensible after the fact.
+# `logLevel` still decides what is printed and the format is unchanged.
+#
+# Two things the chart deliberately does not do for you. It never reads the DSN, so it cannot
+# name the ingest host in the NetworkPolicies. The defaults do happen to cover it —
+# `networkPolicy.egress.https` permits TCP/443 to `0.0.0.0/0` minus private space — but a
+# deployment that narrowed `networkPolicy.egress.cidr`, turned `egress.https` off, or replaced
+# the CIDR rule with `networkPolicy.cilium.egress.toFQDNs` has to name the endpoint itself, and
+# getting that wrong is silent: an SDK that cannot reach its endpoint queues events and then
+# discards them, so the project stays empty, which reads as "no errors". And it configures
+# nothing inside Sentry — the project, its quota and its server-side data-scrubbing rules are
+# yours.
+sentry:
+  # @schema
+  # # @config projection sentry.enabled optional
+  # type: boolean
+  # @schema
+  # -- Initialise the Sentry client (`sentry.enabled`). Off, every other key here is inert. On,
+  # the server refuses to boot without a DSN rather than starting with a reporter that reports
+  # nowhere, so this and `dsn` are set together.
+  enabled: false
+
+  # @schema
+  # type: string
+  # @schema
+  # -- Ingest URL, `https://<key>@<host>/<project>`. A credential — the embedded key is a bearer
+  # token for the project's ingest endpoint, and the server prints the configuration it holds on
+  # the refusal path — so it is delivered as a file in `PORTFOLIO_SECRETS_DIR` under
+  # `sentry__dsn` and never written into the ConfigMap. It is the only credential this chart
+  # handles, and switching Sentry on is what gives the pod a secrets volume at all. Leave it
+  # empty and put that key in the Secret named by `existingSecret` to keep it out of `helm get
+  # values` entirely.
+  dsn: ""
+
+  # @schema
+  # # @config projection sentry.environment optional when sentry.enabled
+  # type: string
+  # @schema
+  # -- Environment tag on every event (`sentry.environment`). Empty lets the server derive it
+  # from the build profile: `production` for the release binary every published image is. Set it
+  # for anything in between, such as a staging deployment of that same image.
+  environment: ""
+
+  # @schema
+  # # @config projection sentry.release optional when sentry.enabled
+  # type: string
+  # @schema
+  # -- Release tag on every event (`sentry.release`). Empty uses `portfolio@<version>`, the
+  # workspace version the binary was built from — which is what makes a regression attributable
+  # to a deploy, since every deploy of this site is a new image cut from a new version.
+  release: ""
+
+  # @schema
+  # # @config projection sentry.server_name optional when sentry.enabled
+  # type: string
+  # @schema
+  # -- Host tag on every event (`sentry.server_name`). Empty reports none, which is the right
+  # answer here: the value would be one replica's pod name, and this site runs one image behind
+  # a tunnel, so it identifies nothing an event does not already say.
+  serverName: ""
+
+  # @schema
+  # # @config projection sentry.sample_rate when sentry.enabled
+  # type: number
+  # minimum: 0
+  # maximum: 1
+  # @schema
+  # -- Fraction of captured events actually sent (`sentry.sample_rate`). A blunt volume cap — it
+  # drops whole issues, not repetitions of one, so a rare bug is exactly as likely to be dropped
+  # as a noisy one — so leave it at `1` unless a quota forces otherwise.
+  sampleRate: 1.0
+
+  # @schema
+  # # @config projection sentry.traces_sample_rate when sentry.enabled
+  # type: number
+  # minimum: 0
+  # maximum: 1
+  # @schema
+  # -- Fraction of request traces recorded (`sentry.traces_sample_rate`). `0` records none, which
+  # is what keeps switching Sentry on for crash reporting from also switching performance data
+  # on. This server is the edge and starts every trace it has — nothing upstream hands it one —
+  # so this rate alone decides whether a trace exists. `0.05`-`0.2` is an ordinary production
+  # figure.
+  tracesSampleRate: 0.0
+
+  # @schema
+  # # @config projection sentry.capture_level when sentry.enabled
+  # enum: ["off", error, warn, info, debug, trace]
+  # @schema
+  # -- Least severe `tracing` level reported as a Sentry issue (`sentry.capture_level`). Quote
+  # `"off"` — unquoted, YAML reads it as the boolean `false`.
+  captureLevel: error
+
+  # @schema
+  # # @config projection sentry.breadcrumb_level when sentry.enabled
+  # enum: ["off", error, warn, info, debug, trace]
+  # @schema
+  # -- Least severe `tracing` level kept as a breadcrumb, the trail attached to the next issue
+  # (`sentry.breadcrumb_level`). Records at or above `captureLevel` become issues instead, so the
+  # two thresholds partition the stream rather than overlapping on it. Quote `"off"`.
+  breadcrumbLevel: info
+
+  # @schema
+  # # @config projection sentry.max_breadcrumbs when sentry.enabled
+  # type: integer
+  # minimum: 0
+  # @schema
+  # -- How many breadcrumbs one event carries (`sentry.max_breadcrumbs`).
+  maxBreadcrumbs: 100
+
+  # @schema
+  # # @config projection sentry.attach_stacktraces when sentry.enabled
+  # type: boolean
+  # @schema
+  # -- Attach a stack trace to events that carry none of their own (`sentry.attach_stacktraces`).
+  attachStacktraces: true
+
+  # @schema
+  # # @config projection sentry.send_default_pii when sentry.enabled
+  # type: boolean
+  # @schema
+  # -- Send personally identifying data with every event: the client IP, the whole request header
+  # set — `Cookie` included — and the resolved user (`sentry.send_default_pii`). **Off, and worth
+  # leaving off.** A reader's address and cookies are not what makes a crash report actionable,
+  # and Sentry is a third party for the purposes of the privacy page this site publishes — a page
+  # that says no third-party service receives visitor data, which is a statement this one key is
+  # the way to falsify. It is two controls rather than one, besides: off is also what keeps the
+  # HTTP middleware redacting sensitive headers.
+  sendDefaultPii: false
+
+  # @schema
+  # # @config projection sentry.http_transactions when sentry.enabled
+  # type: boolean
+  # @schema
+  # -- Record one transaction per request, named by the matched route rather than by the URI
+  # (`sentry.http_transactions`), so `/api/repos/{name}` does not become one transaction name per
+  # repository. Whether a started transaction is kept is `tracesSampleRate`'s decision; this is
+  # the switch for taking the middleware out entirely.
+  httpTransactions: true
+
+  # @schema
+  # # @config projection sentry.span_attributes when sentry.enabled
+  # type: boolean
+  # @schema
+  # -- Copy `tracing` span fields onto the Sentry span as attributes (`sentry.span_attributes`).
+  # Off: the span fields here routinely carry request paths and the negotiated locale, and a
+  # transaction is retained for longer than a log line.
+  spanAttributes: false
+
+  # @schema
+  # # @config projection sentry.debug when sentry.enabled
+  # type: boolean
+  # @schema
+  # -- Print the SDK's own diagnostics to stderr (`sentry.debug`). For proving a DSN works, not
+  # for running.
+  debug: false
+
+# @schema
+# type: string
+# @schema
+# -- Name of an existing Secret holding the Sentry DSN, which keeps it out of `values.yaml` and
+# out of the Helm release object. **Its key is the configuration path, not a free-form name**:
+# `sentry__dsn`, because the file name is what the loader parses. Set, the chart renders no
+# Secret of its own and `sentry.dsn` is ignored. It is read only while `sentry.enabled` is set —
+# nothing else this server reads is a credential.
+existingSecret: ""
+
+# @schema
 # type: object
 # additionalProperties: true
 # @schema
@@ -226,10 +402,10 @@ configMount:
   # @schema
   # type: string
   # @schema
-  # -- Directory credential files would be mounted at, passed as `PORTFOLIO_SECRETS_DIR`. The
-  # server reads no secret today — `github.token` belongs to the build-time repository
-  # builder — so nothing is mounted and the variable is not set; the value is here for an
-  # operator adding one through `extraVolumes`.
+  # -- Directory credential files are mounted at, passed as `PORTFOLIO_SECRETS_DIR`. The Sentry
+  # DSN is the only credential this server reads — `github.token` belongs to the build-time
+  # repository builder — so the volume and the variable both appear only while `sentry.enabled`
+  # is set, and a release that does not report to Sentry carries neither.
   secretsDir: /etc/portfolio/secrets
 
 # @schema

--- a/charts/s3-bucket-perma-link/Chart.yaml
+++ b/charts/s3-bucket-perma-link/Chart.yaml
@@ -1,7 +1,7 @@
 name: s3-bucket-perma-link
 description: This chart deploys a simple web server that provides permanent links to specific S3 bucket resources. It allows you to define static URL paths that always point to specific files in your S3 buckets.
-version: 4.1.3
-appVersion: v1.1.1
+version: 5.0.0
+appVersion: v2.0.0
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts
 sources:

--- a/charts/s3-bucket-perma-link/Chart.yaml
+++ b/charts/s3-bucket-perma-link/Chart.yaml
@@ -1,7 +1,7 @@
 name: s3-bucket-perma-link
 description: This chart deploys a simple web server that provides permanent links to specific S3 bucket resources. It allows you to define static URL paths that always point to specific files in your S3 buckets.
-version: 4.1.3
-appVersion: v1.1.1
+version: 4.1.4
+appVersion: v2.0.0
 apiVersion: v2
 home: https://github.com/TimSchoenle/helm-charts
 sources:

--- a/charts/s3-bucket-perma-link/README.md
+++ b/charts/s3-bucket-perma-link/README.md
@@ -1,6 +1,6 @@
 # s3-bucket-perma-link
 
-![Version: 4.1.3](https://img.shields.io/badge/Version-4.1.3-informational?style=flat-square) ![AppVersion: v1.1.1](https://img.shields.io/badge/AppVersion-v1.1.1-informational?style=flat-square)
+![Version: 4.1.4](https://img.shields.io/badge/Version-4.1.4-informational?style=flat-square) ![AppVersion: v2.0.0](https://img.shields.io/badge/AppVersion-v2.0.0-informational?style=flat-square)
 
 This chart deploys a simple web server that provides permanent links to specific S3 bucket resources. It allows you to define static URL paths that always point to specific files in your S3 buckets.
 
@@ -428,11 +428,11 @@ policy pointing at the wrong Gateway looks correct and blocks everything.
 | gateway.tls.enabled | bool | `false` | Add an HTTPS listener. |
 | gateway.tls.mode | string | `"Terminate"` | TLS mode. |
 | gateway.tls.options | object | `{}` | Implementation-specific TLS options. |
-| image | object | `{"pullPolicy":"","registry":"","repository":"timmi6790/s3-bucket-perma-link","tag":"v1.1.1@sha256:0f3fb15ccda6fe17400186d16d8a4a4bb249b0d7e6c169f7d5bbb950c6337a76"}` | Container image the pod runs, composed as `registry/repository:tag`. |
+| image | object | `{"pullPolicy":"","registry":"","repository":"timmi6790/s3-bucket-perma-link","tag":"v2.0.0@sha256:a331869902bd25de2ac46873f6f4188a7a524d8f4717e2bbfdcdfc23c31e6520"}` | Container image the pod runs, composed as `registry/repository:tag`. |
 | image.pullPolicy | string | `""` | The image pull policy. Empty resolves automatically from the tag/digest. |
 | image.registry | string | `""` | Registry host. Empty means Docker Hub. |
 | image.repository | string | `"timmi6790/s3-bucket-perma-link"` | The container image repository. |
-| image.tag | string | `"v1.1.1@sha256:0f3fb15ccda6fe17400186d16d8a4a4bb249b0d7e6c169f7d5bbb950c6337a76"` | The container image tag, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the pull, while the tag stays on as the readable version marker. Defaults to the chart's `appVersion` when empty. |
+| image.tag | string | `"v2.0.0@sha256:a331869902bd25de2ac46873f6f4188a7a524d8f4717e2bbfdcdfc23c31e6520"` | The container image tag, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the pull, while the tag stays on as the readable version marker. Defaults to the chart's `appVersion` when empty. |
 | imagePullSecrets | list | `[]` | Optional image pull secrets for private registries. |
 | ingress | object | `{"annotations":{},"enabled":false,"hosts":[],"ingressClassName":"nginx","tls":[]}` | The Ingress in front of the Service. Off by default; `gateway` is the Gateway API alternative and the two are independent switches. |
 | ingress.annotations | object | `{}` | Custom annotations for the Ingress resource. Useful for configuring ingress controllers (e.g., cert-manager, rate limits). |

--- a/charts/s3-bucket-perma-link/README.md
+++ b/charts/s3-bucket-perma-link/README.md
@@ -1,6 +1,6 @@
 # s3-bucket-perma-link
 
-![Version: 4.1.3](https://img.shields.io/badge/Version-4.1.3-informational?style=flat-square) ![AppVersion: v1.1.1](https://img.shields.io/badge/AppVersion-v1.1.1-informational?style=flat-square)
+![Version: 5.0.0](https://img.shields.io/badge/Version-5.0.0-informational?style=flat-square) ![AppVersion: v2.0.0](https://img.shields.io/badge/AppVersion-v2.0.0-informational?style=flat-square)
 
 This chart deploys a simple web server that provides permanent links to specific S3 bucket resources. It allows you to define static URL paths that always point to specific files in your S3 buckets.
 
@@ -14,6 +14,7 @@ bucket has to be made public.
 - Kubernetes 1.19+
 - Helm 3.0+
 - An S3-compatible bucket and a credential pair that can read it
+- A Sentry DSN, if `telemetry.sentry.enabled` is set
 - An ingress controller, or the Gateway API CRDs and a `Gateway`, if the links are meant to
   work outside the cluster
 - Cilium 1.16+, if `networkPolicy.engine` is `cilium` or `both`
@@ -91,7 +92,70 @@ Set `configMount.rolloutOnChange: true` to make it behave like an ordinary image
 `s3.accessKey` / `s3.secretKey` are accepted as an alternative to `existingSecret` and make the
 chart render the Secret itself. That puts the credentials into `values.yaml` and into the Helm
 release object, where anyone who can run `helm get values` can read them — use it for a
-throwaway cluster, not for anything real. `existingSecret` wins if both are set.
+throwaway cluster, not for anything real. `existingSecret` wins if both are set. The same is
+true of `telemetry.sentry.dsn`.
+
+## Error reporting and tracing
+
+`telemetry.sentry` reports errors and panics to Sentry, and can record a transaction per
+request. It is off, and inert while it is off: no client, no panic hook, no subscriber layer and
+no HTTP middleware is installed, so nothing leaves the process and nothing about a rendered
+release changes.
+
+```yaml
+telemetry:
+  sentry:
+    enabled: true
+    dsn: https://<key>@<host>/<project>
+```
+
+The DSN embeds a write key for the project's event stream, so the chart treats it as the
+credential it is: it goes to the Secret under `telemetry__sentry__dsn`, alongside the S3 keys,
+and never into the ConfigMap — which matters twice here, because the reload supervisor prints
+the configuration it holds. Switching the feature on with no DSN, neither inline nor in an
+`existingSecret`, is refused at render time: the service refuses to boot rather than installing
+a client that reports nowhere, and a rejected `helm upgrade` beats a CrashLoopBackOff.
+
+**Check the egress.** The chart never reads the DSN, so it cannot name the ingest host in the
+network policies. The defaults do cover it — `networkPolicy.egress.https` permits TCP/443 to
+`0.0.0.0/0` minus private space — so an out-of-the-box release reaches Sentry without further
+work. A release that narrowed `networkPolicy.egress.cidr`, turned `egress.https` off, or
+replaced the CIDR rule with `networkPolicy.cilium.egress.toFQDNs` has to name the endpoint
+itself. Getting that wrong is silent: an SDK that cannot reach its endpoint queues events and
+then discards them, so the project simply stays empty, which reads as "no errors".
+
+```yaml
+networkPolicy:
+  enabled: true
+  extraEgress:
+    - to:
+        - ipBlock:
+            cidr: 34.120.195.249/32 # your ingest endpoint
+      ports:
+        - port: 443
+          protocol: TCP
+```
+
+Under the Cilium engine the same destination is better expressed by name, via
+`networkPolicy.cilium.egress.toFQDNs`.
+
+`tracesSampleRate` is `0` — this server starts no traces of its own, which is the sensible
+setting for a service whose whole job is one redirect. It still continues a trace that arrives
+already sampled, so a caller that does trace sees the hop either way.
+
+`sendDefaultPii` stays off. On, every event carries the client IP, the whole request header set
+and a buffered body, to a third party — and the same flag is what stops the HTTP middleware
+redacting sensitive headers. This service publishes public links; the address of whoever
+followed one is not what makes a failed S3 fetch actionable.
+
+`environment`, `release` and `serverName` are empty by default and the chart writes none of
+them: the service resolves the first two itself, and `release` is also the name the image's
+debug-file upload symbolicates against — overriding it without a matching upload leaves events
+with no symbols.
+
+Unlike the rest of this chart's configuration, `telemetry.sentry` is read once as the process
+boots, so a change to it needs a restart: roll the Deployment, or set
+`configMount.rolloutOnChange: true`.
 
 ## Non-AWS endpoints
 
@@ -108,6 +172,33 @@ existingSecret: s3-credentials
 ```
 
 ## Upgrading
+
+### 4.x to 5.0
+
+Chart 5.0 tracks the service's 2.0 release, which replaced the single `telemetry.sentry_dsn` key
+with a full `telemetry.sentry` block — fifteen settings and the DSN — and made Sentry an optional
+compile-time feature with tracing support. `telemetry.sentryDsn` is gone; a `helm upgrade` with
+4.x values fails schema validation naming the key rather than silently dropping error reporting.
+
+| Before | After |
+|---|---|
+| `telemetry.sentryDsn: https://...` | `telemetry.sentry.enabled: true` **and** `telemetry.sentry.dsn: https://...` |
+| (unset) | (unset — `telemetry.sentry.enabled` defaults to `false`) |
+
+Two behaviours changed along with the spelling:
+
+- **The DSN is a credential now.** 4.x rendered it into `config.toml`, where anything that can
+  read the namespace could print it — and where the reload supervisor's own logging could too.
+  It goes to the Secret instead, under `telemetry__sentry__dsn`, so an `existingSecret` that
+  should carry it needs that key added, and the pod projects it only while
+  `telemetry.sentry.enabled` is set.
+- **The switch is separate from the DSN.** Setting one without the other is refused at render
+  time in both directions: on with no DSN is a boot failure upstream, and a DSN with the switch
+  off is a credential in the release that nothing reads.
+
+Everything else under the block is new and optional, and the defaults reproduce 4.x behaviour.
+Note `attachStacktrace` — singular, unlike the sibling charts in this repository, because that is
+the key this image reads.
 
 ### 3.x to 4.0
 
@@ -395,7 +486,7 @@ policy pointing at the wrong Gateway looks correct and blocks everything.
 | configMount.configDir | string | `"/etc/s3-bucket-perma-link/config"` | Directory the rendered `config.toml` is mounted at, passed as `S3_PERMA_LINK_CONFIG`. |
 | configMount.rolloutOnChange | bool | `false` | Add `checksum/*` pod annotations so a configuration change rolls the Deployment. Off by default, and deliberately so: the service watches the directories its configuration came from and rebuilds its bucket clients and listener in place when the kubelet updates the mounted ConfigMap or Secret, which is strictly better than a rollout. Turn this on only if you want configuration changes to behave like an ordinary image bump. `telemetry.*` is installed once per process and needs a restart either way. |
 | configMount.secretsDir | string | `"/etc/s3-bucket-perma-link/secrets"` | Directory the credential files are mounted at, passed as `S3_PERMA_LINK_SECRETS_DIR`. |
-| existingSecret | string | `""` | Name of an existing Secret holding the S3 credentials, which keeps them out of `values.yaml` and out of the Helm release object. **Its keys are the configuration paths, not free-form names**: `s3__access_key` and `s3__secret_key`, because the file name is what the loader parses. Set, the chart renders no Secret of its own and `s3.accessKey` / `s3.secretKey` are ignored. |
+| existingSecret | string | `""` | Name of an existing Secret holding the server's credentials, which keeps them out of `values.yaml` and out of the Helm release object. **Its keys are the configuration paths, not free-form names**: `s3__access_key`, `s3__secret_key` and, once `telemetry.sentry.enabled` is set, `telemetry__sentry__dsn` — because the file name is what the loader parses. Set, the chart renders no Secret of its own and `s3.accessKey`, `s3.secretKey` and `telemetry.sentry.dsn` are ignored. |
 | extraEnv | list | `[]` | Additional environment variables for the application container. |
 | extraVolumeMounts | list | `[]` | Additional volume mounts added to the application container. |
 | extraVolumes | list | `[]` | Additional volumes added to the pod. |
@@ -560,9 +651,25 @@ policy pointing at the wrong Gateway looks correct and blocks everything.
 | startupProbe.periodSeconds | int | `5` | Probe interval. |
 | startupProbe.timeoutSeconds | int | `3` | Probe timeout. |
 | strategy | object | `{}` | Deployment update strategy. Empty uses the Kubernetes default rolling update. |
-| telemetry | object | `{"logLevel":"info","sentryDsn":""}` | Logging and error reporting, rendered under `telemetry` in `config.toml`. |
+| telemetry | object | `{"logLevel":"info","sentry":{"attachStacktrace":true,"breadcrumbLevel":"info","captureLevel":"error","debug":false,"dsn":"","enabled":false,"environment":"","httpTransactions":true,"maxBreadcrumbs":100,"release":"","sampleRate":1,"sendDefaultPii":false,"serverName":"","shutdownTimeoutSecs":2,"spanAttributes":false,"tracesSampleRate":0}}` | Logging and error reporting, rendered under `telemetry` in `config.toml`. |
 | telemetry.logLevel | string | `"info"` | Log level (`telemetry.log_level`). |
-| telemetry.sentryDsn | string | `""` | Sentry DSN (`telemetry.sentry_dsn`). Empty disables Sentry entirely. |
+| telemetry.sentry | object | `{"attachStacktrace":true,"breadcrumbLevel":"info","captureLevel":"error","debug":false,"dsn":"","enabled":false,"environment":"","httpTransactions":true,"maxBreadcrumbs":100,"release":"","sampleRate":1,"sendDefaultPii":false,"serverName":"","shutdownTimeoutSecs":2,"spanAttributes":false,"tracesSampleRate":0}` | Sentry error reporting and request tracing. **Off**, and wholly inert while it is: no client, no panic hook, no subscriber layer and no HTTP middleware is installed, and nothing leaves the process.  Two things the chart deliberately does not do for you. It never reads the DSN, so it cannot name the ingest host in the NetworkPolicies. The defaults do happen to cover it — `networkPolicy.egress.https` permits TCP/443 to `0.0.0.0/0` minus private space — but a deployment that narrowed `networkPolicy.egress.cidr`, turned `egress.https` off, or replaced the CIDR rule with `networkPolicy.cilium.egress.toFQDNs` has to name the endpoint itself, and getting that wrong is silent: an SDK that cannot reach its endpoint queues events and then discards them, so the project stays empty, which reads as "no errors". And it configures nothing inside Sentry — the project, its quota and its server-side data-scrubbing rules are yours.  Unlike the rest of this chart's configuration, the block is read once as the process boots rather than re-read when the kubelet refreshes the mount, so a change to it takes effect on the next restart. `configMount.rolloutOnChange` is what turns one into a rollout. |
+| telemetry.sentry.attachStacktrace | bool | `true` | Attach a stack trace to events that carry none of their own (`telemetry.sentry.attach_stacktrace`, singular). |
+| telemetry.sentry.breadcrumbLevel | string | `"info"` | Least severe `tracing` level kept as a breadcrumb, the trail attached to the next issue (`telemetry.sentry.breadcrumb_level`). Records at or above `captureLevel` become issues instead. Independent of `logLevel`, so tightening the console does not silently empty every trail — and asking for `debug` breadcrumbs makes the process evaluate `debug` records it does not print. Quote `"off"`. |
+| telemetry.sentry.captureLevel | string | `"error"` | Least severe `tracing` level reported as a Sentry issue (`telemetry.sentry.capture_level`). Quote `"off"` — unquoted, YAML reads it as the boolean `false`. |
+| telemetry.sentry.debug | bool | `false` | Print the SDK's own diagnostics to stderr (`telemetry.sentry.debug`). For proving a DSN works, not for running. |
+| telemetry.sentry.dsn | string | `""` | Ingest URL, `https://<key>@<host>/<project>`. A credential — the embedded key is a bearer token for the project's ingest endpoint, and the reload supervisor prints the configuration it holds — so it is delivered as a file in `S3_PERMA_LINK_SECRETS_DIR` under `telemetry__sentry__dsn`, alongside the S3 credentials, and never written into the ConfigMap. Leave it empty and put that key in the Secret named by `existingSecret` to keep it out of `helm get values` entirely. |
+| telemetry.sentry.enabled | bool | `false` | Initialise the Sentry client (`telemetry.sentry.enabled`). Off, every other key here is inert. On, the server refuses to boot without a DSN rather than starting with a reporter that reports nowhere, so this and `dsn` are set together. |
+| telemetry.sentry.environment | string | `""` | Environment tag on every event (`telemetry.sentry.environment`). Empty lets the server resolve it: `production` from a release build, `development` from a debug one. It always sends one, so `SENTRY_ENVIRONMENT` — a channel that would bypass the layered loader entirely — is never consulted. |
+| telemetry.sentry.httpTransactions | bool | `true` | Record one transaction per request, named by the matched route rather than by the URI (`telemetry.sentry.http_transactions`). Whether a started transaction is kept is `tracesSampleRate`'s decision; this is the switch for a deployment that wants error reporting and no performance data at all. The per-request hub is installed either way, which is what stops breadcrumbs from concurrent requests landing on one another's issues. |
+| telemetry.sentry.maxBreadcrumbs | int | `100` | How many breadcrumbs one event carries (`telemetry.sentry.max_breadcrumbs`). |
+| telemetry.sentry.release | string | `""` | Release tag on every event (`telemetry.sentry.release`). Empty uses `s3-bucket-perma-link@<version>`, which is both what makes a regression attributable to a deploy and the name the image's debug-file upload symbolicates against — override it only alongside a matching upload, or events arrive without symbols. |
+| telemetry.sentry.sampleRate | float | `1` | Fraction of captured events actually sent (`telemetry.sentry.sample_rate`). A blunt volume cap — it drops whole issues, not repetitions of one, so a rare error is exactly what it loses — so leave it at `1` unless a quota forces otherwise. |
+| telemetry.sentry.sendDefaultPii | bool | `false` | Send personally identifying data with every event: the client IP, the whole request header set, and a buffered request body (`telemetry.sentry.send_default_pii`). **Off, and worth leaving off** — this server publishes public links, and the address of whoever followed one is not what makes a failed S3 fetch actionable, while Sentry is a third party. It is two controls rather than one, besides: off is also what keeps the HTTP middleware redacting sensitive headers. |
+| telemetry.sentry.serverName | string | `""` | Host tag on every event (`telemetry.sentry.server_name`). Empty reports none, which is the right answer here: the value would be one replica's pod name, gone by the time anyone reads the issue. |
+| telemetry.sentry.shutdownTimeoutSecs | int | `2` | How long process exit waits for queued events to drain (`telemetry.sentry.shutdown_timeout_secs`). Paid on every pod shutdown, so it is time added to every rollout; keep it well inside `terminationGracePeriodSeconds`. `0` discards whatever is still queued. |
+| telemetry.sentry.spanAttributes | bool | `false` | Copy `tracing` span fields onto the Sentry span as attributes (`telemetry.sentry.span_attributes`). Off: the span fields here carry request paths and object keys, and a transaction is retained for longer than a log line. |
+| telemetry.sentry.tracesSampleRate | float | `0` | Fraction of traces this server **starts** that are recorded (`telemetry.sentry.traces_sample_rate`). `0` starts none, which is the sensible setting for a service whose whole job is one redirect, and it is what makes the feature free to switch on for error reporting alone. It does not take the server out of a trace that reaches it already sampled: an inbound `sentry-trace` header is continued whatever this says. |
 | terminationGracePeriodSeconds | int | `30` | Grace period for pod shutdown. |
 | tolerations | list | `[]` | Tolerations for pod assignment. |
 | topologySpreadConstraints | list | `[]` | Pod topology spread constraints for availability. |

--- a/charts/s3-bucket-perma-link/README.md
+++ b/charts/s3-bucket-perma-link/README.md
@@ -519,11 +519,11 @@ policy pointing at the wrong Gateway looks correct and blocks everything.
 | gateway.tls.enabled | bool | `false` | Add an HTTPS listener. |
 | gateway.tls.mode | string | `"Terminate"` | TLS mode. |
 | gateway.tls.options | object | `{}` | Implementation-specific TLS options. |
-| image | object | `{"pullPolicy":"","registry":"","repository":"timmi6790/s3-bucket-perma-link","tag":"v1.1.1@sha256:0f3fb15ccda6fe17400186d16d8a4a4bb249b0d7e6c169f7d5bbb950c6337a76"}` | Container image the pod runs, composed as `registry/repository:tag`. |
+| image | object | `{"pullPolicy":"","registry":"","repository":"timmi6790/s3-bucket-perma-link","tag":"v2.0.0@sha256:a331869902bd25de2ac46873f6f4188a7a524d8f4717e2bbfdcdfc23c31e6520"}` | Container image the pod runs, composed as `registry/repository:tag`. |
 | image.pullPolicy | string | `""` | The image pull policy. Empty resolves automatically from the tag/digest. |
 | image.registry | string | `""` | Registry host. Empty means Docker Hub. |
 | image.repository | string | `"timmi6790/s3-bucket-perma-link"` | The container image repository. |
-| image.tag | string | `"v1.1.1@sha256:0f3fb15ccda6fe17400186d16d8a4a4bb249b0d7e6c169f7d5bbb950c6337a76"` | The container image tag, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the pull, while the tag stays on as the readable version marker. Defaults to the chart's `appVersion` when empty. |
+| image.tag | string | `"v2.0.0@sha256:a331869902bd25de2ac46873f6f4188a7a524d8f4717e2bbfdcdfc23c31e6520"` | The container image tag, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the pull, while the tag stays on as the readable version marker. Defaults to the chart's `appVersion` when empty. |
 | imagePullSecrets | list | `[]` | Optional image pull secrets for private registries. |
 | ingress | object | `{"annotations":{},"enabled":false,"hosts":[],"ingressClassName":"nginx","tls":[]}` | The Ingress in front of the Service. Off by default; `gateway` is the Gateway API alternative and the two are independent switches. |
 | ingress.annotations | object | `{}` | Custom annotations for the Ingress resource. Useful for configuring ingress controllers (e.g., cert-manager, rate limits). |

--- a/charts/s3-bucket-perma-link/README.md.gotmpl
+++ b/charts/s3-bucket-perma-link/README.md.gotmpl
@@ -16,6 +16,7 @@ bucket has to be made public.
 - Kubernetes 1.19+
 - Helm 3.0+
 - An S3-compatible bucket and a credential pair that can read it
+- A Sentry DSN, if `telemetry.sentry.enabled` is set
 - An ingress controller, or the Gateway API CRDs and a `Gateway`, if the links are meant to
   work outside the cluster
 - Cilium 1.16+, if `networkPolicy.engine` is `cilium` or `both`
@@ -93,7 +94,70 @@ Set `configMount.rolloutOnChange: true` to make it behave like an ordinary image
 `s3.accessKey` / `s3.secretKey` are accepted as an alternative to `existingSecret` and make the
 chart render the Secret itself. That puts the credentials into `values.yaml` and into the Helm
 release object, where anyone who can run `helm get values` can read them — use it for a
-throwaway cluster, not for anything real. `existingSecret` wins if both are set.
+throwaway cluster, not for anything real. `existingSecret` wins if both are set. The same is
+true of `telemetry.sentry.dsn`.
+
+## Error reporting and tracing
+
+`telemetry.sentry` reports errors and panics to Sentry, and can record a transaction per
+request. It is off, and inert while it is off: no client, no panic hook, no subscriber layer and
+no HTTP middleware is installed, so nothing leaves the process and nothing about a rendered
+release changes.
+
+```yaml
+telemetry:
+  sentry:
+    enabled: true
+    dsn: https://<key>@<host>/<project>
+```
+
+The DSN embeds a write key for the project's event stream, so the chart treats it as the
+credential it is: it goes to the Secret under `telemetry__sentry__dsn`, alongside the S3 keys,
+and never into the ConfigMap — which matters twice here, because the reload supervisor prints
+the configuration it holds. Switching the feature on with no DSN, neither inline nor in an
+`existingSecret`, is refused at render time: the service refuses to boot rather than installing
+a client that reports nowhere, and a rejected `helm upgrade` beats a CrashLoopBackOff.
+
+**Check the egress.** The chart never reads the DSN, so it cannot name the ingest host in the
+network policies. The defaults do cover it — `networkPolicy.egress.https` permits TCP/443 to
+`0.0.0.0/0` minus private space — so an out-of-the-box release reaches Sentry without further
+work. A release that narrowed `networkPolicy.egress.cidr`, turned `egress.https` off, or
+replaced the CIDR rule with `networkPolicy.cilium.egress.toFQDNs` has to name the endpoint
+itself. Getting that wrong is silent: an SDK that cannot reach its endpoint queues events and
+then discards them, so the project simply stays empty, which reads as "no errors".
+
+```yaml
+networkPolicy:
+  enabled: true
+  extraEgress:
+    - to:
+        - ipBlock:
+            cidr: 34.120.195.249/32 # your ingest endpoint
+      ports:
+        - port: 443
+          protocol: TCP
+```
+
+Under the Cilium engine the same destination is better expressed by name, via
+`networkPolicy.cilium.egress.toFQDNs`.
+
+`tracesSampleRate` is `0` — this server starts no traces of its own, which is the sensible
+setting for a service whose whole job is one redirect. It still continues a trace that arrives
+already sampled, so a caller that does trace sees the hop either way.
+
+`sendDefaultPii` stays off. On, every event carries the client IP, the whole request header set
+and a buffered body, to a third party — and the same flag is what stops the HTTP middleware
+redacting sensitive headers. This service publishes public links; the address of whoever
+followed one is not what makes a failed S3 fetch actionable.
+
+`environment`, `release` and `serverName` are empty by default and the chart writes none of
+them: the service resolves the first two itself, and `release` is also the name the image's
+debug-file upload symbolicates against — overriding it without a matching upload leaves events
+with no symbols.
+
+Unlike the rest of this chart's configuration, `telemetry.sentry` is read once as the process
+boots, so a change to it needs a restart: roll the Deployment, or set
+`configMount.rolloutOnChange: true`.
 
 ## Non-AWS endpoints
 
@@ -110,6 +174,33 @@ existingSecret: s3-credentials
 ```
 
 ## Upgrading
+
+### 4.x to 5.0
+
+Chart 5.0 tracks the service's 2.0 release, which replaced the single `telemetry.sentry_dsn` key
+with a full `telemetry.sentry` block — fifteen settings and the DSN — and made Sentry an optional
+compile-time feature with tracing support. `telemetry.sentryDsn` is gone; a `helm upgrade` with
+4.x values fails schema validation naming the key rather than silently dropping error reporting.
+
+| Before | After |
+|---|---|
+| `telemetry.sentryDsn: https://...` | `telemetry.sentry.enabled: true` **and** `telemetry.sentry.dsn: https://...` |
+| (unset) | (unset — `telemetry.sentry.enabled` defaults to `false`) |
+
+Two behaviours changed along with the spelling:
+
+- **The DSN is a credential now.** 4.x rendered it into `config.toml`, where anything that can
+  read the namespace could print it — and where the reload supervisor's own logging could too.
+  It goes to the Secret instead, under `telemetry__sentry__dsn`, so an `existingSecret` that
+  should carry it needs that key added, and the pod projects it only while
+  `telemetry.sentry.enabled` is set.
+- **The switch is separate from the DSN.** Setting one without the other is refused at render
+  time in both directions: on with no DSN is a boot failure upstream, and a DSN with the switch
+  off is a credential in the release that nothing reads.
+
+Everything else under the block is new and optional, and the defaults reproduce 4.x behaviour.
+Note `attachStacktrace` — singular, unlike the sibling charts in this repository, because that is
+the key this image reads.
 
 ### 3.x to 4.0
 

--- a/charts/s3-bucket-perma-link/ci/sentry.yaml
+++ b/charts/s3-bucket-perma-link/ci/sentry.yaml
@@ -1,0 +1,58 @@
+# Sentry switched on, with the egress rule that makes it reach anything.
+#
+# A render fixture, not an install fixture: an S3 endpoint that does not resolve and a DSN
+# pointing at a host that does not exist. `ct install` takes every `ci/*-values.yaml`, while the
+# render and policy jobs glob `ci/*.yaml`.
+#
+# Every key is set away from its default on purpose. The chart writes the whole block through to
+# one document, so a fixture that left the defaults in place would render the same `config.toml`
+# whether the mapping were right or reversed.
+#
+# `networkPolicy` is here for the half of this feature the chart cannot derive. The DSN is a
+# credential, so the chart never reads it and cannot name the ingest host. The defaults would
+# already reach it — `egress.https` permits TCP/443 to `0.0.0.0/0` minus private space — so the
+# fixture renders the *explicit* form instead, which is what a deployment that narrowed
+# `egress.cidr` or turned `egress.https` off has to write for itself. It names a CIDR because
+# the portable dialect cannot express a hostname; `ci/cilium.yaml` is where `toFQDNs` is
+# exercised.
+s3:
+  accessKey: ci-access-key
+  secretKey: ci-secret-key
+  host: s3.example.com
+  region: eu-central-1
+
+bucket:
+  entries:
+    ci:
+      bucket: ci-bucket
+      object: ci/object.txt
+
+telemetry:
+  logLevel: debug
+  sentry:
+    enabled: true
+    dsn: https://ci0123456789abcdef@sentry.example.com/42
+    environment: ci
+    release: s3-bucket-perma-link@2.0.0
+    serverName: ci-render-fixture
+    sampleRate: 0.5
+    tracesSampleRate: 0.2
+    captureLevel: warn
+    breadcrumbLevel: debug
+    maxBreadcrumbs: 50
+    attachStacktrace: false
+    sendDefaultPii: false
+    httpTransactions: false
+    spanAttributes: true
+    shutdownTimeoutSecs: 5
+    debug: true
+
+networkPolicy:
+  enabled: true
+  extraEgress:
+    - to:
+        - ipBlock:
+            cidr: 34.120.195.249/32
+      ports:
+        - port: 443
+          protocol: TCP

--- a/charts/s3-bucket-perma-link/config-contract.yaml
+++ b/charts/s3-bucket-perma-link/config-contract.yaml
@@ -23,13 +23,15 @@ unbound:
   - keys:
       - s3.access_key
       - s3.secret_key
+      - telemetry.sentry.dsn
     reason: >-
-      Delivered as files in S3_PERMA_LINK_SECRETS_DIR, from `s3.accessKey` and `s3.secretKey`,
-      and never written into `config.toml` — a long-lived object-store credential in a
-      ConfigMap is readable by anything that can read the namespace. Both bindings exist; they
-      run through the Secret rather than through the configuration document the markers
-      describe, and `just check-config-secrets` reconciles that channel from the rendered
-      manifests rather than from a comment.
+      Delivered as files in S3_PERMA_LINK_SECRETS_DIR, from `s3.accessKey`, `s3.secretKey` and
+      `telemetry.sentry.dsn`, and never written into `config.toml` — a long-lived object-store
+      credential in a ConfigMap is readable by anything that can read the namespace, and the
+      Sentry DSN embeds an ingest key that is one too. All three bindings exist; they run
+      through the Secret rather than through the configuration document the markers describe,
+      and `just check-config-secrets` reconciles that channel from the rendered manifests
+      rather than from a comment.
 
 documents:
   - name: server

--- a/charts/s3-bucket-perma-link/contracts/server.json
+++ b/charts/s3-bucket-perma-link/contracts/server.json
@@ -1,15 +1,15 @@
 {
   "source": {
     "image": "docker.io/timmi6790/s3-bucket-perma-link",
-    "digest": "sha256:0f3fb15ccda6fe17400186d16d8a4a4bb249b0d7e6c169f7d5bbb950c6337a76",
-    "sha256": "90c2889892aa32fbae0d5da12be979acc5193bbfb66ac187caf484af10aa9d8a",
-    "fetched": "2026-08-19T12:22:59Z"
+    "digest": "sha256:a331869902bd25de2ac46873f6f4188a7a524d8f4717e2bbfdcdfc23c31e6520",
+    "sha256": "bff2061caad22e5a396ad639e9920d72a180f4bd960f92594252a82f82102096",
+    "fetched": "2026-08-26T14:25:09Z"
   },
   "contract": {
     "terrace_contract": 1,
     "app": {
       "name": "s3-bucket-perma-link",
-      "version": "v1.1.1",
+      "version": "v2.0.0",
       "source": "https://github.com/TimSchoenle/s3-bucket-perma-link"
     },
     "schema": {
@@ -210,7 +210,7 @@
           "env": "S3_PERMA_LINK_TELEMETRY__LOG_LEVEL",
           "env_file": "S3_PERMA_LINK_TELEMETRY__LOG_LEVEL_FILE",
           "secrets_file": "telemetry__log_level",
-          "docs": "How much the service says: `trace`, `debug`, `info`, `warn` or `error`.\n\nParsed by [`Self::level`].",
+          "docs": "How much the service says: `trace`, `debug`, `info`, `warn` or `error`.\n\nThe console sink only. What Sentry takes is `telemetry.sentry.capture_level` and\n`telemetry.sentry.breadcrumb_level`, which are filtered independently.\n\nParsed by [`Self::level`].",
           "ty": "String",
           "values": [],
           "constraint": {
@@ -229,11 +229,38 @@
           "reserved": false
         },
         {
-          "path": "telemetry.sentry_dsn",
-          "env": "S3_PERMA_LINK_TELEMETRY__SENTRY_DSN",
-          "env_file": "S3_PERMA_LINK_TELEMETRY__SENTRY_DSN_FILE",
-          "secrets_file": "telemetry__sentry_dsn",
-          "docs": "Sentry DSN. Absent disables Sentry entirely.\n\nA [`SecretString`]: a DSN is a write credential for the project it names — and, like the\nS3 credentials, one serde must not be able to write back out.",
+          "path": "telemetry.sentry.enabled",
+          "env": "S3_PERMA_LINK_TELEMETRY__SENTRY__ENABLED",
+          "env_file": "S3_PERMA_LINK_TELEMETRY__SENTRY__ENABLED_FILE",
+          "secrets_file": "telemetry__sentry__enabled",
+          "docs": "Initialise the Sentry client. `false` installs no client, no panic hook, no subscriber\nlayer and no HTTP middleware, so every other key in this block is inert.",
+          "ty": "bool",
+          "values": [],
+          "constraint": {
+            "type": "boolean"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(true|false)\\s*$",
+            "type": "string"
+          },
+          "text_form": "boolean",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "false",
+          "default_value": false,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.dsn",
+          "env": "S3_PERMA_LINK_TELEMETRY__SENTRY__DSN",
+          "env_file": "S3_PERMA_LINK_TELEMETRY__SENTRY__DSN_FILE",
+          "secrets_file": "telemetry__sentry__dsn",
+          "docs": "Ingest URL, `https://<key>@<host>/<project>`.\n\nA [`SecretString`]: the embedded key is a bearer credential for the project it names, and\nthis struct is nested inside a [`Config`](super::Config) the reload supervisor logs with\n`{:?}`. Mount it like the S3 credentials rather than committing it — the same `_FILE`\nindirection and secrets-directory layers apply.\n\nAbsent while [`Self::enabled`] is set is a boot failure, not a silent no-op.",
           "ty": "SecretString",
           "values": [],
           "constraint": {
@@ -249,6 +276,352 @@
           "note": null,
           "required": false,
           "secret": true,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.environment",
+          "env": "S3_PERMA_LINK_TELEMETRY__SENTRY__ENVIRONMENT",
+          "env_file": "S3_PERMA_LINK_TELEMETRY__SENTRY__ENVIRONMENT_FILE",
+          "secrets_file": "telemetry__sentry__environment",
+          "docs": "Environment tag on every event, e.g. `production` or `staging`.\n\nUnset resolves to `production` for a release build and `development` for a debug one —\nthe same rule the SDK applies, but applied *here*, so that `SENTRY_ENVIRONMENT` is never\nconsulted. That variable is a second configuration channel that bypasses this loader and\nits shadow-key rejection, and a field the service always sets is one it cannot reach.",
+          "ty": "String",
+          "values": [],
+          "constraint": {
+            "type": "string"
+          },
+          "text_form": "text",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": null,
+          "default_value": null,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.release",
+          "env": "S3_PERMA_LINK_TELEMETRY__SENTRY__RELEASE",
+          "env_file": "S3_PERMA_LINK_TELEMETRY__SENTRY__RELEASE_FILE",
+          "secrets_file": "telemetry__sentry__release",
+          "docs": "Release tag on every event.\n\nUnset resolves to `s3-bucket-perma-link@<crate version>`, which is what makes a\nregression attributable to a deploy. It is also the name the Dockerfile's `sentry-cli\ndebug-files upload` symbolicates against, so overriding it here without matching that\nupload leaves events with no symbols.",
+          "ty": "String",
+          "values": [],
+          "constraint": {
+            "type": "string"
+          },
+          "text_form": "text",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": null,
+          "default_value": null,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.server_name",
+          "env": "S3_PERMA_LINK_TELEMETRY__SENTRY__SERVER_NAME",
+          "env_file": "S3_PERMA_LINK_TELEMETRY__SENTRY__SERVER_NAME_FILE",
+          "secrets_file": "telemetry__sentry__server_name",
+          "docs": "Host tag on every event. Unset reports none: the identity of one replica is\ninfrastructure detail, and in a container it is a pod name that is gone by the time\nanybody reads the issue.",
+          "ty": "String",
+          "values": [],
+          "constraint": {
+            "type": "string"
+          },
+          "text_form": "text",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": null,
+          "default_value": null,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.sample_rate",
+          "env": "S3_PERMA_LINK_TELEMETRY__SENTRY__SAMPLE_RATE",
+          "env_file": "S3_PERMA_LINK_TELEMETRY__SENTRY__SAMPLE_RATE_FILE",
+          "secrets_file": "telemetry__sentry__sample_rate",
+          "docs": "Fraction of captured events actually sent, `0.0`–`1.0`.\n\nA blunt volume cap: it drops whole issues rather than repetitions of one, so a rare\nerror is exactly what it loses. Leave it at `1.0` unless quota forces otherwise.",
+          "ty": "f32",
+          "values": [],
+          "constraint": {
+            "type": "number"
+          },
+          "text_form": "unknown",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "1",
+          "default_value": 1.0,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.traces_sample_rate",
+          "env": "S3_PERMA_LINK_TELEMETRY__SENTRY__TRACES_SAMPLE_RATE",
+          "env_file": "S3_PERMA_LINK_TELEMETRY__SENTRY__TRACES_SAMPLE_RATE_FILE",
+          "secrets_file": "telemetry__sentry__traces_sample_rate",
+          "docs": "Fraction of traces this service **starts** that are recorded, `0.0`–`1.0`.\n\n`0.0` — the default — means it starts none of its own, which is the sensible setting for\na service whose whole job is one redirect: performance data on it is a cost with no\nquestion behind it. It does not remove this service from a trace that reaches it already\nsampled: an inbound `sentry-trace` header is continued regardless, so a caller that does\ntrace still sees the hop.",
+          "ty": "f32",
+          "values": [],
+          "constraint": {
+            "type": "number"
+          },
+          "text_form": "unknown",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "0",
+          "default_value": 0.0,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.capture_level",
+          "env": "S3_PERMA_LINK_TELEMETRY__SENTRY__CAPTURE_LEVEL",
+          "env_file": "S3_PERMA_LINK_TELEMETRY__SENTRY__CAPTURE_LEVEL_FILE",
+          "secrets_file": "telemetry__sentry__capture_level",
+          "docs": "Least severe `tracing` level reported as a Sentry **issue**.",
+          "ty": "SentryLevel",
+          "values": [],
+          "text_form": "unknown",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "error",
+          "default_value": "error",
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.breadcrumb_level",
+          "env": "S3_PERMA_LINK_TELEMETRY__SENTRY__BREADCRUMB_LEVEL",
+          "env_file": "S3_PERMA_LINK_TELEMETRY__SENTRY__BREADCRUMB_LEVEL_FILE",
+          "secrets_file": "telemetry__sentry__breadcrumb_level",
+          "docs": "Least severe `tracing` level kept as a **breadcrumb** — the trail attached to the next\nissue. Records at or above `capture_level` become issues instead.\n\nSpelled as a key rather than as a rustdoc link to [`Self::capture_level`]: this first\nparagraph is a cell in the generated README table, where an intra-doc link renders as\nits own source.\n\nIndependent of [`TelemetryConfig::log_level`](super::TelemetryConfig): the two sinks\ncarry their own filters, so tightening the console to `warn` does not silently empty\nevery breadcrumb trail. The cost is symmetric — asking for `debug` breadcrumbs makes the\nprocess evaluate `debug` records it does not print.",
+          "ty": "SentryLevel",
+          "values": [],
+          "text_form": "unknown",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "info",
+          "default_value": "info",
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.max_breadcrumbs",
+          "env": "S3_PERMA_LINK_TELEMETRY__SENTRY__MAX_BREADCRUMBS",
+          "env_file": "S3_PERMA_LINK_TELEMETRY__SENTRY__MAX_BREADCRUMBS_FILE",
+          "secrets_file": "telemetry__sentry__max_breadcrumbs",
+          "docs": "How many breadcrumbs one event carries.",
+          "ty": "usize",
+          "values": [],
+          "constraint": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*\\+?[0-9]+\\s*$",
+            "type": "string"
+          },
+          "text_form": "integer",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "100",
+          "default_value": 100,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.attach_stacktrace",
+          "env": "S3_PERMA_LINK_TELEMETRY__SENTRY__ATTACH_STACKTRACE",
+          "env_file": "S3_PERMA_LINK_TELEMETRY__SENTRY__ATTACH_STACKTRACE_FILE",
+          "secrets_file": "telemetry__sentry__attach_stacktrace",
+          "docs": "Attach a stack trace to events that carry none of their own.",
+          "ty": "bool",
+          "values": [],
+          "constraint": {
+            "type": "boolean"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(true|false)\\s*$",
+            "type": "string"
+          },
+          "text_form": "boolean",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "true",
+          "default_value": true,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.send_default_pii",
+          "env": "S3_PERMA_LINK_TELEMETRY__SENTRY__SEND_DEFAULT_PII",
+          "env_file": "S3_PERMA_LINK_TELEMETRY__SENTRY__SEND_DEFAULT_PII_FILE",
+          "secrets_file": "telemetry__sentry__send_default_pii",
+          "docs": "Send personally identifying data with every event: the client IP, the full request header\nset, and the request body where one was buffered.\n\n**Off, and worth leaving off.** This service serves public links; the IP address of\nwhoever followed one is not what makes a failed S3 fetch actionable, and Sentry is a\nthird party. On, it also widens what the HTTP middleware records, because the actix\nintegration reads this same flag to decide whether to redact sensitive headers.",
+          "ty": "bool",
+          "values": [],
+          "constraint": {
+            "type": "boolean"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(true|false)\\s*$",
+            "type": "string"
+          },
+          "text_form": "boolean",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "false",
+          "default_value": false,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.http_transactions",
+          "env": "S3_PERMA_LINK_TELEMETRY__SENTRY__HTTP_TRANSACTIONS",
+          "env_file": "S3_PERMA_LINK_TELEMETRY__SENTRY__HTTP_TRANSACTIONS_FILE",
+          "secrets_file": "telemetry__sentry__http_transactions",
+          "docs": "Record one Sentry transaction per request, named by the matched route.\n\nWhether a started transaction is *kept* is [`Self::traces_sample_rate`]'s decision; this\nis the switch for a deployment that wants error reporting and no performance data at all.\nThe per-request hub is installed either way — without it, breadcrumbs from concurrently\nserved requests all land on the main hub and every issue arrives with a trail belonging\nto whoever else was in flight.",
+          "ty": "bool",
+          "values": [],
+          "constraint": {
+            "type": "boolean"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(true|false)\\s*$",
+            "type": "string"
+          },
+          "text_form": "boolean",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "true",
+          "default_value": true,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.span_attributes",
+          "env": "S3_PERMA_LINK_TELEMETRY__SENTRY__SPAN_ATTRIBUTES",
+          "env_file": "S3_PERMA_LINK_TELEMETRY__SENTRY__SPAN_ATTRIBUTES_FILE",
+          "secrets_file": "telemetry__sentry__span_attributes",
+          "docs": "Copy `tracing` span fields onto the Sentry span as attributes.\n\nOff: the span fields here carry request paths and object keys, and a transaction is\nstored under a longer retention than a log line.",
+          "ty": "bool",
+          "values": [],
+          "constraint": {
+            "type": "boolean"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(true|false)\\s*$",
+            "type": "string"
+          },
+          "text_form": "boolean",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "false",
+          "default_value": false,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.shutdown_timeout_secs",
+          "env": "S3_PERMA_LINK_TELEMETRY__SENTRY__SHUTDOWN_TIMEOUT_SECS",
+          "env_file": "S3_PERMA_LINK_TELEMETRY__SENTRY__SHUTDOWN_TIMEOUT_SECS_FILE",
+          "secrets_file": "telemetry__sentry__shutdown_timeout_secs",
+          "docs": "How long process exit waits for queued events to drain, in seconds.\n\nPaid on every shutdown, including the rolling ones a deploy produces, so it trades\nagainst how quickly a replica goes away. `0` discards whatever is still queued.",
+          "ty": "u64",
+          "values": [],
+          "constraint": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*\\+?[0-9]+\\s*$",
+            "type": "string"
+          },
+          "text_form": "integer",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "2",
+          "default_value": 2,
+          "note": null,
+          "required": false,
+          "secret": false,
+          "reserved": false
+        },
+        {
+          "path": "telemetry.sentry.debug",
+          "env": "S3_PERMA_LINK_TELEMETRY__SENTRY__DEBUG",
+          "env_file": "S3_PERMA_LINK_TELEMETRY__SENTRY__DEBUG_FILE",
+          "secrets_file": "telemetry__sentry__debug",
+          "docs": "Print the SDK's own diagnostics to stderr. For proving a DSN works, not for running.",
+          "ty": "bool",
+          "values": [],
+          "constraint": {
+            "type": "boolean"
+          },
+          "text_constraint": {
+            "pattern": "^\\s*(true|false)\\s*$",
+            "type": "string"
+          },
+          "text_form": "boolean",
+          "aliases": [],
+          "env_aliases": [],
+          "env_file_aliases": [],
+          "secrets_file_aliases": [],
+          "default": "false",
+          "default_value": false,
+          "note": null,
+          "required": false,
+          "secret": false,
           "reserved": false
         }
       ]
@@ -314,13 +687,91 @@
           "properties": {
             "log_level": {
               "default": "info",
-              "description": "How much the service says: `trace`, `debug`, `info`, `warn` or `error`.\n\nParsed by [`Self::level`].",
+              "description": "How much the service says: `trace`, `debug`, `info`, `warn` or `error`.\n\nThe console sink only. What Sentry takes is `telemetry.sentry.capture_level` and\n`telemetry.sentry.breadcrumb_level`, which are filtered independently.\n\nParsed by [`Self::level`].",
               "type": "string"
             },
-            "sentry_dsn": {
-              "description": "Sentry DSN. Absent disables Sentry entirely.\n\nA [`SecretString`]: a DSN is a write credential for the project it names — and, like the\nS3 credentials, one serde must not be able to write back out.",
-              "type": "string",
-              "writeOnly": true
+            "sentry": {
+              "additionalProperties": false,
+              "properties": {
+                "attach_stacktrace": {
+                  "default": true,
+                  "description": "Attach a stack trace to events that carry none of their own.",
+                  "type": "boolean"
+                },
+                "breadcrumb_level": {
+                  "default": "info",
+                  "description": "Least severe `tracing` level kept as a **breadcrumb** — the trail attached to the next\nissue. Records at or above `capture_level` become issues instead.\n\nSpelled as a key rather than as a rustdoc link to [`Self::capture_level`]: this first\nparagraph is a cell in the generated README table, where an intra-doc link renders as\nits own source.\n\nIndependent of [`TelemetryConfig::log_level`](super::TelemetryConfig): the two sinks\ncarry their own filters, so tightening the console to `warn` does not silently empty\nevery breadcrumb trail. The cost is symmetric — asking for `debug` breadcrumbs makes the\nprocess evaluate `debug` records it does not print."
+                },
+                "capture_level": {
+                  "default": "error",
+                  "description": "Least severe `tracing` level reported as a Sentry **issue**."
+                },
+                "debug": {
+                  "default": false,
+                  "description": "Print the SDK's own diagnostics to stderr. For proving a DSN works, not for running.",
+                  "type": "boolean"
+                },
+                "dsn": {
+                  "description": "Ingest URL, `https://<key>@<host>/<project>`.\n\nA [`SecretString`]: the embedded key is a bearer credential for the project it names, and\nthis struct is nested inside a [`Config`](super::Config) the reload supervisor logs with\n`{:?}`. Mount it like the S3 credentials rather than committing it — the same `_FILE`\nindirection and secrets-directory layers apply.\n\nAbsent while [`Self::enabled`] is set is a boot failure, not a silent no-op.",
+                  "type": "string",
+                  "writeOnly": true
+                },
+                "enabled": {
+                  "default": false,
+                  "description": "Initialise the Sentry client. `false` installs no client, no panic hook, no subscriber\nlayer and no HTTP middleware, so every other key in this block is inert.",
+                  "type": "boolean"
+                },
+                "environment": {
+                  "description": "Environment tag on every event, e.g. `production` or `staging`.\n\nUnset resolves to `production` for a release build and `development` for a debug one —\nthe same rule the SDK applies, but applied *here*, so that `SENTRY_ENVIRONMENT` is never\nconsulted. That variable is a second configuration channel that bypasses this loader and\nits shadow-key rejection, and a field the service always sets is one it cannot reach.",
+                  "type": "string"
+                },
+                "http_transactions": {
+                  "default": true,
+                  "description": "Record one Sentry transaction per request, named by the matched route.\n\nWhether a started transaction is *kept* is [`Self::traces_sample_rate`]'s decision; this\nis the switch for a deployment that wants error reporting and no performance data at all.\nThe per-request hub is installed either way — without it, breadcrumbs from concurrently\nserved requests all land on the main hub and every issue arrives with a trail belonging\nto whoever else was in flight.",
+                  "type": "boolean"
+                },
+                "max_breadcrumbs": {
+                  "default": 100,
+                  "description": "How many breadcrumbs one event carries.",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "release": {
+                  "description": "Release tag on every event.\n\nUnset resolves to `s3-bucket-perma-link@<crate version>`, which is what makes a\nregression attributable to a deploy. It is also the name the Dockerfile's `sentry-cli\ndebug-files upload` symbolicates against, so overriding it here without matching that\nupload leaves events with no symbols.",
+                  "type": "string"
+                },
+                "sample_rate": {
+                  "default": 1.0,
+                  "description": "Fraction of captured events actually sent, `0.0`–`1.0`.\n\nA blunt volume cap: it drops whole issues rather than repetitions of one, so a rare\nerror is exactly what it loses. Leave it at `1.0` unless quota forces otherwise.",
+                  "type": "number"
+                },
+                "send_default_pii": {
+                  "default": false,
+                  "description": "Send personally identifying data with every event: the client IP, the full request header\nset, and the request body where one was buffered.\n\n**Off, and worth leaving off.** This service serves public links; the IP address of\nwhoever followed one is not what makes a failed S3 fetch actionable, and Sentry is a\nthird party. On, it also widens what the HTTP middleware records, because the actix\nintegration reads this same flag to decide whether to redact sensitive headers.",
+                  "type": "boolean"
+                },
+                "server_name": {
+                  "description": "Host tag on every event. Unset reports none: the identity of one replica is\ninfrastructure detail, and in a container it is a pod name that is gone by the time\nanybody reads the issue.",
+                  "type": "string"
+                },
+                "shutdown_timeout_secs": {
+                  "default": 2,
+                  "description": "How long process exit waits for queued events to drain, in seconds.\n\nPaid on every shutdown, including the rolling ones a deploy produces, so it trades\nagainst how quickly a replica goes away. `0` discards whatever is still queued.",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "span_attributes": {
+                  "default": false,
+                  "description": "Copy `tracing` span fields onto the Sentry span as attributes.\n\nOff: the span fields here carry request paths and object keys, and a transaction is\nstored under a longer retention than a log line.",
+                  "type": "boolean"
+                },
+                "traces_sample_rate": {
+                  "default": 0.0,
+                  "description": "Fraction of traces this service **starts** that are recorded, `0.0`–`1.0`.\n\n`0.0` — the default — means it starts none of its own, which is the sensible setting for\na service whose whole job is one redirect: performance data on it is a cost with no\nquestion behind it. It does not remove this service from a trace that reaches it already\nsampled: an inbound `sentry-trace` header is continued regardless, so a caller that does\ntrace still sees the hop.",
+                  "type": "number"
+                }
+              },
+              "type": "object"
             }
           },
           "type": "object"
@@ -331,20 +782,6 @@
     },
     "external": {
       "env": [
-        {
-          "name": "SENTRY_ENVIRONMENT",
-          "owner": "sentry",
-          "docs": "Environment tag on reported events. Read by `sentry::init`, not by this loader.",
-          "ty": "String",
-          "values": [],
-          "constraint": {
-            "type": "string"
-          },
-          "text_form": "text",
-          "default": "production",
-          "required": false,
-          "secret": false
-        },
         {
           "name": "HTTP_PROXY",
           "owner": "sentry",

--- a/charts/s3-bucket-perma-link/templates/_helpers.tpl
+++ b/charts/s3-bucket-perma-link/templates/_helpers.tpl
@@ -2,9 +2,15 @@
 The configuration the chart derives from its own first-class values, as the TOML tree the
 service reads.
 
-Optional keys are omitted rather than written empty: an empty `telemetry.sentry_dsn` is a
-*supplied* value to the loader, and "Sentry configured with a blank DSN" is not what an
-operator who left it unset meant.
+Optional keys are omitted rather than written empty: an empty
+`telemetry.sentry.environment` is a *supplied* value to the loader, and "reported with a blank
+environment tag" is not what an operator who left it unset meant.
+
+`telemetry.sentry` is written only while its switch is on, for the same reason: every key under
+it is inert otherwise, so writing the block unconditionally would put fifteen settings that do
+nothing into the document an operator reads to find out what the server is doing. The DSN never
+appears here at all — it is a credential, and it goes to the Secret under
+`telemetry__sentry__dsn` alongside the S3 keys.
 */}}
 {{- define "s3-bucket-perma-link.derivedConfig" -}}
 server:
@@ -15,8 +21,29 @@ s3:
   region: {{ .Values.s3.region | quote }}
 telemetry:
   log_level: {{ .Values.telemetry.logLevel | quote }}
-  {{- with .Values.telemetry.sentryDsn }}
-  sentry_dsn: {{ . | quote }}
+  {{- if .Values.telemetry.sentry.enabled }}
+  sentry:
+    enabled: true
+    {{- with .Values.telemetry.sentry.environment }}
+    environment: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.telemetry.sentry.release }}
+    release: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.telemetry.sentry.serverName }}
+    server_name: {{ . | quote }}
+    {{- end }}
+    sample_rate: {{ .Values.telemetry.sentry.sampleRate }}
+    traces_sample_rate: {{ .Values.telemetry.sentry.tracesSampleRate }}
+    capture_level: {{ .Values.telemetry.sentry.captureLevel | quote }}
+    breadcrumb_level: {{ .Values.telemetry.sentry.breadcrumbLevel | quote }}
+    max_breadcrumbs: {{ .Values.telemetry.sentry.maxBreadcrumbs }}
+    attach_stacktrace: {{ .Values.telemetry.sentry.attachStacktrace }}
+    send_default_pii: {{ .Values.telemetry.sentry.sendDefaultPii }}
+    http_transactions: {{ .Values.telemetry.sentry.httpTransactions }}
+    span_attributes: {{ .Values.telemetry.sentry.spanAttributes }}
+    shutdown_timeout_secs: {{ .Values.telemetry.sentry.shutdownTimeoutSecs }}
+    debug: {{ .Values.telemetry.sentry.debug }}
   {{- end }}
 {{- with .Values.bucket.entries }}
 bucket:
@@ -54,10 +81,31 @@ is appended verbatim and never parsed, so a chart that has one steps out of the 
 rejecting a configuration it cannot see.
 */}}
 {{- define "s3-bucket-perma-link.validateValues" -}}
+{{- $messages := list -}}
+{{- /*
+Sentry, checked outside the `configExtraToml` guard below.
+
+Both halves of "a reporter that reports nowhere is worse than none". Upstream refuses to boot
+with the switch on and no DSN, so this is a CrashLoopBackOff rather than a degraded feature, and
+a rejected `helm upgrade` beats one. The DSN cannot arrive through `configExtraToml` either — it
+is a credential and travels the Secret — so unlike the bucket entries below there is nothing
+here the escape hatch could be supplying, and stepping out of the way would only hide the fault.
+An `existingSecret` is taken as the answer, because the chart cannot see inside one.
+
+The converse is the ordinary dead-value check: a DSN set while the switch is off is neither
+written into the Secret nor read by anything, so it would sit in the release meaning nothing —
+and a DSN is a credential to leave lying around.
+*/ -}}
+{{- $sentry := .Values.telemetry.sentry -}}
+{{- if and $sentry.enabled (not $sentry.dsn) (not .Values.existingSecret) -}}
+{{- $messages = append $messages "  - telemetry.sentry.enabled is set but no DSN is available. The server refuses to boot rather than installing a client that reports nowhere, so this is a CrashLoopBackOff, not a degraded feature. Set `telemetry.sentry.dsn`, or put `telemetry__sentry__dsn` in the Secret named by `existingSecret`." -}}
+{{- end -}}
+{{- if and (not $sentry.enabled) $sentry.dsn -}}
+{{- $messages = append $messages "  - telemetry.sentry.dsn is set while telemetry.sentry.enabled is false. No client is installed, so the DSN is neither projected into the pod nor written into the Secret and would sit in the release meaning nothing. Set `telemetry.sentry.enabled=true`, or clear the DSN." -}}
+{{- end -}}
 {{- if not .Values.configExtraToml -}}
 {{- $config := include "s3-bucket-perma-link.effectiveConfig" . | fromYaml -}}
 {{- $entries := $config | dig "bucket" "entries" dict -}}
-{{- $messages := list -}}
 {{- if not $entries -}}
 {{- $messages = append $messages "  - bucket.entries is required but was not set: a server with no entry serves nothing" -}}
 {{- end -}}
@@ -73,9 +121,9 @@ rejecting a configuration it cannot see.
 {{- end -}}
 {{- end -}}
 {{- end -}}
+{{- end -}}
 {{- if $messages -}}
 {{- fail (printf "\n\nVALUES VALIDATION FAILED for chart %q:\n%s\n" .Chart.Name (join "\n" $messages)) -}}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 
@@ -83,10 +131,18 @@ rejecting a configuration it cannot see.
 The credentials this chart manages, keyed by the file name the loader reads them from: a
 configuration path with `__` for nesting and no dots, because a `.` in the name is refused
 rather than treated as a separator.
+
+The Sentry DSN appears only while the switch is on. Listed unconditionally it would survive into
+`s3-bucket-perma-link.secretKeys` under an `existingSecret` — which cannot be read from here, so
+every key the chart knows about is projected — and the pod would mount a file for a client it
+never installs.
 */}}
 {{- define "s3-bucket-perma-link.secretData" -}}
 s3__access_key: {{ .Values.s3.accessKey | quote }}
 s3__secret_key: {{ .Values.s3.secretKey | quote }}
+{{- if .Values.telemetry.sentry.enabled }}
+telemetry__sentry__dsn: {{ .Values.telemetry.sentry.dsn | quote }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/s3-bucket-perma-link/tests/configmap_test.yaml
+++ b/charts/s3-bucket-perma-link/tests/configmap_test.yaml
@@ -51,21 +51,13 @@ tests:
           path: data["config.toml"]
           pattern: '\[bucket\.entries\."docs/handbook"\]'
 
-  # An empty optional value is still a *supplied* value to the loader, and "Sentry configured
-  # with a blank DSN" is not what leaving it unset meant.
-  - it: omits an unset Sentry DSN rather than writing it empty
+  # Off has to mean *absent*, not "present and false": every key under the block is inert while
+  # the switch is down. `tests/sentry_test.yaml` is where the block itself is exercised.
+  - it: writes no Sentry block while the switch is off
     asserts:
       - notMatchRegex:
           path: data["config.toml"]
-          pattern: 'sentry_dsn'
-
-  - it: writes the Sentry DSN once it is set
-    set:
-      telemetry.sentryDsn: https://key@sentry.example.invalid/1
-    asserts:
-      - matchRegex:
-          path: data["config.toml"]
-          pattern: 'sentry_dsn = "https://key@sentry\.example\.invalid/1"'
+          pattern: 'sentry'
 
   - it: merges the raw config tree over the derived values
     set:

--- a/charts/s3-bucket-perma-link/tests/contract_roundtrip_server_test.yaml
+++ b/charts/s3-bucket-perma-link/tests/contract_roundtrip_server_test.yaml
@@ -8,7 +8,7 @@
 # Chart:       s3-bucket-perma-link
 # Declaration: charts/s3-bucket-perma-link/config-contract.yaml (document `server`)
 # Contract:    charts/s3-bucket-perma-link/contracts/server.json
-# Coverage:    5 of 9 contract keys carry a probe
+# Coverage:    16 of 24 contract keys carry a probe
 #
 # Regenerate with `just contract-tests`. `just check-contract-tests` fails a pull request whose
 # committed copy has drifted from the contract it was generated against.
@@ -112,6 +112,127 @@ tests:
           path: data["config.toml"]
           pattern: '(?m)^\[telemetry\]$\n(?:[^\[\n][^\n]*\n|\n)*^log_level = "contract-probe-telemetry-log-level"$'
 
+  - it: delivers telemetry.sentry.attach_stacktrace into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      bucket.entries: {"render-prerequisite": {"bucket": "render-prerequisite", "object": "render-prerequisite"}}
+      config.telemetry.sentry.attach_stacktrace: false
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^attach_stacktrace = false$'
+
+  - it: delivers telemetry.sentry.debug into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      bucket.entries: {"render-prerequisite": {"bucket": "render-prerequisite", "object": "render-prerequisite"}}
+      config.telemetry.sentry.debug: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^debug = true$'
+
+  - it: delivers telemetry.sentry.enabled into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      bucket.entries: {"render-prerequisite": {"bucket": "render-prerequisite", "object": "render-prerequisite"}}
+      config.telemetry.sentry.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^enabled = true$'
+
+  - it: delivers telemetry.sentry.environment into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      bucket.entries: {"render-prerequisite": {"bucket": "render-prerequisite", "object": "render-prerequisite"}}
+      config.telemetry.sentry.environment: contract-probe-telemetry-sentry-environment
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^environment = "contract-probe-telemetry-sentry-environment"$'
+
+  - it: delivers telemetry.sentry.http_transactions into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      bucket.entries: {"render-prerequisite": {"bucket": "render-prerequisite", "object": "render-prerequisite"}}
+      config.telemetry.sentry.http_transactions: false
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^http_transactions = false$'
+
+  - it: delivers telemetry.sentry.max_breadcrumbs into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      bucket.entries: {"render-prerequisite": {"bucket": "render-prerequisite", "object": "render-prerequisite"}}
+      config.telemetry.sentry.max_breadcrumbs: 4242
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^max_breadcrumbs = 4242$'
+
+  - it: delivers telemetry.sentry.release into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      bucket.entries: {"render-prerequisite": {"bucket": "render-prerequisite", "object": "render-prerequisite"}}
+      config.telemetry.sentry.release: contract-probe-telemetry-sentry-release
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^release = "contract-probe-telemetry-sentry-release"$'
+
+  - it: delivers telemetry.sentry.send_default_pii into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      bucket.entries: {"render-prerequisite": {"bucket": "render-prerequisite", "object": "render-prerequisite"}}
+      config.telemetry.sentry.send_default_pii: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^send_default_pii = true$'
+
+  - it: delivers telemetry.sentry.server_name into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      bucket.entries: {"render-prerequisite": {"bucket": "render-prerequisite", "object": "render-prerequisite"}}
+      config.telemetry.sentry.server_name: contract-probe-telemetry-sentry-server-name
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^server_name = "contract-probe-telemetry-sentry-server-name"$'
+
+  - it: delivers telemetry.sentry.shutdown_timeout_secs into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      bucket.entries: {"render-prerequisite": {"bucket": "render-prerequisite", "object": "render-prerequisite"}}
+      config.telemetry.sentry.shutdown_timeout_secs: 4242
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^shutdown_timeout_secs = 4242$'
+
+  - it: delivers telemetry.sentry.span_attributes into config.toml
+    documentSelector:
+      path: data["config.toml"]
+    set:
+      bucket.entries: {"render-prerequisite": {"bucket": "render-prerequisite", "object": "render-prerequisite"}}
+      config.telemetry.sentry.span_attributes: true
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '(?m)^\[telemetry\.sentry\]$\n(?:[^\[\n][^\n]*\n|\n)*^span_attributes = true$'
+
   # Contract keys carrying no case, and why. An unexplained absence is indistinguishable from an
   # oversight, so every one of them is named here rather than simply left out.
   #
@@ -122,5 +243,13 @@ tests:
   #                credential-shaped value in a test file is a credential
   # s3.secret_key: `secret: true`: the probe would be committed to this repository, and a
   #                credential-shaped value in a test file is a credential
-  # telemetry.sentry_dsn: `secret: true`: the probe would be committed to this repository, and a
+  # telemetry.sentry.breadcrumb_level: `unknown`: the producer publishes no constraint for this
+  #                                    key, so no probe can be known-valid
+  # telemetry.sentry.capture_level: `unknown`: the producer publishes no constraint for this
+  #                                 key, so no probe can be known-valid
+  # telemetry.sentry.dsn: `secret: true`: the probe would be committed to this repository, and a
   #                       credential-shaped value in a test file is a credential
+  # telemetry.sentry.sample_rate: `unknown`: the producer publishes no constraint for this key,
+  #                               so no probe can be known-valid
+  # telemetry.sentry.traces_sample_rate: `unknown`: the producer publishes no constraint for
+  #                                      this key, so no probe can be known-valid

--- a/charts/s3-bucket-perma-link/tests/deployment_test.yaml
+++ b/charts/s3-bucket-perma-link/tests/deployment_test.yaml
@@ -109,6 +109,36 @@ tests:
             mountPath: /etc/s3-bucket-perma-link/secrets
             readOnly: true
 
+  # `common.fileConfig.secretKeys` projects every key the chart knows about once an
+  # `existingSecret` is named, because it cannot read one. A DSN key listed unconditionally would
+  # therefore mount a file for a client that is never installed.
+  - it: projects no DSN key while Sentry is off
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      existingSecret: my-s3-secret
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes[?(@.name == "secrets")].projected.sources[0].secret.items
+          content:
+            key: telemetry__sentry__dsn
+            path: telemetry__sentry__dsn
+
+  - it: projects the DSN key once Sentry is on
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      existingSecret: my-s3-secret
+      telemetry.sentry.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes[?(@.name == "secrets")].projected.sources[0].secret.items
+          content:
+            key: telemetry__sentry__dsn
+            path: telemetry__sentry__dsn
+
   - it: projects an existing Secret when one is given
     documentSelector:
       path: kind

--- a/charts/s3-bucket-perma-link/tests/sentry_test.yaml
+++ b/charts/s3-bucket-perma-link/tests/sentry_test.yaml
@@ -1,0 +1,247 @@
+# Sentry error reporting and request tracing: an optional feature whose whole risk is asymmetric.
+#
+# Off, it must change nothing at all — not a key in the ConfigMap, not a key in the Secret —
+# because it is off in every release that has not asked for it. On, fifteen settings have to
+# arrive at fifteen distinct paths, and a value that lands at the wrong one is a compiled default
+# nobody chose rather than an error. Two of those paths are traps: `attach_stacktrace` is
+# singular here where every sibling service spells it plural, and `send_default_pii` is the one
+# whose wrong answer is a privacy incident rather than a bug.
+#
+# So the suite is written around the edges: what is absent while it is off, what is present when
+# it is on, and where the DSN is allowed to appear. The assertion that the DSN never reaches the
+# ConfigMap is the one here whose failure would be a disclosure.
+#
+# The pod-shape assertions live in `deployment_test.yaml` instead. A suite that lists
+# `deployment.yaml` cannot also carry a `failedTemplate` assertion — helm-unittest reports "no
+# failed document" for the whole suite — and the validation this feature adds is the half worth
+# testing.
+suite: sentry
+templates:
+  - configmap.yaml
+  - secret.yaml
+set:
+  bucket.entries:
+    logo:
+      bucket: my-bucket
+      object: logo.png
+tests:
+  # Off has to mean *absent*, not "present and false": every key under the block is inert while
+  # the switch is down, so writing them would put fifteen settings that do nothing into the
+  # document an operator reads to find out what the server is doing.
+  - it: writes no Sentry block at all while the switch is off
+    template: configmap.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'sentry'
+
+  - it: writes the whole block when the switch is on
+    template: configmap.yaml
+    set:
+      telemetry.sentry:
+        enabled: true
+        dsn: https://key@sentry.example.invalid/1
+        environment: staging
+        release: s3-bucket-perma-link@2.0.0
+        serverName: link-a
+        sampleRate: 0.5
+        tracesSampleRate: 0.25
+        captureLevel: warn
+        breadcrumbLevel: debug
+        maxBreadcrumbs: 50
+        attachStacktrace: false
+        sendDefaultPii: true
+        httpTransactions: false
+        spanAttributes: true
+        shutdownTimeoutSecs: 5
+        debug: true
+    asserts:
+      # One assertion per key, and every value set away from its default: the defect class this
+      # suite exists for is a value arriving at the wrong path, which a fixture that left the
+      # defaults in place would render identically whether the mapping were right or reversed.
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[telemetry\.sentry\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nenabled = true'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nenvironment = "staging"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nrelease = "s3-bucket-perma-link@2\.0\.0"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nserver_name = "link-a"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nsample_rate = 0\.5'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\ntraces_sample_rate = 0\.25'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\ncapture_level = "warn"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nbreadcrumb_level = "debug"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nmax_breadcrumbs = 50'
+      # Singular. The plural spelling every sibling chart uses would be a key this image does
+      # not read, and the compiled default would win in silence.
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nattach_stacktrace = false'
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'attach_stacktraces'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nsend_default_pii = true'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nhttp_transactions = false'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nspan_attributes = true'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nshutdown_timeout_secs = 5'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\ndebug = true'
+
+  # An empty optional value is a *supplied* value to the loader, and "reported with a blank
+  # environment tag" is not what leaving it unset meant. These three have no chart default
+  # because the server derives all of them.
+  - it: omits the three derived tags rather than writing them empty
+    template: configmap.yaml
+    set:
+      telemetry.sentry.enabled: true
+      telemetry.sentry.dsn: https://key@sentry.example.invalid/1
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'environment'
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'release'
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'server_name'
+      # The keys that do have a chart default are still written, so the document says what the
+      # server is actually doing rather than leaving it to the struct.
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nsample_rate = 1'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\ncapture_level = "error"'
+
+  # This server publishes public links; the address of whoever followed one is not what makes a
+  # failed S3 fetch actionable, and the same flag is what stops the HTTP middleware redacting
+  # sensitive headers. Off is the chart default and has to stay it.
+  - it: leaves personally identifying data off by default
+    template: configmap.yaml
+    set:
+      telemetry.sentry.enabled: true
+      telemetry.sentry.dsn: https://key@sentry.example.invalid/1
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\nsend_default_pii = false'
+
+  # The DSN embeds an ingest key, and the reload supervisor prints the configuration it holds. A
+  # ConfigMap is readable by anything that can read the namespace, so it travels the channel the
+  # S3 credentials do.
+  - it: keeps the DSN out of the ConfigMap
+    template: configmap.yaml
+    set:
+      telemetry.sentry.enabled: true
+      telemetry.sentry.dsn: https://key@sentry.example.invalid/1
+    asserts:
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'dsn'
+
+  - it: writes the DSN into the Secret under the path the loader reads
+    template: secret.yaml
+    set:
+      telemetry.sentry.enabled: true
+      telemetry.sentry.dsn: https://key@sentry.example.invalid/1
+    asserts:
+      - equal:
+          path: stringData.telemetry__sentry__dsn
+          value: https://key@sentry.example.invalid/1
+
+  - it: writes no DSN key into the Secret while the switch is off
+    template: secret.yaml
+    set:
+      s3.accessKey: test-access
+      s3.secretKey: test-secret
+    asserts:
+      - notExists:
+          path: stringData.telemetry__sentry__dsn
+
+  # Upstream refuses to boot with the switch on and no DSN, so this is a CrashLoopBackOff rather
+  # than a degraded feature — worth catching at render time.
+  - it: refuses the switch with no DSN anywhere
+    template: configmap.yaml
+    set:
+      telemetry.sentry.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "telemetry.sentry.enabled is set but no DSN is available"
+
+  # The chart cannot see inside an `existingSecret`, and a DSN it cannot see is not the same as
+  # a DSN that is missing.
+  - it: accepts an existing Secret as the DSN it cannot see
+    template: configmap.yaml
+    set:
+      telemetry.sentry.enabled: true
+      existingSecret: my-s3-secret
+    asserts:
+      - isKind:
+          of: ConfigMap
+
+  # The ordinary dead-value check: a credential sitting in the release meaning nothing.
+  - it: refuses a DSN set while the switch is off
+    template: configmap.yaml
+    set:
+      telemetry.sentry.dsn: https://key@sentry.example.invalid/1
+    asserts:
+      - failedTemplate:
+          errorPattern: "telemetry.sentry.dsn is set while telemetry.sentry.enabled is false"
+
+  # `configExtraToml` makes the bucket checks step out of the way, because it is appended
+  # verbatim and could be supplying the entries. It cannot be supplying the DSN — that travels
+  # the Secret — so the Sentry checks stay on.
+  - it: still refuses a bad Sentry pair behind configExtraToml
+    template: configmap.yaml
+    set:
+      configExtraToml: |
+        [bucket.entries.extra]
+        bucket = "b"
+        object = "o"
+      telemetry.sentry.dsn: https://key@sentry.example.invalid/1
+    asserts:
+      - failedTemplate:
+          errorPattern: "telemetry.sentry.dsn is set while telemetry.sentry.enabled is false"
+
+  # `config` is the highest-precedence layer the chart renders, so it has to be able to reach
+  # inside a block the first-class values built.
+  - it: lets the raw config tree override a derived Sentry key
+    template: configmap.yaml
+    set:
+      telemetry.sentry.enabled: true
+      telemetry.sentry.dsn: https://key@sentry.example.invalid/1
+      config:
+        telemetry:
+          sentry:
+            traces_sample_rate: 0.75
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\ntraces_sample_rate = 0\.75'

--- a/charts/s3-bucket-perma-link/values.schema.json
+++ b/charts/s3-bucket-perma-link/values.schema.json
@@ -1339,7 +1339,7 @@
     },
     "existingSecret": {
       "default": "",
-      "description": "Name of an existing Secret holding the S3 credentials, which keeps them out of\n`values.yaml` and out of the Helm release object. **Its keys are the configuration paths, not\nfree-form names**: `s3__access_key` and `s3__secret_key`, because the file name is what the\nloader parses. Set, the chart renders no Secret of its own and `s3.accessKey` / `s3.secretKey`\nare ignored.",
+      "description": "Name of an existing Secret holding the server's credentials, which keeps them out of\n`values.yaml` and out of the Helm release object. **Its keys are the configuration paths, not\nfree-form names**: `s3__access_key`, `s3__secret_key` and, once `telemetry.sentry.enabled` is\nset, `telemetry__sentry__dsn` — because the file name is what the loader parses. Set, the\nchart renders no Secret of its own and `s3.accessKey`, `s3.secretKey` and\n`telemetry.sentry.dsn` are ignored.",
       "required": [],
       "title": "existingSecret",
       "type": "string"
@@ -2636,12 +2636,145 @@
           "required": [],
           "title": "logLevel"
         },
-        "sentryDsn": {
-          "default": "",
-          "description": "Sentry DSN (`telemetry.sentry_dsn`). Empty disables Sentry entirely.",
+        "sentry": {
+          "additionalProperties": true,
+          "description": "Sentry error reporting and request tracing. **Off**, and wholly inert while it is: no\nclient, no panic hook, no subscriber layer and no HTTP middleware is installed, and nothing\nleaves the process.\n\nTwo things the chart deliberately does not do for you. It never reads the DSN, so it cannot\nname the ingest host in the NetworkPolicies. The defaults do happen to cover it —\n`networkPolicy.egress.https` permits TCP/443 to `0.0.0.0/0` minus private space — but a\ndeployment that narrowed `networkPolicy.egress.cidr`, turned `egress.https` off, or replaced\nthe CIDR rule with `networkPolicy.cilium.egress.toFQDNs` has to name the endpoint itself,\nand getting that wrong is silent: an SDK that cannot reach its endpoint queues events and\nthen discards them, so the project stays empty, which reads as \"no errors\". And it\nconfigures nothing inside Sentry — the project, its quota and its server-side data-scrubbing\nrules are yours.\n\nUnlike the rest of this chart's configuration, the block is read once as the process boots\nrather than re-read when the kubelet refreshes the mount, so a change to it takes effect on\nthe next restart. `configMount.rolloutOnChange` is what turns one into a rollout.",
+          "properties": {
+            "attachStacktrace": {
+              "default": true,
+              "description": "Attach a stack trace to events that carry none of their own\n(`telemetry.sentry.attach_stacktrace`, singular).",
+              "required": [],
+              "title": "attachStacktrace",
+              "type": "boolean"
+            },
+            "breadcrumbLevel": {
+              "default": "info",
+              "description": "Least severe `tracing` level kept as a breadcrumb, the trail attached to the next issue\n(`telemetry.sentry.breadcrumb_level`). Records at or above `captureLevel` become issues\ninstead. Independent of `logLevel`, so tightening the console does not silently empty every\ntrail — and asking for `debug` breadcrumbs makes the process evaluate `debug` records it\ndoes not print. Quote `\"off\"`.",
+              "enum": [
+                "off",
+                "error",
+                "warn",
+                "info",
+                "debug",
+                "trace"
+              ],
+              "required": [],
+              "title": "breadcrumbLevel"
+            },
+            "captureLevel": {
+              "default": "error",
+              "description": "Least severe `tracing` level reported as a Sentry issue\n(`telemetry.sentry.capture_level`). Quote `\"off\"` — unquoted, YAML reads it as the boolean\n`false`.",
+              "enum": [
+                "off",
+                "error",
+                "warn",
+                "info",
+                "debug",
+                "trace"
+              ],
+              "required": [],
+              "title": "captureLevel"
+            },
+            "debug": {
+              "default": false,
+              "description": "Print the SDK's own diagnostics to stderr (`telemetry.sentry.debug`). For proving a DSN\nworks, not for running.",
+              "required": [],
+              "title": "debug",
+              "type": "boolean"
+            },
+            "dsn": {
+              "default": "",
+              "description": "Ingest URL, `https://\u003ckey\u003e@\u003chost\u003e/\u003cproject\u003e`. A credential — the embedded key is a\nbearer token for the project's ingest endpoint, and the reload supervisor prints the\nconfiguration it holds — so it is delivered as a file in `S3_PERMA_LINK_SECRETS_DIR` under\n`telemetry__sentry__dsn`, alongside the S3 credentials, and never written into the\nConfigMap. Leave it empty and put that key in the Secret named by `existingSecret` to keep\nit out of `helm get values` entirely.",
+              "required": [],
+              "title": "dsn",
+              "type": "string"
+            },
+            "enabled": {
+              "default": false,
+              "description": "Initialise the Sentry client (`telemetry.sentry.enabled`). Off, every other key here is\ninert. On, the server refuses to boot without a DSN rather than starting with a reporter\nthat reports nowhere, so this and `dsn` are set together.",
+              "required": [],
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "environment": {
+              "default": "",
+              "description": "Environment tag on every event (`telemetry.sentry.environment`). Empty lets the server\nresolve it: `production` from a release build, `development` from a debug one. It always\nsends one, so `SENTRY_ENVIRONMENT` — a channel that would bypass the layered loader\nentirely — is never consulted.",
+              "required": [],
+              "title": "environment",
+              "type": "string"
+            },
+            "httpTransactions": {
+              "default": true,
+              "description": "Record one transaction per request, named by the matched route rather than by the URI\n(`telemetry.sentry.http_transactions`). Whether a started transaction is kept is\n`tracesSampleRate`'s decision; this is the switch for a deployment that wants error\nreporting and no performance data at all. The per-request hub is installed either way,\nwhich is what stops breadcrumbs from concurrent requests landing on one another's issues.",
+              "required": [],
+              "title": "httpTransactions",
+              "type": "boolean"
+            },
+            "maxBreadcrumbs": {
+              "default": 100,
+              "description": "How many breadcrumbs one event carries (`telemetry.sentry.max_breadcrumbs`).",
+              "minimum": 0,
+              "required": [],
+              "title": "maxBreadcrumbs",
+              "type": "integer"
+            },
+            "release": {
+              "default": "",
+              "description": "Release tag on every event (`telemetry.sentry.release`). Empty uses\n`s3-bucket-perma-link@\u003cversion\u003e`, which is both what makes a regression attributable to a\ndeploy and the name the image's debug-file upload symbolicates against — override it only\nalongside a matching upload, or events arrive without symbols.",
+              "required": [],
+              "title": "release",
+              "type": "string"
+            },
+            "sampleRate": {
+              "default": 1,
+              "description": "Fraction of captured events actually sent (`telemetry.sentry.sample_rate`). A blunt\nvolume cap — it drops whole issues, not repetitions of one, so a rare error is exactly what\nit loses — so leave it at `1` unless a quota forces otherwise.",
+              "maximum": 1,
+              "minimum": 0,
+              "required": [],
+              "title": "sampleRate",
+              "type": "number"
+            },
+            "sendDefaultPii": {
+              "default": false,
+              "description": "Send personally identifying data with every event: the client IP, the whole request\nheader set, and a buffered request body (`telemetry.sentry.send_default_pii`). **Off, and\nworth leaving off** — this server publishes public links, and the address of whoever\nfollowed one is not what makes a failed S3 fetch actionable, while Sentry is a third party.\nIt is two controls rather than one, besides: off is also what keeps the HTTP middleware\nredacting sensitive headers.",
+              "required": [],
+              "title": "sendDefaultPii",
+              "type": "boolean"
+            },
+            "serverName": {
+              "default": "",
+              "description": "Host tag on every event (`telemetry.sentry.server_name`). Empty reports none, which is\nthe right answer here: the value would be one replica's pod name, gone by the time anyone\nreads the issue.",
+              "required": [],
+              "title": "serverName",
+              "type": "string"
+            },
+            "shutdownTimeoutSecs": {
+              "default": 2,
+              "description": "How long process exit waits for queued events to drain\n(`telemetry.sentry.shutdown_timeout_secs`). Paid on every pod shutdown, so it is time added\nto every rollout; keep it well inside `terminationGracePeriodSeconds`. `0` discards\nwhatever is still queued.",
+              "minimum": 0,
+              "required": [],
+              "title": "shutdownTimeoutSecs",
+              "type": "integer"
+            },
+            "spanAttributes": {
+              "default": false,
+              "description": "Copy `tracing` span fields onto the Sentry span as attributes\n(`telemetry.sentry.span_attributes`). Off: the span fields here carry request paths and\nobject keys, and a transaction is retained for longer than a log line.",
+              "required": [],
+              "title": "spanAttributes",
+              "type": "boolean"
+            },
+            "tracesSampleRate": {
+              "default": 0,
+              "description": "Fraction of traces this server **starts** that are recorded\n(`telemetry.sentry.traces_sample_rate`). `0` starts none, which is the sensible setting for\na service whose whole job is one redirect, and it is what makes the feature free to switch\non for error reporting alone. It does not take the server out of a trace that reaches it\nalready sampled: an inbound `sentry-trace` header is continued whatever this says.",
+              "maximum": 1,
+              "minimum": 0,
+              "required": [],
+              "title": "tracesSampleRate",
+              "type": "number"
+            }
+          },
           "required": [],
-          "title": "sentryDsn",
-          "type": "string"
+          "title": "sentry"
         }
       },
       "required": [],

--- a/charts/s3-bucket-perma-link/values.schema.json
+++ b/charts/s3-bucket-perma-link/values.schema.json
@@ -1639,7 +1639,7 @@
           "type": "string"
         },
         "tag": {
-          "default": "v1.1.1@sha256:0f3fb15ccda6fe17400186d16d8a4a4bb249b0d7e6c169f7d5bbb950c6337a76",
+          "default": "v2.0.0@sha256:a331869902bd25de2ac46873f6f4188a7a524d8f4717e2bbfdcdfc23c31e6520",
           "description": "The container image tag, pinned by digest (`vX.Y.Z\npull, while the tag stays on as the readable version marker. Defaults to the chart's\n`appVersion` when empty.",
           "required": [],
           "title": "tag",

--- a/charts/s3-bucket-perma-link/values.yaml
+++ b/charts/s3-bucket-perma-link/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- The container image tag, pinned by digest (`vX.Y.Z@sha256:...`). The digest pins the
   # pull, while the tag stays on as the readable version marker. Defaults to the chart's
   # `appVersion` when empty.
-  tag: v1.1.1@sha256:0f3fb15ccda6fe17400186d16d8a4a4bb249b0d7e6c169f7d5bbb950c6337a76
+  tag: v2.0.0@sha256:a331869902bd25de2ac46873f6f4188a7a524d8f4717e2bbfdcdfc23c31e6520
 
   # @schema
   # enum: ["", Always, IfNotPresent, Never]

--- a/charts/s3-bucket-perma-link/values.yaml
+++ b/charts/s3-bucket-perma-link/values.yaml
@@ -129,20 +129,195 @@ telemetry:
   logLevel: info
 
   # @schema
-  # # @config projection telemetry.sentry_dsn optional
-  # type: string
+  # additionalProperties: true
   # @schema
-  # -- Sentry DSN (`telemetry.sentry_dsn`). Empty disables Sentry entirely.
-  sentryDsn: ""
+  # -- Sentry error reporting and request tracing. **Off**, and wholly inert while it is: no
+  # client, no panic hook, no subscriber layer and no HTTP middleware is installed, and nothing
+  # leaves the process.
+  #
+  # Two things the chart deliberately does not do for you. It never reads the DSN, so it cannot
+  # name the ingest host in the NetworkPolicies. The defaults do happen to cover it —
+  # `networkPolicy.egress.https` permits TCP/443 to `0.0.0.0/0` minus private space — but a
+  # deployment that narrowed `networkPolicy.egress.cidr`, turned `egress.https` off, or replaced
+  # the CIDR rule with `networkPolicy.cilium.egress.toFQDNs` has to name the endpoint itself,
+  # and getting that wrong is silent: an SDK that cannot reach its endpoint queues events and
+  # then discards them, so the project stays empty, which reads as "no errors". And it
+  # configures nothing inside Sentry — the project, its quota and its server-side data-scrubbing
+  # rules are yours.
+  #
+  # Unlike the rest of this chart's configuration, the block is read once as the process boots
+  # rather than re-read when the kubelet refreshes the mount, so a change to it takes effect on
+  # the next restart. `configMount.rolloutOnChange` is what turns one into a rollout.
+  sentry:
+    # @schema
+    # # @config projection telemetry.sentry.enabled optional
+    # type: boolean
+    # @schema
+    # -- Initialise the Sentry client (`telemetry.sentry.enabled`). Off, every other key here is
+    # inert. On, the server refuses to boot without a DSN rather than starting with a reporter
+    # that reports nowhere, so this and `dsn` are set together.
+    enabled: false
+
+    # @schema
+    # type: string
+    # @schema
+    # -- Ingest URL, `https://<key>@<host>/<project>`. A credential — the embedded key is a
+    # bearer token for the project's ingest endpoint, and the reload supervisor prints the
+    # configuration it holds — so it is delivered as a file in `S3_PERMA_LINK_SECRETS_DIR` under
+    # `telemetry__sentry__dsn`, alongside the S3 credentials, and never written into the
+    # ConfigMap. Leave it empty and put that key in the Secret named by `existingSecret` to keep
+    # it out of `helm get values` entirely.
+    dsn: ""
+
+    # @schema
+    # # @config projection telemetry.sentry.environment optional when telemetry.sentry.enabled
+    # type: string
+    # @schema
+    # -- Environment tag on every event (`telemetry.sentry.environment`). Empty lets the server
+    # resolve it: `production` from a release build, `development` from a debug one. It always
+    # sends one, so `SENTRY_ENVIRONMENT` — a channel that would bypass the layered loader
+    # entirely — is never consulted.
+    environment: ""
+
+    # @schema
+    # # @config projection telemetry.sentry.release optional when telemetry.sentry.enabled
+    # type: string
+    # @schema
+    # -- Release tag on every event (`telemetry.sentry.release`). Empty uses
+    # `s3-bucket-perma-link@<version>`, which is both what makes a regression attributable to a
+    # deploy and the name the image's debug-file upload symbolicates against — override it only
+    # alongside a matching upload, or events arrive without symbols.
+    release: ""
+
+    # @schema
+    # # @config projection telemetry.sentry.server_name optional when telemetry.sentry.enabled
+    # type: string
+    # @schema
+    # -- Host tag on every event (`telemetry.sentry.server_name`). Empty reports none, which is
+    # the right answer here: the value would be one replica's pod name, gone by the time anyone
+    # reads the issue.
+    serverName: ""
+
+    # @schema
+    # # @config projection telemetry.sentry.sample_rate when telemetry.sentry.enabled
+    # type: number
+    # minimum: 0
+    # maximum: 1
+    # @schema
+    # -- Fraction of captured events actually sent (`telemetry.sentry.sample_rate`). A blunt
+    # volume cap — it drops whole issues, not repetitions of one, so a rare error is exactly what
+    # it loses — so leave it at `1` unless a quota forces otherwise.
+    sampleRate: 1.0
+
+    # @schema
+    # # @config projection telemetry.sentry.traces_sample_rate when telemetry.sentry.enabled
+    # type: number
+    # minimum: 0
+    # maximum: 1
+    # @schema
+    # -- Fraction of traces this server **starts** that are recorded
+    # (`telemetry.sentry.traces_sample_rate`). `0` starts none, which is the sensible setting for
+    # a service whose whole job is one redirect, and it is what makes the feature free to switch
+    # on for error reporting alone. It does not take the server out of a trace that reaches it
+    # already sampled: an inbound `sentry-trace` header is continued whatever this says.
+    tracesSampleRate: 0.0
+
+    # @schema
+    # # @config projection telemetry.sentry.capture_level when telemetry.sentry.enabled
+    # enum: ["off", error, warn, info, debug, trace]
+    # @schema
+    # -- Least severe `tracing` level reported as a Sentry issue
+    # (`telemetry.sentry.capture_level`). Quote `"off"` — unquoted, YAML reads it as the boolean
+    # `false`.
+    captureLevel: error
+
+    # @schema
+    # # @config projection telemetry.sentry.breadcrumb_level when telemetry.sentry.enabled
+    # enum: ["off", error, warn, info, debug, trace]
+    # @schema
+    # -- Least severe `tracing` level kept as a breadcrumb, the trail attached to the next issue
+    # (`telemetry.sentry.breadcrumb_level`). Records at or above `captureLevel` become issues
+    # instead. Independent of `logLevel`, so tightening the console does not silently empty every
+    # trail — and asking for `debug` breadcrumbs makes the process evaluate `debug` records it
+    # does not print. Quote `"off"`.
+    breadcrumbLevel: info
+
+    # @schema
+    # # @config projection telemetry.sentry.max_breadcrumbs when telemetry.sentry.enabled
+    # type: integer
+    # minimum: 0
+    # @schema
+    # -- How many breadcrumbs one event carries (`telemetry.sentry.max_breadcrumbs`).
+    maxBreadcrumbs: 100
+
+    # @schema
+    # # @config projection telemetry.sentry.attach_stacktrace when telemetry.sentry.enabled
+    # type: boolean
+    # @schema
+    # -- Attach a stack trace to events that carry none of their own
+    # (`telemetry.sentry.attach_stacktrace`, singular).
+    attachStacktrace: true
+
+    # @schema
+    # # @config projection telemetry.sentry.send_default_pii when telemetry.sentry.enabled
+    # type: boolean
+    # @schema
+    # -- Send personally identifying data with every event: the client IP, the whole request
+    # header set, and a buffered request body (`telemetry.sentry.send_default_pii`). **Off, and
+    # worth leaving off** — this server publishes public links, and the address of whoever
+    # followed one is not what makes a failed S3 fetch actionable, while Sentry is a third party.
+    # It is two controls rather than one, besides: off is also what keeps the HTTP middleware
+    # redacting sensitive headers.
+    sendDefaultPii: false
+
+    # @schema
+    # # @config projection telemetry.sentry.http_transactions when telemetry.sentry.enabled
+    # type: boolean
+    # @schema
+    # -- Record one transaction per request, named by the matched route rather than by the URI
+    # (`telemetry.sentry.http_transactions`). Whether a started transaction is kept is
+    # `tracesSampleRate`'s decision; this is the switch for a deployment that wants error
+    # reporting and no performance data at all. The per-request hub is installed either way,
+    # which is what stops breadcrumbs from concurrent requests landing on one another's issues.
+    httpTransactions: true
+
+    # @schema
+    # # @config projection telemetry.sentry.span_attributes when telemetry.sentry.enabled
+    # type: boolean
+    # @schema
+    # -- Copy `tracing` span fields onto the Sentry span as attributes
+    # (`telemetry.sentry.span_attributes`). Off: the span fields here carry request paths and
+    # object keys, and a transaction is retained for longer than a log line.
+    spanAttributes: false
+
+    # @schema
+    # # @config projection telemetry.sentry.shutdown_timeout_secs when telemetry.sentry.enabled
+    # type: integer
+    # minimum: 0
+    # @schema
+    # -- How long process exit waits for queued events to drain
+    # (`telemetry.sentry.shutdown_timeout_secs`). Paid on every pod shutdown, so it is time added
+    # to every rollout; keep it well inside `terminationGracePeriodSeconds`. `0` discards
+    # whatever is still queued.
+    shutdownTimeoutSecs: 2
+
+    # @schema
+    # # @config projection telemetry.sentry.debug when telemetry.sentry.enabled
+    # type: boolean
+    # @schema
+    # -- Print the SDK's own diagnostics to stderr (`telemetry.sentry.debug`). For proving a DSN
+    # works, not for running.
+    debug: false
 
 # @schema
 # type: string
 # @schema
-# -- Name of an existing Secret holding the S3 credentials, which keeps them out of
+# -- Name of an existing Secret holding the server's credentials, which keeps them out of
 # `values.yaml` and out of the Helm release object. **Its keys are the configuration paths, not
-# free-form names**: `s3__access_key` and `s3__secret_key`, because the file name is what the
-# loader parses. Set, the chart renders no Secret of its own and `s3.accessKey` / `s3.secretKey`
-# are ignored.
+# free-form names**: `s3__access_key`, `s3__secret_key` and, once `telemetry.sentry.enabled` is
+# set, `telemetry__sentry__dsn` — because the file name is what the loader parses. Set, the
+# chart renders no Secret of its own and `s3.accessKey`, `s3.secretKey` and
+# `telemetry.sentry.dsn` are ignored.
 existingSecret: ""
 
 # @schema


### PR DESCRIPTION
Four applications released optional Sentry support on the same day. This surfaces it in all four
charts and merges the image bumps that carry the refreshed contracts, because neither half is
green on its own: the bump PRs repin the digest and vendor a contract full of keys nothing binds,
and a chart that binds them has no contract to bind them against.

Closes #500, closes #499, closes #501, closes #502 — all four are merged in here.

| chart | version | appVersion | upstream release |
|---|---|---|---|
| `mp-stats-legacy-viewer` | 3.2.3 → **3.3.0** | v0.19.0 | TimSchoenle/mp-stats-legacy-viewer#446 |
| `portfolio` | 5.1.7 → **5.2.0** | v2.10.0 | TimSchoenle/Portfolio#1138 |
| `netcup-offer-bot` | 5.1.3 → **6.0.0** | v3.0.0 | TimSchoenle/netcup-offer-bot#488 |
| `s3-bucket-perma-link` | 4.1.3 → **5.0.0** | v2.0.0 | TimSchoenle/s3-bucket-perma-link#422 |

## Off, and inert while it is off

`telemetry.sentry.enabled` (`sentry.enabled` on `portfolio`) is `false`, and that has to mean
*absent* rather than *present and false*: every key under the block is inert while the switch is
down, so writing them would put a dozen-plus settings that do nothing into the document an
operator reads to find out what the process is doing. On a release that does not ask for it,
nothing about the rendered output changes — no ConfigMap key, no Secret, no volume, no variable.

Each chart's suite asserts that edge first, and `mp-stats-legacy-viewer`'s and `portfolio`'s
assert it about **pod shape** too: the DSN is the only credential either server reads, so
switching Sentry on is what gives those pods a secrets volume and a `<PREFIX>_SECRETS_DIR` in the
first place. Both charts gain `existingSecret` and a `templates/secret.yaml` for it.

## No two of these images spell it the same way

The differences are load-bearing, and copying one chart's block to the next would produce keys the
image does not read — which `serde` ignores in silence, so the pod starts, reports healthy, and
runs on a compiled default nobody chose.

- `portfolio` keeps the block at the **top level**, outside `telemetry`, and has no
  `shutdownTimeoutSecs`.
- `s3-bucket-perma-link` spells it **`attachStacktrace`, singular**, where the other three are
  plural. There is a test whose only job is to pin that.
- `netcup-offer-bot` has no `httpTransactions`, `sendDefaultPii` or `spanAttributes` — it serves
  no HTTP.
- `mp-stats-legacy-viewer` also gained `telemetry.logFilter` and `telemetry.jsonLogs`, which are
  not Sentry at all but are new in the same release and have to be restated here: pointing
  `MP_STATS_CONFIG` at this chart's mount *replaces* the `/config.toml` the image ships.

## Two majors, and why

`netcup-offer-bot` and `s3-bucket-perma-link` **removed** `telemetry.sentry_dsn` upstream, so
`telemetry.sentryDsn` is gone from both charts; a `helm upgrade` carrying the old key fails schema
validation naming it rather than silently dropping error reporting. Migration tables are in each
chart's `## Upgrading` section.

Both also **move the DSN out of `config.toml` into the Secret**, under `telemetry__sentry__dsn`.
The old charts rendered a bearer credential for the project's ingest endpoint into a ConfigMap
readable by anything that can read the namespace — and in `s3-bucket-perma-link`'s case the reload
supervisor prints the struct that holds it. An `existingSecret` that should carry it needs that
key added; the pod projects it only while the switch is on, so a release that does not report to
Sentry mounts nothing extra.

## What the charts refuse

`validateValues` rejects both bad halves of the pair, in every chart:

- **switch on, no DSN anywhere** — upstream refuses to boot rather than installing a client that
  reports nowhere, so this is a CrashLoopBackOff, not a degraded feature. A rejected `helm
  upgrade` beats one. An `existingSecret` is taken as the answer, since the chart cannot see
  inside one.
- **DSN set, switch off** — it is neither written into the Secret nor read by anything, so it
  would sit in the release meaning nothing, and a DSN is a credential to leave lying around.

These checks sit *outside* the `configExtraToml` guard that the bucket and CSP checks step behind,
because the DSN cannot arrive through the escape hatch: it does not travel the configuration
document at all.

## Egress, which the chart cannot derive

The chart never reads the DSN, so it cannot name the ingest host in the network policies. The
defaults do cover it — `networkPolicy.egress.https` permits TCP/443 to `0.0.0.0/0` minus private
space — so an out-of-the-box release reaches Sentry. A release that narrowed `egress.cidr`, turned
`egress.https` off, or replaced the CIDR rule with `cilium.egress.toFQDNs` has to name the
endpoint itself, and **getting that wrong is silent**: an SDK that cannot reach its endpoint
queues events and then discards them, so the project stays empty, which reads as "no errors".
Each `ci/sentry.yaml` renders the explicit rule rather than leaning on the permissive default, so
the policy job covers it.

`sendDefaultPii` stays off everywhere. On `portfolio` that is not a preference: the site publishes
a privacy page stating that no third-party service receives visitor data, and this key is the one
way to falsify it.

## The portfolio contract, and why a commit here fixes it

#502 repinned the image to `a6ada5d2` but its vendored `contracts/server.json` was still the
v2.9.0 document from `a3380c80`, so the staleness interlock held `check-config` red for that chart
alone. The cause was infrastructure, not the change: **every job in that workflow run failed with
"The job was not acquired by Runner of type hosted even after multiple attempts"**, including the
Documentation job that runs `just contracts` and commits the refresh back.

Refreshed here from the registry with the pinned `oras` 1.3.3 / `cosign` v3.1.3, signature
verified, contract written for the digest the chart actually pins. Not hand-edited — a contract
that cannot be proven to belong to the pinned digest is worse than none.

## Also in here

`just contract-tests` regenerated all four round-trip suites from the refreshed contracts: **+77
generated cases**, one per newly declared key, each proving the value arrives at the path the
image reads it from.

`check-config-bindings`' own tests carried the pre-release key counts (`8/5/7/7` → `25/16/21/21`)
and asserted a `telemetry.sentryDsn` marker this release renamed. Updated, along with the
per-chart shapes their docstrings enumerate — plus three new assertions for the traps above:
the singular `attach_stacktrace`, `portfolio`'s un-nested block, and the optional-*and*-gated
marker form the derived tags use.

## Verification

Every non-cluster gate green on the merged tree: `check-config`, `check-config-bindings`,
`check-contract-tests`, `check-contract-coverage`, `check-values-docs`, `check-immutable`,
`validate-manifests` (893 resources, k8s 1.34), `lint-policy`, `test-contract-union` (474 tests),
`lint-python`, and `helm lint --strict` across all 22 chart/fixture pairs.

Unit tests: **1033 passing** across every chart and the library fixture. The only failures in the
tree are 4 pre-existing `paperless-ngx` snapshot mismatches caused by `core.autocrlf` on this
machine; they are untouched by this branch and green in CI.

## Reviewing it

Read `values.yaml` against `contracts/*.json` per chart — the `# @config` markers are the mapping,
and `check-config-bindings` proves every one of them names a key the image really declares. The
generated round-trip suites are worth a skim rather than a read; the hand-written
`tests/sentry_test.yaml` files are where the judgement is.
