### PR TITLE
fix(scripts): write @schema blocks a new chart's own schema accepts

### DIFF
--- a/.github/scripts/config_scaffold.py
+++ b/.github/scripts/config_scaffold.py
@@ -51,7 +51,8 @@ One rule per row, applied in order; the first that matches wins.
 | `reserved`                        | nothing, plus an `unbound` entry   | the loader owns it      |
 | `secret`, and file-supplyable     | `secretData`, plus `unbound`       | never a ConfigMap       |
 | `secret`, not file-supplyable     | nothing, plus an `unbound` entry   | no safe channel exists  |
-| `structured`                      | a chart value typed `object`       | the tree is the value   |
+| `structured`                      | a chart value typed by its own     | the tree is the value   |
+|                                   | constraint, or an open `object`    |                         |
 | anything else                     | a chart value, typed and defaulted | the ordinary case       |
 
 The credential rule is the one worth arguing with, so it is written down rather than assumed. A
@@ -367,25 +368,55 @@ def schema_lines(key: dict[str, Any], indent: str) -> list[str]:
 
     Only the keywords the contract vocabulary already allows are copied, and they are copied
     rather than translated: `constraint` is JSON Schema and so is an `@schema` block, so a
-    `minimum` means the same thing on both sides. A `structured` key is the exception — its
-    constraint describes the TOML *literal* the environment layer would carry, where the chart
-    value is the tree itself.
+    `minimum` means the same thing on both sides.
+
+    Two shapes are not a straight copy, and both were measured against helm-schema rather than
+    reasoned about:
+
+    **An `enum` is the whole block.** helm-schema refuses one carrying both — `Error while
+    validating jsonschema of key backend: cannot use both 'enum' and 'type' in the same schema`,
+    which exits `just schema` fatally and leaves every chart's `values.schema.json` unwritten. So
+    a key whose constraint names an `enum` emits its members alone, with `null` joining them
+    where the key is optional, the way `image.pullPolicy` in the chassis spells its empty member.
+    helm-schema drops that `null` from the generated property, which costs nothing: Helm deletes
+    a `null` value during coalescing, so the validator is never shown one.
+
+    **A `structured` key whose constraint is an object, or which names no type, is opened rather
+    than described.** Such a constraint says the value is a table and nothing about what is in
+    it — `internal.peers` is a `BTreeMap<String, PeerConfig>` and its constraint is
+    `{"type": "object"}` — so the block accepts any table rather than inventing properties the
+    contract never stated.
+
+    A `structured` key whose constraint names an *array* is a different thing and used to be
+    caught by the same branch. It carries its own `items`, and `default_for` writes an array
+    beside it, so describing it as an object made the chart reject its own defaults the moment
+    `just schema` ran: nine keys in `discord-alertmanager` — `alertmanager.endpoints`, the four
+    `discord.capabilities.*`, `links.allowed_hosts`, `links.buttons`, `render.key_labels` and
+    `routes` — every one of which had to be corrected by hand.
     """
+    constraint = key.get("constraint") or {}
+
+    if "enum" in constraint:
+        members = list(constraint["enum"])
+        if not key.get("required") and None not in members:
+            members.append(None)
+        return [f"{indent}# enum: {_schema_scalar(members)}"]
+
+    declared = constraint.get("type")
+    types = [str(name) for name in (declared if isinstance(declared, list) else [declared])
+             if name is not None]
     body: list[str] = []
 
-    if key.get("text_form") == "structured":
+    if key.get("text_form") == "structured" and (not types or "object" in types):
         types = ["object"]
         body = ["additionalProperties: true"]
     else:
-        constraint = key.get("constraint") or {}
-        declared = constraint.get("type")
-        types = [str(name) for name in (declared if isinstance(declared, list) else [declared])
-                 if name is not None]
-        for keyword in ("enum", "const", "minimum", "maximum", "exclusiveMinimum",
-                        "exclusiveMaximum", "multipleOf", "minLength", "maxLength", "pattern"):
+        for keyword in ("const", "minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum",
+                        "multipleOf", "minLength", "maxLength", "pattern", "items", "minItems",
+                        "maxItems", "uniqueItems"):
             if keyword not in constraint:
                 continue
-            body.append(f"{keyword}: {_schema_scalar(constraint[keyword])}")
+            body.extend(_schema_keyword(keyword, constraint[keyword]))
 
     if not types:
         # The constraint names no type. Rather than guess one, accept every JSON type — the
@@ -419,6 +450,23 @@ def _schema_scalar(value: Any) -> str:
     if isinstance(value, list):
         return "[" + ", ".join(_schema_scalar(item) for item in value) + "]"
     return _quoted(str(value))
+
+
+def _schema_keyword(name: str, value: Any) -> list[str]:
+    """One JSON Schema keyword as the YAML lines an `@schema` comment carries.
+
+    A scalar is one line. A subschema is a nested block — `items` on a `Vec<T>` is the one that
+    occurs, and a flow mapping would parse identically — because block form is what every
+    hand-written `@schema` in this repository uses and these lines are read by people first.
+    """
+    if isinstance(value, dict):
+        if not value:
+            return [f"{name}: {{}}"]
+        lines = [f"{name}:"]
+        for inner in sorted(value):
+            lines.extend(f"  {line}" for line in _schema_keyword(str(inner), value[inner]))
+        return lines
+    return [f"{name}: {_schema_scalar(value)}"]
 
 
 def _quoted(text: str) -> str:
@@ -455,7 +503,13 @@ def default_for(key: dict[str, Any]) -> Any:
         return None
 
     if key.get("text_form") == "structured":
-        return {}
+        # Empty, in the shape the constraint names. An empty table where the constraint says
+        # `array` is the same defect `schema_lines` used to have from the other side: the chart
+        # would be written with a default its own `values.schema.json` rejects.
+        declared = (key.get("constraint") or {}).get("type")
+        if isinstance(declared, list):
+            declared = declared[0] if declared else None
+        return [] if str(declared) == "array" else {}
 
     candidate = tg.satisfying(key)
     if candidate is not None:
@@ -481,6 +535,32 @@ def invented(plan: Plan) -> list[Placement]:
         for item in plan.projected
         if not item.optional and item.key.get("default_value") is None
     ]
+
+
+def undescribed(plan: Plan) -> list[str]:
+    """The grouping blocks whose `# --` description is a placeholder, as values paths.
+
+    The companion to `invented`, and reported for the same reason: `branch_placeholder` writes a
+    `TODO` because a contract says nothing about the blocks a chart groups its keys into, and a
+    placeholder nobody was told about is one helm-docs publishes into the README table.
+    """
+    surfaced = plan.projected + plan.secrets
+    if not surfaced:
+        return []
+
+    found: list[str] = []
+
+    def walk(node: dict[str, Any], prefix: str) -> None:
+        for name in sorted(node):
+            child = node[name]
+            if isinstance(child, Placement):
+                continue
+            path = f"{prefix}.{name}" if prefix else name
+            found.append(path)
+            walk(child, path)
+
+    walk(tree_of(surfaced), "")
+    return found
 
 
 def values_scalar(value: Any) -> str:
@@ -510,20 +590,25 @@ def marker_line(placement: Placement, indent: str) -> str:
     return f"{indent}# # {MARKER} {placement.marker_class} {placement.path}{suffix}"
 
 
-def description_lines(placement: Placement, indent: str) -> list[str]:
-    """The helm-docs description for one value: `# --` on the first line, `#` on the rest.
+def described(text: str, indent: str) -> list[str]:
+    """One helm-docs description: `# --` on the first line, `#` on the rest.
 
     The marker belongs to the description as a whole and helm-docs reads it that way — repeating
     it on every wrapped line puts a literal `--` in the middle of the rendered sentence.
     """
+    wrapped = wrap(text, "", WIDTH - len(indent) - 5)
+    return [f"{indent}# -- {wrapped[0]}"] + [f"{indent}# {line}" for line in wrapped[1:]]
+
+
+def description_lines(placement: Placement, indent: str) -> list[str]:
+    """The helm-docs description for one contract key's value."""
     key = placement.key
     summary = summary_of(key).rstrip(".")
     text = f"{summary} (`{key['path']}`)."
     if placement.where == SECRET_FILE:
         text += f" Delivered as the secrets-directory file `{_file_name(placement)}`."
 
-    wrapped = wrap(text, "", WIDTH - len(indent) - 5)
-    return [f"{indent}# -- {wrapped[0]}"] + [f"{indent}# {line}" for line in wrapped[1:]]
+    return described(text, indent)
 
 
 def value_block(placement: Placement, indent: str = "") -> list[str]:
@@ -573,7 +658,7 @@ def tree_of(placements: list[Placement]) -> dict[str, Any]:
     return tree
 
 
-def render_tree(tree: dict[str, Any], indent: str = "") -> list[str]:
+def render_tree(tree: dict[str, Any], indent: str = "", depth: int = 0) -> list[str]:
     """The values blocks for one level of the tree, deepest structure last."""
     lines: list[str] = []
     for name in sorted(tree):
@@ -586,9 +671,56 @@ def render_tree(tree: dict[str, Any], indent: str = "") -> list[str]:
             lines.append(f"{indent}# @schema")
             lines.append(f"{indent}# additionalProperties: true")
             lines.append(f"{indent}# @schema")
+            lines.extend(described(branch_placeholder(node, depth + 1), indent))
             lines.append(f"{indent}{name}:")
-            lines.extend(render_tree(node, indent + "  "))
+            lines.extend(render_tree(node, indent + "  ", depth + 1))
     return lines
+
+
+def branch_placeholder(node: dict[str, Any], depth: int) -> str:
+    """The description a grouping block is scaffolded with, naming the prefix it holds.
+
+    A contract describes keys, not the blocks a chart groups them into, so there is nothing here
+    to derive a sentence from and no honest way to invent one. `just check-values-docs` requires
+    one all the same — helm-docs gives a documented group its own README row, and helm-schema
+    copies the text into the property an editor shows on hover — so the scaffold writes a `TODO`
+    in the same spelling `Chart.yaml`'s description placeholder uses, and `new-chart.py` lists
+    every one of them in its closing output rather than leaving them to a gate.
+
+    Without this, a freshly scaffolded chart failed `just check-values-docs` with one entry per
+    grouping block — sixteen for `discord-alertmanager`, fourteen from its contract plus `image`
+    and `configMount` — which is what the gate reported before anybody had read a line of it.
+    """
+    return (
+        f"TODO: what the `{branch_prefix(node, depth)}` settings have in common, in one sentence."
+    )
+
+
+def branch_prefix(node: dict[str, Any], depth: int) -> str:
+    """The contract path prefix one grouping block holds.
+
+    Read off a key underneath it rather than off the values path: `values_path_for` camel-cases
+    each segment independently, so the two paths have the same segment count and the contract
+    spelling — which is what the description should name — is only recoverable from a key.
+    """
+    placement = _any_placement(node)
+    if placement is None:
+        # `tree_of` only ever creates a branch on the way to a leaf, so this is unreachable — but
+        # a branch holding nothing would render a mapping with no values and no prefix to name.
+        raise ScaffoldError("a values branch was built with no key underneath it")
+    return ".".join(placement.path.split(".")[:depth])
+
+
+def _any_placement(node: dict[str, Any]) -> Placement | None:
+    """Any placement under this branch. They all share its prefix, so any of them will do."""
+    for name in sorted(node):
+        child = node[name]
+        if isinstance(child, Placement):
+            return child
+        found = _any_placement(child)
+        if found is not None:
+            return found
+    return None
 
 
 def render_values(
@@ -619,6 +751,7 @@ def render_values(
         "# @schema",
         "# additionalProperties: true",
         "# @schema",
+        "# -- Container image the pod runs, composed as `registry/repository:tag`.",
         "image:",
         "  # @schema",
         "  # type: string",
@@ -754,6 +887,7 @@ def render_values(
             "# @schema",
             "# additionalProperties: true",
             "# @schema",
+            "# -- Where the rendered configuration document and the credential files are mounted.",
             "configMount:",
             "  # @schema",
             "  # type: string",

--- a/.github/scripts/new-chart.py
+++ b/.github/scripts/new-chart.py
@@ -61,12 +61,20 @@ What "finished" means
 The chart this writes passes `just check` — every offline gate, including the ones that read a
 contract. That is the bar, and it is checked by running them rather than asserted here.
 
+One of them runs here as well. `check-values-docs` reads `values.yaml` alone — no network, no
+resolved dependencies, no render — so this command can hold its own output against it before
+printing that the chart passes, and `assert_documented` does. The rest cannot: they read a
+`values.schema.json` that `just schema` has not generated yet, and generating one would mean
+resolving `charts/common` from inside a scaffold.
+
 What it is not is *done*, and what is left is printed as an ordered list at the end rather than
 left to be discovered: the chart description and the README prose, which a generator cannot write
 and helm-docs will happily publish as placeholders; whatever the workload needs beyond a
-Deployment, none of which is in a contract; the `unbound` reasons, each generated with a
-defensible sentence and a defensible sentence is not a considered one; and, where the image
-publishes no default for a key it requires, the value this scaffold had to invent.
+Deployment, none of which is in a contract; the description on each grouping block in
+`values.yaml`, because a contract describes keys and says nothing about the blocks a chart groups
+them into; the `unbound` reasons, each generated with a defensible sentence and a defensible
+sentence is not a considered one; and, where the image publishes no default for a key it
+requires, the value this scaffold had to invent.
 
 It does not commit, add a `ci/` fixture beyond the one, or touch the root README — the chart index
 is derived from `Chart.yaml`, so the table picks the chart up on its own.
@@ -306,15 +314,20 @@ def _refresh_module():
     the whole signature-verification story — behind an exit code, and this command has to be able
     to remove the partial chart it just wrote.
     """
+    return _module("refresh-contracts.py", "refresh_contracts")
+
+
+def _module(file_name: str, module_name: str):
+    """One of this directory's hyphenated scripts, imported by path and cached in `sys.modules`."""
     import importlib.util
 
-    if "refresh_contracts" in sys.modules:
-        return sys.modules["refresh_contracts"]
+    if module_name in sys.modules:
+        return sys.modules[module_name]
 
-    path = Path(__file__).resolve().parent / "refresh-contracts.py"
-    spec = importlib.util.spec_from_file_location("refresh_contracts", path)
+    path = Path(__file__).resolve().parent / file_name
+    spec = importlib.util.spec_from_file_location(module_name, path)
     module = importlib.util.module_from_spec(spec)
-    sys.modules["refresh_contracts"] = module
+    sys.modules[module_name] = module
     spec.loader.exec_module(module)
     return module
 
@@ -446,6 +459,32 @@ def _write(path: Path, text: str) -> None:
 # --------------------------------------------------------------------------------------------
 
 
+def assert_documented(chart_dir: Path) -> None:
+    """Hold the generated `values.yaml` against `just check-values-docs` before claiming it passes.
+
+    The closing output tells a contributor this chart passes `just check`, and that sentence was
+    false in one specific way until this ran: a scaffold that gave its grouping blocks no `# --`
+    line failed that gate on every one of them, on a chart nobody had written by hand.
+
+    This gate and not the others because of what exists at this point. `values.schema.json` is
+    generated from `values.yaml` by `just schema`, which needs `helm` and a resolved
+    `charts/common` underneath it — so the gates that read a schema have nothing to read here, and
+    starting a dependency build inside a scaffold to give them one would be a second thing this
+    command does. `check-values-docs` reads the values file and nothing else: no network, no
+    dependencies, no render. `just deps && just docs` remains step one of the closing output, and
+    the schema-reading gates are checked by the `just check` that follows it.
+    """
+    missing = _module("check-values-docs.py", "check_values_docs").undocumented(
+        chart_dir / "values.yaml"
+    )
+    if missing:
+        listed = ", ".join(key.path for key in missing)
+        raise ScaffoldAborted(
+            f"{chart_dir / 'values.yaml'}: {len(missing)} value(s) carry no `# --` description, "
+            f"which `just check-values-docs` refuses: {listed}"
+        )
+
+
 def next_steps(chart_dir: Path, surface: sc.Surface, out) -> None:
     """The ordered list of what a person still has to do, printed rather than left to be found."""
     name = chart_dir.name
@@ -476,6 +515,15 @@ def next_steps(chart_dir: Path, surface: sc.Surface, out) -> None:
             "Add whatever the workload needs beyond a Deployment — a Service, an Ingress, a "
             "PodMonitor, a volume. None of that is in the contract."
         )
+        grouped = sc.undescribed(plan)
+        if grouped:
+            steps.append(
+                "Replace the placeholder description on each grouping block in "
+                f"charts/{name}/values.yaml. A contract describes keys, not the blocks a chart "
+                "groups them into, so each of these carries a `TODO` that helm-docs will publish "
+                f"into the README table as it stands: {', '.join(grouped)}."
+            )
+
         guessed = sc.invented(plan)
         if guessed:
             steps.append(
@@ -609,6 +657,7 @@ def main(argv: list[str]) -> int:
         if args.no_contract:
             if owed:
                 opt_out(chart_dir, args.reason, args.repository)
+            assert_documented(chart_dir)
             next_steps(chart_dir, sc.plain(), sys.stdout)
             return 0
 
@@ -628,6 +677,7 @@ def main(argv: list[str]) -> int:
         if load_declaration(chart_dir) is None:
             raise ScaffoldAborted(f"{chart_dir / sc.DECLARATION} was written and cannot be read")
 
+        assert_documented(chart_dir)
         next_steps(chart_dir, surface, sys.stdout)
         return 0
 

--- a/.github/scripts/tests/test_contract_scaffold.py
+++ b/.github/scripts/tests/test_contract_scaffold.py
@@ -30,6 +30,15 @@ the `with` wrapper in the derived helper is for, and what its absence would sile
 The plain form is asserted for what it does *not* write. A chart whose image publishes no contract
 must not carry `configMount`, `config` or a ConfigMap: each describes a loader nothing knows this
 image has, and a value an operator can set that nothing honours is worse than an absent one.
+
+`SchemaBlocks` and `Descriptions` are a fifth kind of case, and the reason they exist is the same
+for all three defects they cover: none of them is reachable from the scaffold's own run.
+`values.schema.json` is generated from `values.yaml` by `just schema`, and at the moment the
+scaffold finishes there is no schema for anything to disagree with — so a block typed `object`
+above an array default, a block helm-schema refuses outright, and a grouping key with no `# --`
+line all left the generator looking correct and were found on a chart. They are asserted against
+the two readers that decide it: `blocks` parses the `@schema` comments the way helm-schema does,
+and the description assertions call `check-values-docs` rather than re-implementing its rule.
 """
 
 from __future__ import annotations
@@ -48,8 +57,14 @@ sys.path.insert(0, str(SCRIPTS))
 import config_bindings as cb  # noqa: E402
 import config_contract as cc  # noqa: E402
 import config_scaffold as sc  # noqa: E402
+from entry import load  # noqa: E402
 
 TEMPLATES = SCRIPTS.parent / "templates" / "chart"
+
+# The gate the generated values file has to satisfy, run over the generated text rather than
+# re-implemented here: a second reader of `# --` placement would agree with this scaffold and
+# disagree with the gate, which is the failure the assertion exists to catch.
+values_docs = load("check_values_docs", "check-values-docs.py")
 
 
 def key(path: str, **overrides: Any) -> dict[str, Any]:
@@ -86,6 +101,57 @@ def values_of(surface: sc.Surface, chart: str = "app") -> dict[str, Any]:
     """The generated `values.yaml`, parsed. Proves it is YAML as well as what it says."""
     text = sc.render_values(chart, surface, "org/app", "v1.0.0", "", "config.toml")
     return yaml.safe_load(text) or {}
+
+
+def blocks(text: str) -> list[tuple[str, dict[str, Any], Any]]:
+    """Every `@schema` block in a values file, with the key it describes and that key's default.
+
+    Read the way helm-schema reads them — the text between the two delimiters is YAML, and the
+    `# @config` marker inside it is a YAML comment — so this sees exactly what `just schema` will
+    be handed, which is what makes an assertion about one worth anything.
+    """
+    lines = text.splitlines()
+    found: list[tuple[str, dict[str, Any], Any]] = []
+    number = 0
+    while number < len(lines):
+        if lines[number].strip() != "# @schema":
+            number += 1
+            continue
+
+        indent = len(lines[number]) - len(lines[number].lstrip())
+        body: list[str] = []
+        number += 1
+        while number < len(lines) and lines[number].strip() != "# @schema":
+            body.append(lines[number][indent:].removeprefix("#").removeprefix(" "))
+            number += 1
+
+        # Past the closing delimiter, past the description, and onto the key the run belongs to.
+        number += 1
+        while number < len(lines) and lines[number].lstrip().startswith("#"):
+            number += 1
+
+        line = lines[number].strip() if number < len(lines) else ""
+        name, _, written = line.partition(":")
+        default = yaml.safe_load(written) if written.strip() else None
+        found.append((name, yaml.safe_load("\n".join(body)) or {}, default))
+    return found
+
+
+def _json_type(value: Any) -> str:
+    """The JSON Schema type name for one rendered default."""
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    return "string"
 
 
 class Naming(unittest.TestCase):
@@ -242,6 +308,211 @@ class ValuesTree(unittest.TestCase):
         values = yaml.safe_load(text)
         for name in ("podSecurityContextPreset", "serviceAccount", "networkPolicy", "resources"):
             self.assertIn(name, values)
+
+
+class SchemaBlocks(unittest.TestCase):
+    """What the `@schema` block above a generated value says.
+
+    Three defects lived here at once, all found scaffolding `discord-alertmanager` and all worked
+    around in that chart by hand rather than fixed. Two of them are below; the third is
+    `Descriptions`. None was caught by the scaffold's own run, because `values.schema.json` does
+    not exist yet at that point and every gate that would have noticed reads one.
+    """
+
+    def test_a_structured_array_keeps_the_constraint_the_contract_published(self):
+        """`type: [object]` beside an array default is a chart that rejects its own values."""
+        entry = key(
+            "a.hosts", text_form="structured", default_value=["one"],
+            constraint={"type": "array", "items": {"type": "string"}},
+        )
+        block = self._block(entry, "hosts")
+        self.assertEqual(block["type"], ["array", "null"])
+        self.assertEqual(block["items"], {"type": "string"})
+        self.assertNotIn("additionalProperties", block)
+
+    def test_a_structured_arrays_default_is_a_value_its_own_block_accepts(self):
+        entry = key(
+            "a.hosts", text_form="structured", default_value=["one"],
+            constraint={"type": "array", "items": {"type": "string"}},
+        )
+        surface = sc.from_contract(union_of(entry))
+        text = sc.render_values("app", surface, "org/app", "v1", "", "config.toml")
+        for name, block, default in blocks(text):
+            if name == "hosts":
+                self.assertIn(_json_type(default), block["type"])
+                break
+        else:  # pragma: no cover - the loop above always finds it
+            self.fail("the generated values file carries no block for `hosts`")
+
+    def test_a_required_structured_array_defaults_to_an_array_rather_than_a_table(self):
+        entry = key(
+            "a.hosts", text_form="structured", required=True,
+            constraint={"type": "array", "items": {"type": "string"}},
+        )
+        self.assertEqual(sc.default_for(entry), [])
+
+    def test_a_structured_object_is_still_opened_rather_than_described(self):
+        """`internal.peers` is a `BTreeMap<String, PeerConfig>` and its constraint says only that.
+
+        The contract states the value is a table and nothing about what is in it, so the block
+        accepts any table. Inventing properties here would refuse a peer nobody declared.
+        """
+        entry = key("a.peers", text_form="structured", constraint={"type": "object"})
+        block = self._block(entry, "peers")
+        self.assertEqual(block["type"], ["object", "null"])
+        self.assertIs(block["additionalProperties"], True)
+
+    def test_a_structured_key_with_no_declared_type_is_opened_too(self):
+        entry = key("a.peers", text_form="structured", constraint={})
+        block = self._block(entry, "peers")
+        self.assertEqual(block["type"], ["object", "null"])
+        self.assertIs(block["additionalProperties"], True)
+
+    def test_an_enum_is_the_whole_block(self):
+        """helm-schema refuses one carrying both, fatally, and writes no schema for any chart.
+
+        `level=fatal msg="Error while validating jsonschema of key backend: cannot use both
+        'enum' and 'type' in the same schema"` — measured against helm-schema 0.18.1.
+        """
+        entry = key(
+            "a.backend", text_form="choice", default_value="sqlite",
+            constraint={"type": "string", "enum": ["sqlite", "postgres"]},
+        )
+        block = self._block(entry, "backend")
+        self.assertNotIn("type", block)
+        self.assertEqual(block["enum"], ["sqlite", "postgres", None])
+
+    def test_a_required_enum_gains_no_null_member(self):
+        entry = key(
+            "a.backend", text_form="choice", required=True, default_value="sqlite",
+            constraint={"type": "string", "enum": ["sqlite", "postgres"]},
+        )
+        self.assertEqual(self._block(entry, "backend")["enum"], ["sqlite", "postgres"])
+
+    def test_no_generated_block_carries_both_enum_and_type(self):
+        """The property, over a surface holding one of every shape rather than over one key."""
+        surface = sc.from_contract(
+            union_of(
+                key("a.text"),
+                key("a.port", text_form="integer", constraint={"type": "integer", "minimum": 1}),
+                key("a.backend", text_form="choice",
+                    constraint={"type": "string", "enum": ["sqlite", "postgres"]}),
+                key("a.hosts", text_form="structured",
+                    constraint={"type": "array", "items": {"type": "string"}}),
+                key("a.peers", text_form="structured", constraint={"type": "object"}),
+                key("a.token", secret=True),
+            )
+        )
+        chassis = (TEMPLATES / "values.chassis.yaml").read_text(encoding="utf-8")
+        text = sc.render_values("app", surface, "org/app", "v1", chassis, "config.toml")
+        for name, block, _ in blocks(text):
+            with self.subTest(value=name):
+                self.assertFalse("enum" in block and "type" in block, block)
+
+    def test_a_bounded_scalar_still_copies_its_bounds(self):
+        entry = key(
+            "a.port", text_form="integer",
+            constraint={"type": "integer", "minimum": 1, "maximum": 65535},
+        )
+        block = self._block(entry, "port")
+        self.assertEqual(block["type"], ["integer", "null"])
+        self.assertEqual((block["minimum"], block["maximum"]), (1, 65535))
+
+    def _block(self, entry: dict[str, Any], leaf: str) -> dict[str, Any]:
+        """The parsed `@schema` block the scaffold writes above one key's value."""
+        surface = sc.from_contract(union_of(entry))
+        text = sc.render_values("app", surface, "org/app", "v1", "", "config.toml")
+        for name, block, _ in blocks(text):
+            if name == leaf:
+                return block
+        self.fail(f"the generated values file carries no block for `{leaf}`")
+
+
+class Descriptions(unittest.TestCase):
+    """Every generated value carries the `# --` line `just check-values-docs` demands.
+
+    The third defect, and the one a scaffold could not see: the gate reads `values.yaml` alone,
+    but nothing ran it here, so a freshly scaffolded chart failed it on every grouping block —
+    sixteen of them for `discord-alertmanager`. `new-chart.py` now runs it before printing that
+    the chart passes `just check`.
+    """
+
+    def test_the_contracted_form_leaves_nothing_undocumented(self):
+        surface = sc.from_contract(
+            union_of(
+                key("alertmanager.endpoints", text_form="structured",
+                    constraint={"type": "array", "items": {"type": "string"}}),
+                key("discord.capabilities.view", text_form="structured",
+                    constraint={"type": "array", "items": {"type": "string"}}),
+                key("storage.backend", text_form="choice",
+                    constraint={"type": "string", "enum": ["sqlite", "postgres"]}),
+                key("routes", text_form="structured", constraint={"type": "array"}),
+                key("discord.token", secret=True),
+            )
+        )
+        self.assertEqual(self._undocumented(surface), [])
+
+    def test_the_plain_form_leaves_nothing_undocumented(self):
+        self.assertEqual(self._undocumented(sc.plain()), [])
+
+    def test_a_grouping_block_names_the_prefix_it_holds(self):
+        surface = sc.from_contract(union_of(key("discord.capabilities.view")))
+        text = sc.render_values("app", surface, "org/app", "v1", "", "config.toml")
+        self.assertIn("# -- TODO: what the `discord` settings have in common", text)
+        self.assertIn("# -- TODO: what the `discord.capabilities` settings have in common", text)
+
+    def test_the_prefix_is_the_contract_spelling_not_the_values_one(self):
+        """`values_path_for` camel-cases each segment, and the description names the key."""
+        surface = sc.from_contract(union_of(key("rate_limit.per_ip.burst")))
+        text = sc.render_values("app", surface, "org/app", "v1", "", "config.toml")
+        self.assertIn("`rate_limit.per_ip`", text)
+        self.assertNotIn("`rateLimit.perIp`", text)
+
+    def test_every_placeholder_is_reported(self):
+        plan = sc.plan_keys(union_of(key("a.b.c"), key("d.token", secret=True), key("e")))
+        self.assertEqual(sc.undescribed(plan), ["a", "a.b", "d"])
+
+    def test_a_surface_with_no_nesting_reports_none(self):
+        self.assertEqual(sc.undescribed(sc.plan_keys(union_of(key("a")))), [])
+
+    def test_the_chassis_blocks_carry_a_sentence_rather_than_a_placeholder(self):
+        """`image` and `configMount` are the same in every chart, so neither is a TODO."""
+        surface = sc.from_contract(union_of(key("a.b")))
+        described = self._described(
+            sc.render_values("app", surface, "org/app", "v1", "", "config.toml")
+        )
+        for name in ("image", "configMount"):
+            self.assertIn(name, described)
+            self.assertNotIn("TODO", described[name], name)
+
+    @staticmethod
+    def _undocumented(surface: sc.Surface) -> list[str]:
+        """The values `just check-values-docs` would report, asked of the gate rather than of a
+        second reader written here — which is the only way this assertion can be wrong in the
+        contributor's favour rather than in its own.
+        """
+        chassis = (TEMPLATES / "values.chassis.yaml").read_text(encoding="utf-8")
+        text = sc.render_values("app", surface, "org/app", "v1", chassis, "config.toml")
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "values.yaml"
+            path.write_text(text, encoding="utf-8", newline="\n")
+            return [found.path for found in values_docs.undocumented(path)]
+
+    @staticmethod
+    def _described(text: str) -> dict[str, str]:
+        """Each top-level key's `# --` line, keyed by the key it sits above."""
+        lines = text.splitlines()
+        found: dict[str, str] = {}
+        for number, line in enumerate(lines):
+            if line.startswith("#") or not line.endswith(":"):
+                continue
+            above = number - 1
+            while above >= 0 and lines[above].startswith("#"):
+                if lines[above].startswith("# -- "):
+                    found[line[:-1]] = lines[above]
+                    break
+                above -= 1
+        return found
 
 
 class DerivedHelper(unittest.TestCase):


### PR DESCRIPTION
`just new-chart` claims its output passes `just check`. Three things it wrote made that false. All three were found on 2026-09-01 scaffolding a 63-key chart and were worked around in that chart's `values.yaml` by hand rather than fixed at source; this fixes them at source.

None of the three is reachable from the scaffolder's own run, and that is the common cause worth naming: `values.schema.json` is generated from `values.yaml` by `just schema`, so at the moment the scaffold finishes there is no schema for anything to disagree with. A block typed `object` above an array default, a block helm-schema refuses outright, and a grouping key with no `# --` line all left the generator looking correct and were found on a chart.

## 1. A `structured` key lost its constraint

`schema_lines` hardcoded `types = ["object"]` and `body = ["additionalProperties: true"]` for every key whose `text_form` is `structured`, discarding the key's own `constraint`. Every `Vec<T>` key therefore got `type: [object, 'null']` while `default_for` wrote an array beside it — so once `just schema` ran, the chart rejected its own defaults. Nine keys hit this in one chart.

The constraint is now copied the way the non-structured branch already copied it, through a new `_schema_keyword` that renders a subschema as a nested block:

```yaml
# @schema
# # @config structured alertmanager.endpoints optional
# type: [array, 'null']
# items:
#   type: "string"
# @schema
# -- Base URLs of the Alertmanager peers, tried in order (`alertmanager.endpoints`).
endpoints: []
```

The object branch is kept for keys whose constraint really is an object or names no type — `internal.peers` is a `BTreeMap<String, PeerConfig>` whose constraint says `{"type": "object"}` and nothing about what is in it, so that block still opens rather than inventing properties the contract never stated. Copied keywords gained `items`, `minItems`, `maxItems` and `uniqueItems`.

`default_for` was fixed alongside it: it returned `{}` for a required `structured` key whatever the constraint said, which after this change is a table beside `type: array` — the same defect from the other side.

## 2. An `enum` key got both `enum` and `type`

helm-schema refuses that outright, and fatally:

```
level=fatal msg="Error while validating jsonschema of key backend: cannot use both 'enum' and 'type' in the same schema"
```

so `just schema` writes no `values.schema.json` for any chart in the tree, not just the new one. The members are now the whole block, with `null` joining them where the key is optional — the spelling `image.pullPolicy` in `values.chassis.yaml` already uses for its empty member:

```yaml
# @schema
# # @config projection storage.backend optional
# enum: ["sqlite", "postgres", null]
# @schema
```

Measured against helm-schema 0.18.1: it drops that `null` from the generated property, which costs nothing, because Helm deletes a `null` value during coalescing and the validator is never shown one.

## 3. No grouping block carried a `# --` description

A freshly scaffolded chart failed `just check-values-docs` with one entry per nested block — sixteen for that chart, fourteen from its contract plus `image` and `configMount`.

`image` and `configMount` are the same in every chart and now carry a canned sentence. The contract-derived ones cannot: a contract describes keys and says nothing about the blocks a chart groups them into. Each gets a placeholder naming the contract prefix it holds — `TODO: what the `discord.capabilities` settings have in common, in one sentence.`, in the same spelling `Chart.yaml`'s description placeholder uses — and `next_steps` lists every one of them, beside the invented values it already reported.

`new-chart.py` also now runs `check-values-docs` over its own output before printing that the chart passes `just check`. That gate and not the others because it reads the values file alone — no network, no resolved dependencies, no render. The rest read a schema `just schema` has not generated yet, and resolving `charts/common` from inside a scaffold to give them one would be a second thing this command does; `just deps && just docs` stays step one of the closing output.

## Tests

16 new cases in `test_contract_scaffold.py`, in two classes:

- **`SchemaBlocks`** — a new `blocks()` helper parses the `@schema` comments the way helm-schema does, so the assertions are about what `just schema` will actually be handed. Covers both shapes of `structured` key, the enum-only block, the optional/required `null` member, the property that no generated block ever carries both `enum` and `type`, and that a bounded scalar still copies its bounds.
- **`Descriptions`** — the description assertions call `check-values-docs.undocumented()` rather than re-implementing its rule, so a second reader of `# --` placement cannot agree with the scaffold and disagree with the gate.

## Verification

`just lint-python` clean; `just test-contract-union` 490 passed (37 → 53 in this suite).

A throwaway chart was scaffolded against a contracted image and run through the offline gates, all green — `test-unit` (17 cases including the generated round-trip suite), `validate-manifests`, `check-immutable`, `check-config`, `check-contract-coverage`, `check-config-bindings`, `check-contract-tests`, `check-values-docs`, `check-preset-schema`, `test-contract-union`, `lint`, `lint-policy`, `test-library`, `test-rules` — plus `just schema`, which is where defect 2 used to abort fatally, and `just chart-readmes`, which renders the group rows helm-docs now has descriptions for. The chart and all schema/README regeneration collateral were reverted afterwards.

Not run locally: `ct lint` (`ct` is not on PATH here) and paperless-ngx's four CRLF snapshot failures, which are pre-existing and local-only.

## Two things found but deliberately not fixed here

Both are outside the three defects this change was scoped to, and both are one-liners worth their own change:

1. **`just new-chart` with no `--description` cannot complete.** It writes `description: TODO: what <name> deploys, in one sentence. ...` unquoted into `Chart.yaml`, and the scaffolder itself then dies parsing it in `refresh_chart` — leaving the partial chart behind, because `yaml.ScannerError` is not one of the exception types `main` catches.
2. **`just contract-tests` is missing from the closing output.** Nothing else writes `tests/contract_roundtrip_<document>_test.yaml`, so a chart that follows steps 1–8 as printed fails `check-contract-tests` and `test_contract_testgen.TestGeneratedTree`. It belongs between `just docs` and `just check`.
